### PR TITLE
Fix: Insurance items lost in labyrinth should not be returned

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/Assets/database/traders/54cb50c76803fa8b248b4571/dialogue.json
+++ b/Libraries/SPTarkov.Server.Assets/Assets/database/traders/54cb50c76803fa8b248b4571/dialogue.json
@@ -20,6 +20,10 @@
 		"5c1a3e0686f77445b95c29b3 1",
 		"5c1a3e0686f77445b95c29b3 2"
 	],
+  "insuranceFailedLabyrinth": [
+    "5c1a3e0686f77445b95c29b3 0",
+    "5c1a3e0686f77445b95c29b3 1"
+  ],
 	"insuranceExpired": [
 		"5900a71886f7742d9a47454c 0",
 		"5900a71886f7742d9a47454c 1",

--- a/Libraries/SPTarkov.Server.Assets/Assets/database/traders/54cb57776803fa99248b456e/dialogue.json
+++ b/Libraries/SPTarkov.Server.Assets/Assets/database/traders/54cb57776803fa99248b456e/dialogue.json
@@ -31,5 +31,9 @@
 		"5c1a3e1886f77445b74fb8b0 1",
 		"5c1a3e1886f77445b74fb8b0 2",
 		"5c1a3e2a86f77476ad6d23b0 0"
-	]
+	],
+  "insuranceFailedLabyrinth": [
+    "5c1a3e1886f77445b74fb8b0 1",
+    "5c1a3e2a86f77476ad6d23b0 0"
+  ]
 }

--- a/Libraries/SPTarkov.Server.Core/Controllers/InsuranceController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/InsuranceController.cs
@@ -658,12 +658,12 @@ public class InsuranceController(
     protected void HandleLabyrinthInsurance(Dictionary<string, List<string>?>? traderDialogMessages, Insurance insurance)
     {
         // Use labs specific messages if available, otherwise use default
-        var responseMesageIds =
+        var responseMessageIds  =
             traderDialogMessages["insuranceFailedLabyrinth"]?.Count > 0
                 ? traderDialogMessages["insuranceFailedLabyrinth"]
                 : traderDialogMessages["insuranceFailed"];
 
-        insurance.MessageTemplateId = _randomUtil.GetArrayValue(responseMesageIds);
+        insurance.MessageTemplateId = _randomUtil.GetArrayValue(responseMessageIds);
 
         // Remove all insured items taken into labs
         insurance.Items = [];


### PR DESCRIPTION
At first I was just going to update the labs methods, however this would result in some bad dialogue messages, and I also figured modders may want to allow enabling insurance in labs or labyrinth, not both.