### PR TITLE
chore: Change 'object' types into specific types #148

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/PmcData.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/PmcData.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Utils.Json.Converters;
 
@@ -20,7 +21,10 @@ public record PmcData : BotBase
         set;
     }
 
-    public object CheckedChambers
+    /// <summary>
+    /// Returns the list of IDs of the weapons, which the player has checked the chamber of in the last raid.
+    /// </summary>
+    public List<string> CheckedChambers
     {
         get;
         set;

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -763,20 +763,11 @@ public record BodyPartHealth
 
 public record BodyPartEffectProperties
 {
-    private object? _extraData;
-
     // TODO: this was any, what actual type is it?
     public object? ExtraData
     {
-        get
-        {
-            return _extraData;
-        }
-        set
-        {
-            Console.WriteLine($"ExtraData: {value}");
-            _extraData = value;
-        }
+        get;
+        set;
     }
 
     public double? Time

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -1499,8 +1499,6 @@ public record DeathCause
 
 public record LastPlayerState
 {
-    private object? _equipment;
-
     public LastPlayerStateInfo? Info
     {
         get;
@@ -1516,15 +1514,8 @@ public record LastPlayerState
     // TODO: there is no definition on TS just any
     public object? Equipment
     {
-        get
-        {
-            return _equipment;
-        }
-        set
-        {
-            Console.WriteLine($"Equipment: {value}");
-            _equipment = value;
-        }
+        get;
+        set;
     }
 }
 

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -763,11 +763,20 @@ public record BodyPartHealth
 
 public record BodyPartEffectProperties
 {
+    private object? _extraData;
+
     // TODO: this was any, what actual type is it?
     public object? ExtraData
     {
-        get;
-        set;
+        get
+        {
+            return _extraData;
+        }
+        set
+        {
+            Console.WriteLine($"ExtraData: {value}");
+            _extraData = value;
+        }
     }
 
     public double? Time
@@ -1490,6 +1499,8 @@ public record DeathCause
 
 public record LastPlayerState
 {
+    private object? _equipment;
+
     public LastPlayerStateInfo? Info
     {
         get;
@@ -1505,8 +1516,15 @@ public record LastPlayerState
     // TODO: there is no definition on TS just any
     public object? Equipment
     {
-        get;
-        set;
+        get
+        {
+            return _equipment;
+        }
+        set
+        {
+            Console.WriteLine($"Equipment: {value}");
+            _equipment = value;
+        }
     }
 }
 

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
@@ -646,8 +646,6 @@ public record UpdLight
 
 public record UpdDogtag
 {
-    private object? _side;
-
     [JsonPropertyName("AccountId")]
     public string? AccountId
     {

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
@@ -169,11 +169,11 @@ public record ItemLocation
     }
 
     [JsonPropertyName("r")]
-    public object? R
+    public int R
     {
         get;
         set;
-    } // TODO: Can be string or number
+    }
 
     [JsonPropertyName("isSearched")]
     public bool? IsSearched
@@ -186,11 +186,11 @@ public record ItemLocation
     ///     SPT property?
     /// </summary>
     [JsonPropertyName("rotation")]
-    public object? Rotation
+    public bool? Rotation
     {
         get;
         set;
-    } // TODO: Can be string or boolean
+    }
 }
 
 public record Upd
@@ -646,6 +646,8 @@ public record UpdLight
 
 public record UpdDogtag
 {
+    private object? _side;
+
     [JsonPropertyName("AccountId")]
     public string? AccountId
     {
@@ -670,8 +672,15 @@ public record UpdDogtag
     [JsonPropertyName("Side")]
     public object? Side
     {
-        get;
-        set;
+        get
+        {
+            return _side;
+        }
+        set
+        {
+            Console.WriteLine($"Side: {value}");
+            _side = value;
+        }
     }
 
     [JsonPropertyName("Level")]

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
@@ -670,17 +670,11 @@ public record UpdDogtag
     }
 
     [JsonPropertyName("Side")]
-    public object? Side
+    [JsonConverter(typeof(DogtagSideConverter))]
+    public DogtagSide? Side
     {
-        get
-        {
-            return _side;
-        }
-        set
-        {
-            Console.WriteLine($"Side: {value}");
-            _side = value;
-        }
+        get;
+        set;
     }
 
     [JsonPropertyName("Level")]

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
@@ -770,7 +770,7 @@ public record QuestConditionCounterCondition
     }
 
     [JsonPropertyName("value")]
-    public int? Value
+    public object? Value
     {
         get;
         set;

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
@@ -179,11 +179,11 @@ public record Quest
     ///     Becomes 'AppearStatus' inside client
     /// </summary>
     [JsonPropertyName("status")]
-    public object? Status
+    public int? Status
     {
         get;
         set;
-    } // TODO: string | number
+    }
 
     [JsonPropertyName("KeyQuest")]
     public bool? KeyQuest
@@ -447,11 +447,11 @@ public record QuestCondition
     }
 
     [JsonPropertyName("type")]
-    public object? Type
+    public string? Type
     {
         get;
         set;
-    } // TODO: boolean | string
+    }
 
     [JsonPropertyName("status")]
     public List<QuestStatusEnum>? Status
@@ -770,7 +770,7 @@ public record QuestConditionCounterCondition
     }
 
     [JsonPropertyName("value")]
