### PR TITLE
fix: Ensure unique MongoIDs

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Utils/HashUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/HashUtil.cs
@@ -28,7 +28,7 @@ public partial class HashUtil(RandomUtil _randomUtil)
         objectId[3] = (byte) timestamp;
 
         // Random value (5 bytes)
-        _randomUtil.Random.NextBytes(objectId.Slice(4, 5));
+        _randomUtil.NextBytes(objectId.Slice(4, 5));
 
         // Incrementing counter (3 bytes)
         // 24-bit counter

--- a/Libraries/SPTarkov.Server.Core/Utils/RandomUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/RandomUtil.cs
@@ -35,7 +35,7 @@ public class RandomUtil(ISptLogger<RandomUtil> _logger, ICloner _cloner)
             max -= 1;
         }
 
-        return max > min ? Random.Next(min, exclusive ? max : max + 1) : min;
+        return max > min ? Random.Shared.Next(min, exclusive ? max : max + 1) : min;
     }
 
     /// <summary>
@@ -62,6 +62,11 @@ public class RandomUtil(ISptLogger<RandomUtil> _logger, ICloner _cloner)
     public bool GetBool()
     {
         return Random.Next(0, 2) == 1;
+    }
+
+    public void NextBytes(Span<byte> bytes)
+    {
+        Random.Shared.NextBytes(bytes);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #244

Added a unit test, which naturally fails with the current version of `HashUtil.Generate` due to duplicates.