### PR TITLE
add back jsonconverter

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
@@ -194,6 +194,7 @@ public record ItemLocation
     }
 
     [JsonPropertyName("r")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public ItemRotation R
     {
         get;


### PR DESCRIPTION
Looks like this line got deleted, possible in a merge fix?

From my original PR: https://github.com/sp-tarkov/server-csharp/pull/207/files#diff-3c3ebf45266b9d9c992797322749580d7c0e6631a90f01abe72b97e2883d260bR189

This is necessary