### PR TITLE
fixed missing bonuses in quest rewards

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Helpers/QuestRewardHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/QuestRewardHelper.cs
@@ -125,11 +125,11 @@ public class QuestRewardHelper(
         // 5100 becomes 0.51, add 1 to it, 1.51
         // We multiply the money reward bonuses by the hideout management skill multiplier, giving the new result
         var hideoutManagementBonusMultiplier = hideoutManagementSkill != null
-            ? 1 + hideoutManagementSkill.Progress / 1000
+            ? 2 + hideoutManagementSkill.Progress / 1000
             : 1;
 
         // e.g 15% * 1.4
-        return moneyRewardBonusPercent * hideoutManagementBonusMultiplier ?? 1;
+        return moneyRewardBonusPercent + hideoutManagementBonusMultiplier ?? 1;
     }
 
     /**
@@ -142,24 +142,27 @@ public class QuestRewardHelper(
     public Quest ApplyMoneyBoost(Quest quest, double bonusPercent, QuestStatusEnum questStatus)
     {
         var clonedQuest = _cloner.Clone(quest);
-        var rewards = (List<Reward>) clonedQuest.Rewards.GetType()
-                          .GetProperties()
-                          .FirstOrDefault(p => p.Name == questStatus.ToString())
-                          .GetValue(quest.Rewards) ??
-                      new List<Reward>();
-        var currencyRewards = rewards.Where(r =>
-            r.Type.ToString() == "Item" &&
-            _paymentHelper.IsMoneyTpl(r.Items.FirstOrDefault().Template)
-        );
-        foreach (var reward in currencyRewards)
+
+        if (clonedQuest.Rewards.Success == null) return clonedQuest;
+
+        var itemRewards = clonedQuest.Rewards.Success
+            .Where(reward =>
+                reward.Type == RewardType.Item &&
+                reward.Items is { Count: > 0 } &&
+                _paymentHelper.IsMoneyTpl(reward.Items.FirstOrDefault().Template)
+            );
+        foreach (var moneyReward in itemRewards)
         {
             // Add % bonus to existing StackObjectsCount
-            var rewardItem = reward.Items[0];
-            var newCurrencyAmount = Math.Floor((rewardItem.Upd.StackObjectsCount ?? 0) * (1 + bonusPercent / 100));
+            var rewardItem = moneyReward.Items[0];
+            var newCurrencyAmount = CalculateMoneyRewardAmount(rewardItem, bonusPercent);
             rewardItem.Upd.StackObjectsCount = newCurrencyAmount;
-            reward.Value = newCurrencyAmount;
+            moneyReward.Value = newCurrencyAmount;
         }
 
         return clonedQuest;
     }
+
+    protected double CalculateMoneyRewardAmount(Item item, double bonusPercent) =>
+        Math.Floor((item.Upd.StackObjectsCount ?? 0) * (1 + (bonusPercent / 100)));
 }

--- a/Libraries/SPTarkov.Server.Core/Helpers/QuestRewardHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/QuestRewardHelper.cs
@@ -148,21 +148,18 @@ public class QuestRewardHelper(
         var itemRewards = clonedQuest.Rewards.Success
             .Where(reward =>
                 reward.Type == RewardType.Item &&
-                reward.Items is { Count: > 0 } &&
+                reward.Items != null && reward.Items.Count > 0 &&
                 _paymentHelper.IsMoneyTpl(reward.Items.FirstOrDefault().Template)
             );
         foreach (var moneyReward in itemRewards)
         {
             // Add % bonus to existing StackObjectsCount
             var rewardItem = moneyReward.Items[0];
-            var newCurrencyAmount = CalculateMoneyRewardAmount(rewardItem, bonusPercent);
+            var newCurrencyAmount = Math.Floor((rewardItem.Upd.StackObjectsCount ?? 0) * (1 + (bonusPercent / 100)));
             rewardItem.Upd.StackObjectsCount = newCurrencyAmount;
             moneyReward.Value = newCurrencyAmount;
         }
 
         return clonedQuest;
     }
-
-    protected double CalculateMoneyRewardAmount(Item item, double bonusPercent) =>
-        Math.Floor((item.Upd.StackObjectsCount ?? 0) * (1 + (bonusPercent / 100)));
 }


### PR DESCRIPTION
Fix for issue - https://github.com/sp-tarkov/server-csharp/issues/226

Found out that is both an addition of hideout management skill / 10 + the percent increase according to intel center level 1 (5% or intel level 2 15%).

Changed algos to match the value specified in client on quest screen:

![Escape From Tarkov Screenshot 2025 05 03 - 14 35 17 30](https://github.com/user-attachments/assets/495fd322-447a-4009-b149-44e883383c43)
![Escape From Tarkov Screenshot 2025 05 03 - 14 35 28 08](https://github.com/user-attachments/assets/a077fe2a-05c0-4e47-9295-90dec7e3b7c7)