-    public object? Value
+    public int? Value
     {
         get;
         set;

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/DogtagSide.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/DogtagSide.cs
@@ -1,0 +1,12 @@
+﻿namespace SPTarkov.Server.Core.Models.Enums;
+
+public enum DogtagSide
+{
+    /// <summary>
+    /// This is for the dogtag equipped by the player, which shows up as 0 (integer) on the profile json.
+    /// </summary>
+    NotApplicable,
+
+    Usec,
+    Bear
+}

--- a/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/DogtagSideConverter.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/DogtagSideConverter.cs
@@ -1,0 +1,33 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using SPTarkov.Server.Core.Models.Enums;
+
+namespace SPTarkov.Server.Core.Utils.Json.Converters;
+
+public class DogtagSideConverter : JsonConverter<DogtagSide>
+{
+    public override DogtagSide Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            return DogtagSide.NotApplicable;
+        }
+
+        var value = reader.GetString();
+        return value != null ? Enum.Parse<DogtagSide>(value) : DogtagSide.NotApplicable;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DogtagSide value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case DogtagSide.NotApplicable:
+                writer.WriteNumberValue(0);
+                break;
+            case DogtagSide.Usec:
+            case DogtagSide.Bear:
+                writer.WriteStringValue(value.ToString());
+                break;
+        }
+    }
+}


### PR DESCRIPTION
I have debugged some of the properties that have `object` type, and changed them to relevant types only for the ones that consistently get assigned that specific value type during deserialization. Tested via creating a new profile, launching the game, going into raid, dying, extracting, completing quests, re-launching server.. no exceptions encountered.

I have also tried to determine types for these, but I was never able to break into the setter, so they are still a mystery.

`LastPlayerState.Equipment`
`BodyPartEffectProperties.Extradata`

These ones are tricky, they always get values of multiple types. So I could not touch these.
`Item.Location`
3 object properties inside `Reward`

Moreover I got a bit more adventurous for these two changes, so I need them to be looked into more closely:

- `UpdDogtag.Side` -> This one is always "Usec" or "Bear", EXCEPT here: when you create a new profile, go into the very first raid and extract, this value suddenly appears as `0` on your profile json that indicates the Dogtag that you **wear**. This dogtag JSON has dummy data (killed by, killed timestamp etc. all empty, cos this isn't _that_ type of dogtag) Even though I played with this value, changed into Usec and Bear, it didn't affect or break anything, but still I wanted to preserve original behavior and wrote a new Enum + converter for it.
- ~`QuestConditionCounterCondition.Value` always gets an integer EXCEPT one place: a specific JSON object inside `quests.json` - this is where I made the modification, because I saw that all other instances in this file were integers. I don't know if modifying the JSONs is allowed, so, I can revert if this is something I shouldn't do.~ reverted this one

#148