### PR TITLE
object to object casting error

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using SPTarkov.Server.Core.Models.Eft.Common;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Eft.ItemEvent;

--- a/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using SPTarkov.Server.Core.Models.Eft.Common;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Eft.ItemEvent;
@@ -660,7 +662,7 @@ public class QuestHelper(
                     Template = item.Template,
                     ParentId = item.ParentId,
                     SlotId = item.SlotId,
-                    Location = (ItemLocation) item.Location,
+                    Location = item.Location,
                     Upd = new Upd
                     {
                         StackObjectsCount = item.Upd.StackObjectsCount


### PR DESCRIPTION
Getting this error when turning in the $5000usd for  Friends of the West Part 2.

```
Unable to cast object of type 'System.Text.Json.JsonElement' to type 'SPTarkov.Server.Core.Models.Eft.Common.Tables.ItemLocation'.
   at SPTarkov.Server.Core.Helpers.QuestHelper.AddItemStackSizeChangeIntoEventResponse(ItemEventRouterResponse output, String sessionId, Item item) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Helpers\QuestHelper.cs:line 655
   at SPTarkov.Server.Core.Helpers.QuestHelper.ChangeItemStack(PmcData pmcData, String itemId, Int32 newStackSize, String sessionID, ItemEventRouterResponse output) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Helpers\QuestHelper.cs:line 627
   at SPTarkov.Server.Core.Controllers.QuestController.HandoverQuest(PmcData pmcData, HandoverQuestRequestData request, String sessionID) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Controllers\QuestController.cs:line 338
   at SPTarkov.Server.Core.Callbacks.QuestCallbacks.HandoverQuest(PmcData pmcData, HandoverQuestRequestData info, String sessionID) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Callbacks\QuestCallbacks.cs:line 67
   at SPTarkov.Server.Core.Routers.ItemEvents.QuestItemEventRouter.HandleItemEvent(String url, PmcData pmcData, BaseInteractionRequestData body, String sessionID, ItemEventRouterResponse output) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Routers\ItemEvents\QuestItemEventRouter.cs:line 46
   at SPTarkov.Server.Core.Routers.ItemEventRouter.HandleEvents(ItemEventRouterRequest info, String sessionID) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Routers\ItemEventRouter.cs:line 74
   at SPTarkov.Server.Core.Callbacks.ItemEventCallbacks.HandleEvents(String url, ItemEventRouterRequest info, String sessionID) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Callbacks\ItemEventCallbacks.cs:line 14
   at SPTarkov.Server.Core.Routers.Static.ItemEventStaticRouter.<>c__DisplayClass0_0.<.ctor>b__0(String url, IRequestData info, String sessionID, String output) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Routers\Static\ItemEventStaticRouter.cs:line 25
   at SPTarkov.Server.Core.DI.StaticRouter.HandleStatic(String url, String body, String sessionID, String output) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\DI\Router.cs:line 67
   at SPTarkov.Server.Core.Routers.HttpRouter.HandleRoute(HttpRequest request, String sessionID, ResponseWrapper wrapper, IEnumerable`1 routers, Boolean dynamic, String body, Object& deserializedObject) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Routers\HttpRouter.cs:line 80
   at SPTarkov.Server.Core.Routers.HttpRouter.GetResponse(HttpRequest req, String sessionID, String body, Object& deserializedObject) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Routers\HttpRouter.cs:line 41
   at SPTarkov.Server.Core.Servers.Http.SptHttpListener.GetResponse(String sessionID, HttpRequest req, String body) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Servers\Http\SptHttpListener.cs:line 210
   at SPTarkov.Server.Core.Servers.Http.SptHttpListener.Handle(String sessionId, HttpRequest req, HttpResponse resp) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Servers\Http\SptHttpListener.cs:line 120
   at SPTarkov.Server.Core.Servers.HttpServer.HandleFallback(HttpContext context) in C:\Users\chris\www\tarkov\server\Libraries\SPTarkov.Server.Core\Servers\HttpServer.cs:line 138
```

Given that the location prop for the destination and target class is of `object` I see no reason to cast the type here, but I'm new to this project. Alternatively we can do type checking here in this method if there is a reason.