### PR TITLE
Global statics

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Callbacks/ClientLogCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/ClientLogCallbacks.cs
@@ -6,6 +6,7 @@ using SPTarkov.Server.Core.Services;
 using SPTarkov.Server.Core.Utils;
 using SPTarkov.Server;
 using SPTarkov.Common.Annotations;
+using SPTarkov.Server.Core.Models.Enums;
 
 namespace SPTarkov.Server.Core.Callbacks;
 

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/EntryType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/EntryType.cs
@@ -1,0 +1,10 @@
+namespace SPTarkov.Server.Core.Models.Enums;
+
+public enum EntryType
+{
+    LOCAL,
+    DEBUG,
+    RELEASE,
+    BLEEDING_EDGE,
+    BLEEDING_EDGE_MODS
+}

--- a/Libraries/SPTarkov.Server.Core/SPTarkov.Server.Core.csproj
+++ b/Libraries/SPTarkov.Server.Core/SPTarkov.Server.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <Import Project="..\..\Build.props" />
+  <Import Project="..\..\Build.props"/>
 
   <PropertyGroup>
     <PackageId>SPTarkov.Server.Core</PackageId>
@@ -16,16 +16,46 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SPTarkov.DI\SPTarkov.DI.csproj" />
+    <ProjectReference Include="..\SPTarkov.DI\SPTarkov.DI.csproj"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Hashing" Version="9.0.1" />
-    <PackageReference Include="FastCloner" Version="3.3.2" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.1"/>
+    <PackageReference Include="FastCloner" Version="3.3.2"/>
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
+
+  <PropertyGroup>
+    <!--  SPT specific  -->
+    <!--  using publish - provide flag to disable modding -p:DisableModding=true  -->
+    <SptVersion Condition="'$(SptVersion)' == ''">0.0.0</SptVersion>
+    <SptCommit Condition="'$(SptCommit)' == ''">a12b34</SptCommit>
+    <SptBuildTime Condition="'$(SptBuildTime)' == ''">0000000000</SptBuildTime>
+    <SptBuildType Condition="'$(SptBuildType)' == ''">LOCAL</SptBuildType>
+  </PropertyGroup>
+
+  <Target Name="GenerateProgramStatics" BeforeTargets="BeforeBuild">
+    <WriteLinesToFile
+      File="Utils/ProgramStatics.Generated.cs"
+      Lines="
+using SPTarkov.Server.Core.Models.Enums%3B
+
+namespace SPTarkov.Server.Core.Utils%3B
+
+public static partial class ProgramStatics
+{
+    public static string? _sptVersion = &quot;$(SptVersion)&quot;%3B
+    public static string? _commit = &quot;$(SptCommit)&quot;%3B
+    public static double? _buildTime = $(SptBuildTime)%3B
+    public static EntryType? BuildType = EntryType.$(SptBuildType)%3B
+}
+" Overwrite="true"/>
+    <ItemGroup>
+      <Compile Include="Utils/ProgramStatics.cs"/>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/Libraries/SPTarkov.Server.Core/SPTarkov.Server.Core.csproj
+++ b/Libraries/SPTarkov.Server.Core/SPTarkov.Server.Core.csproj
@@ -47,10 +47,10 @@ namespace SPTarkov.Server.Core.Utils%3B
 
 public static partial class ProgramStatics
 {
-    public static string? _sptVersion = &quot;$(SptVersion)&quot;%3B
-    public static string? _commit = &quot;$(SptCommit)&quot;%3B
-    public static double? _buildTime = $(SptBuildTime)%3B
-    public static EntryType? BuildType = EntryType.$(SptBuildType)%3B
+    private static string? _sptVersion = &quot;$(SptVersion)&quot;%3B
+    private static string? _commit = &quot;$(SptCommit)&quot;%3B
+    private static double? _buildTime = $(SptBuildTime)%3B
+    private static EntryType? BuildType = EntryType.$(SptBuildType)%3B
 }
 " Overwrite="true"/>
     <ItemGroup>

--- a/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.Generated.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.Generated.cs
@@ -4,8 +4,8 @@ namespace SPTarkov.Server.Core.Utils;
 
 public static partial class ProgramStatics
 {
-    public static string? _sptVersion = "0.0.0";
-    public static string? _commit = "a12b34";
-    public static double? _buildTime = 0000000000;
-    public static EntryType? BuildType = EntryType.LOCAL;
+    private static string? _sptVersion = "0.0.0";
+    private static string? _commit = "a12b34";
+    private static double? _buildTime = 0000000000;
+    private static EntryType? BuildType = EntryType.LOCAL;
 }

