### PR TITLE
fixed json parsing error on player death

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -1465,7 +1465,7 @@ public record DeathCause
         set;
     }
 
-    public int? Side
+    public string? Side
     {
         get;
         set;


### PR DESCRIPTION
Fix for issue encountered on player death:

```
[19:19:42.962 FATA][SPTarkov.Server.Core.Servers.HttpServer] [30;41mThe JSON value could not be converted to System.Nullable`1[System.Int32]. Path: $.results.profile.Stats.Eft.DeathCause.Side | LineNumber: 0 | BytePositionInLine: 36980.
[19:19:42.978 FATA][SPTarkov.Server.Core.Servers.HttpServer] [30;41m   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, Utf8JsonReader& reader, Exception ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Deserialize(Utf8JsonReader& reader, ReadStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.DeserializeAsObject(Utf8JsonReader& reader, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpanAsObject(ReadOnlySpan`1 json, JsonTypeInfo jsonTypeInfo)
   at System.Text.Json.JsonSerializer.Deserialize(String json, Type returnType, JsonSerializerOptions options)
   at SPTarkov.Server.Core.Utils.JsonUtil.Deserialize(String json, Type type) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Utils\JsonUtil.cs:line 83
   at SPTarkov.Server.Core.DI.StaticRouter.HandleStatic(String url, String body, String sessionID, String output) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\DI\Router.cs:line 64
   at SPTarkov.Server.Core.Routers.HttpRouter.HandleRoute(HttpRequest request, String sessionID, ResponseWrapper wrapper, IEnumerable`1 routers, Boolean dynamic, String body, Object& deserializedObject) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Routers\HttpRouter.cs:line 80
   at SPTarkov.Server.Core.Routers.HttpRouter.GetResponse(HttpRequest req, String sessionID, String body, Object& deserializedObject) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Routers\HttpRouter.cs:line 41
   at SPTarkov.Server.Core.Servers.Http.SptHttpListener.GetResponse(String sessionID, HttpRequest req, String body) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Servers\Http\SptHttpListener.cs:line 210
   at SPTarkov.Server.Core.Servers.Http.SptHttpListener.Handle(String sessionId, HttpRequest req, HttpResponse resp) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Servers\Http\SptHttpListener.cs:line 120
   at SPTarkov.Server.Core.Servers.HttpServer.HandleFallback(HttpContext context) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Servers\HttpServer.cs:line 138
```

Examing the json recieved from the client it seems the  ` DeathCause` class is supposed to be a string.

Here is the DeathCause object I got from my client.

```
"DeathCause": {
  "DamageType": "Bullet",
  "Side": "Savage",
  "Role": "bossPartisan",
  "WeaponId": "5bf3e0490db83400196199af"
}
```