### PR TITLE
fix: Bot flashlights on during daytime raid

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Controllers/MatchController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/MatchController.cs
@@ -1,5 +1,6 @@
 using SPTarkov.Common.Annotations;
 using SPTarkov.Server.Core.Context;
+using SPTarkov.Server.Core.Helpers;
 using SPTarkov.Server.Core.Models.Eft.Match;
 using SPTarkov.Server.Core.Models.Spt.Config;
 using SPTarkov.Server.Core.Models.Utils;
@@ -18,6 +19,7 @@ public class MatchController(
     ConfigServer _configServer,
     ApplicationContext _applicationContext,
     LocationLifecycleService _locationLifecycleService,
+    WeatherHelper _weatherHelper,
     ICloner _cloner
 )
 {
@@ -98,6 +100,9 @@ public class MatchController(
     /// <param name="sessionId">Session/Player id</param>
     public void ConfigureOfflineRaid(GetRaidConfigurationRequestData request, string sessionId)
     {
+        // set IsNightRaid to use it later for bot inventory generation
+        request.IsNightRaid = _weatherHelper.IsNightTime(request.TimeVariant, request.Location);
+
         // Store request data for access during bot generation
         _applicationContext.AddValue(ContextVariableType.RAID_CONFIGURATION, request);
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/BotGeneratorHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/BotGeneratorHelper.cs
@@ -74,7 +74,6 @@ public class BotGeneratorHelper
         var raidSettings = _applicationContext
             .GetLatestValue(ContextVariableType.RAID_CONFIGURATION)
             ?.GetValue<GetRaidConfigurationRequestData>();
-        var raidIsNight = raidSettings?.TimeVariant == DateTimeEnum.PAST;
 
         RandomisedResourceDetails randomisationSettings = null;
         if (botRole is not null)
@@ -161,7 +160,7 @@ public class BotGeneratorHelper
         if (itemTemplate?.Parent == BaseClasses.FLASHLIGHT)
         {
             // Get chance from botconfig for bot type
-            var lightLaserActiveChance = raidIsNight
+            var lightLaserActiveChance = raidSettings.IsNightRaid
                 ? GetBotEquipmentSettingFromConfig(botRole, "lightIsActiveNightChancePercent", 50)
                 : GetBotEquipmentSettingFromConfig(botRole, "lightIsActiveDayChancePercent", 25);
             itemProperties.Light = new UpdLight
@@ -190,7 +189,7 @@ public class BotGeneratorHelper
         if (itemTemplate?.Parent == BaseClasses.NIGHTVISION)
         {
             // Get chance from botconfig for bot type
-            var nvgActiveChance = raidIsNight
+            var nvgActiveChance = raidSettings.IsNightRaid
                 ? GetBotEquipmentSettingFromConfig(botRole, "nvgIsActiveChanceNightPercent", 90)
                 : GetBotEquipmentSettingFromConfig(botRole, "nvgIsActiveChanceDayPercent", 15);
             itemProperties.Togglable = new UpdTogglable

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Match/GetRaidConfigurationRequestData.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Match/GetRaidConfigurationRequestData.cs
@@ -34,4 +34,11 @@ public record GetRaidConfigurationRequestData : RaidSettings, IRequestData
         get;
         set;
     }
+
+    [JsonIgnore]
+    public bool IsNightRaid
+    {
+        get;
+        set;
+    }
 }

--- a/Libraries/SPTarkov.Server.Core/Utils/TimeUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/TimeUtil.cs
@@ -64,7 +64,7 @@ public class TimeUtil
     /// <returns>The current timestamp in seconds since the Unix epoch in UTC.</returns>
     public long GetTimeStamp()
     {
-        return DateTimeOffset.Now.ToUnixTimeSeconds();
+        return DateTimeOffset.UtcNow.ToUnixTimeSeconds();
     }
 
     /// <summary>


### PR DESCRIPTION
Ran a few raids with two different time slots, day/night.. seems to be fixing the issue
#233