### PR TITLE
actually get rid of quest items on death

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
@@ -908,7 +908,7 @@ public class LocationLifecycleService
     {
         // Exclude completed quests
         var activeQuestIdsInProfile = profileQuests
-            .Where(quest => quest.Status is QuestStatusEnum.AvailableForStart or QuestStatusEnum.Success)
+            .Where(quest => quest.Status != QuestStatusEnum.AvailableForStart && quest.Status != QuestStatusEnum.Success)
             .Select(status => status.QId);
 
         // Get db details of quests we found above

--- a/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
@@ -908,7 +908,7 @@ public class LocationLifecycleService
     {
         // Exclude completed quests
         var activeQuestIdsInProfile = profileQuests
-            .Where(quest => quest.Status != QuestStatusEnum.AvailableForStart && quest.Status != QuestStatusEnum.Success)
+            .Where(quest => quest.Status is not QuestStatusEnum.AvailableForStart and not QuestStatusEnum.Success)
             .Select(status => status.QId);
 
         // Get db details of quests we found above


### PR DESCRIPTION
Currently quest items completedConditions are not being removed. On a player's death, they will get a logger statement `Unable to fix quest item: 65817fbbb454159976c91917, 0 matching quests found, expected 1`.

This is because the loop to iterate through the quests is ONLY including quests that are completed or not started, as opposed to quests the player currently has.