--- a/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.Generated.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.Generated.cs
@@ -1,0 +1,11 @@
+using SPTarkov.Server.Core.Models.Enums;
+
+namespace SPTarkov.Server.Core.Utils;
+
+public static partial class ProgramStatics
+{
+    public static string? _sptVersion = "0.0.0";
+    public static string? _commit = "a12b34";
+    public static double? _buildTime = 0000000000;
+    public static EntryType? BuildType = EntryType.LOCAL;
+}

--- a/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.cs
@@ -1,23 +1,21 @@
+using SPTarkov.Server.Core.Models.Enums;
+
 namespace SPTarkov.Server.Core.Utils;
 
-public static class ProgramStatics
+public static partial class ProgramStatics
 {
-    private static EntryType _entryType;
-
     private static bool _debug;
     private static bool _compiled;
     private static bool _mods;
 
-    private static string? _sptVersion;
-    private static string? _commit;
-    private static double? _buildTime;
-
-    private static BuildInfo buildInfo; // TODO get from buildinfo.json
-
     public static void Initialize()
     {
-        buildInfo = new BuildInfo();
-        _entryType = buildInfo.entryType.GetValueOrDefault(EntryType.LOCAL);
+        var _entryType = ProgramStatics.BuildType ?? EntryType.LOCAL;
+
+        Console.WriteLine($"Entry type: {_entryType}");
+        Console.WriteLine($"SPT Version: {_sptVersion}");
+        Console.WriteLine($"Commit: {_commit}");
+        Console.WriteLine($"Build time: {_buildTime}");
 
         switch (_entryType)
         {
@@ -38,7 +36,7 @@ public static class ProgramStatics
                 _mods = true;
                 break;
             case EntryType.LOCAL:
-            default: // EntryType.LOCAL
+            default:
                 _debug = true;
                 _compiled = false;
                 _mods = true;
@@ -47,9 +45,9 @@ public static class ProgramStatics
     }
 
     // Public Static Getters
-    public static EntryType ENTRY_TYPE()
+    public static EntryType? ENTRY_TYPE()
     {
-        return _entryType;
+        return BuildType;
     }
 
     public static bool DEBUG()
@@ -80,48 +78,5 @@ public static class ProgramStatics
     public static double? BUILD_TIME()
     {
         return _buildTime;
-    }
-}
-
-public enum EntryType
-{
-    LOCAL,
-    DEBUG,
-    RELEASE,
-    BLEEDING_EDGE,
-    BLEEDING_EDGE_MODS
-}
-
-public class BuildInfo
-{
-    public BuildInfo()
-    {
-        sptVersion = "";
-        commit = "";
-        buildTime = 0;
-    }
-
-    public EntryType? entryType
-    {
-        get;
-        set;
-    }
-
-    public string? sptVersion
-    {
-        get;
-        set;
-    }
-
-    public string? commit
-    {
-        get;
-        set;
-    }
-
-    public double? buildTime
-    {
-        get;
-        set;
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/ProgramStatics.cs
@@ -12,11 +12,6 @@ public static partial class ProgramStatics
     {
         var _entryType = ProgramStatics.BuildType ?? EntryType.LOCAL;
 
-        Console.WriteLine($"Entry type: {_entryType}");
-        Console.WriteLine($"SPT Version: {_sptVersion}");
-        Console.WriteLine($"Commit: {_commit}");
-        Console.WriteLine($"Build time: {_buildTime}");
-
         switch (_entryType)
         {
             case EntryType.RELEASE:


### PR DESCRIPTION
Adds a partial class for ProgramStatics, this is partialy generated when building, this allows us to define a few things in the csproj and also use this when publishing the app

usage:
`dotnet publish -c release -p:SptVersion=4.0.0 -p:SptBuildType=BLEEDING_EDGE_MODS`

this will then be used in code in the ProgramStatics class

```
   public static string? _sptVersion = "0.0.0";
    public static string? _commit = "a12b34";
    public static double? _buildTime = 0000000000;
    public static EntryType? BuildType = EntryType.LOCAL;
```