### PR TITLE
fix: Non-instant hideout upgrade completes instantly after game restart

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
@@ -140,7 +140,7 @@ public class HideoutController(
 
             var timestamp = _timeUtil.GetTimeStamp();
 
-            profileHideoutArea.CompleteTime = (int) Math.Round(timestamp - ctime.Value);
+            profileHideoutArea.CompleteTime = (int) Math.Round(timestamp + ctime.Value);
             profileHideoutArea.Constructing = true;
         }
     }


### PR DESCRIPTION
#185 