### PR TITLE
fix: Infinite loading screen

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -88,7 +88,7 @@ public class SptHttpListener : IHttpListener
                     while (readTask.Result != 0)
                     {
                         readBytes += readTask.Result;
-                        totalRead.AddRange(memory.ToArray());
+                        totalRead.AddRange(memory[..readTask.Result].ToArray());
                         memory = new Memory<byte>(new byte[BodyReadBufferSize]);
                         readTask = req.Body.ReadAsync(memory).AsTask();
                         readTask.Wait();

--- a/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
@@ -66,7 +66,7 @@ public class HttpServer(
             KeepAliveInterval = TimeSpan.FromSeconds(60)
         });
 
-        app.Use((HttpContext req, RequestDelegate _) =>
+        app?.Use((HttpContext req, RequestDelegate _) =>
             {
                 return Task.Factory.StartNew(async () => await HandleFallback(req));
             }


### PR DESCRIPTION
#214 

So far, I have identified these two issues that broke the game (hopefully there won't be more)
- Infinite loading screens usually happened at raid end - we'd hit the critical logging part with a JSON parsing error, because there is an unexpected token somewhere in it. I set up Fiddler to finally see we are just returning an empty body for `/client/match/local/end`.. the request body was huge, something like 40kbs min. Replayed the request through Fiddler, got a corrupt JSON - it seemingly got corrupt halfway arround all the way to the end. Turns out, we read request 1024 bytes at a time, using an api that **does not guarantee reading exactly 1024 bytes**. So truncating the read bytes before adding them to the ultimate byte array did the trick.

- Second issue that caused infinite screens was how we maintained ApplicationContext values in LinkedLists. Basically at the time of the exception the linked list's `RemoveFirst` method threw an exception. not because linked list was null, but the head just got detached from the rest. When that happens we just return 200 with an empty body and the client doesn't like that. That, and the linked list I was looking at apparently grew to size of 14, due to multi threading. I looked at using a Concurrent collection instead of linked list but none provides the APIs we wanna provide in there, so I decided to keep a lock object for each type of linked list and lock that stuff each time we access it.