### PR TITLE
fix: Server exception at raid end when client sends bantype data

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
@@ -608,7 +608,7 @@ public class ProfileHelper(
     public bool PlayerIsFleaBanned(PmcData pmcProfile)
     {
         var currentTimestamp = _timeUtil.GetTimeStamp();
-        return pmcProfile?.Info?.Bans?.Any(b => b.BanType == BanType.RAGFAIR && currentTimestamp < b.DateTime) ?? false;
+        return pmcProfile?.Info?.Bans?.Any(b => b.BanType == BanType.RagFair && currentTimestamp < b.DateTime) ?? false;
     }
 
     public bool HasAccessToRepeatableFreeRefreshSystem(PmcData pmcProfile)

--- a/Libraries/SPTarkov.Server.Core/Helpers/TraderHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/TraderHelper.cs
@@ -183,7 +183,7 @@ public class TraderHelper(
         if ((rawProfileTemplate.FleaBlockedDays ?? 0) > 0)
         {
             var newBanDateTime = _timeUtil.GetTimeStampFromNowDays(rawProfileTemplate.FleaBlockedDays ?? 0);
-            var existingBan = pmcData.Info.Bans.FirstOrDefault(ban => ban.BanType == BanType.RAGFAIR);
+            var existingBan = pmcData.Info.Bans.FirstOrDefault(ban => ban.BanType == BanType.RagFair);
             if (existingBan is not null)
             {
                 existingBan.DateTime = newBanDateTime;
@@ -193,7 +193,7 @@ public class TraderHelper(
                 pmcData.Info.Bans.Add(
                     new Ban
                     {
-                        BanType = BanType.RAGFAIR,
+                        BanType = BanType.RagFair,
                         DateTime = newBanDateTime
                     }
                 );

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -618,13 +618,13 @@ public record Ban
 
 public enum BanType
 {
-    CHAT = 0,
-    RAGFAIR = 1,
-    VOIP = 2,
-    TRADING = 3,
-    ONLINE = 4,
-    FRIENDS = 5,
-    CHANGE_NICKNAME = 6
+    Chat,
+    RagFair,
+    Voip,
+    Trading,
+    Online,
+    Friends,
+    ChangeNickname,
 }
 
 public record Customization

--- a/Libraries/SPTarkov.Server.Core/Utils/JsonUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/JsonUtil.cs
@@ -55,7 +55,7 @@ public class JsonUtil
             new EftEnumConverter<EquipmentSlots>(),
             new EftEnumConverter<BuffType>(),
             new EftEnumConverter<BodyPartColliderType>(),
-
+            new EftEnumConverter<BanType>(),
             new EftEnumConverter<LogLevel>(),
             new EftEnumConverter<LogTextColor>(),
             new EftEnumConverter<LogBackgroundColor>(),


### PR DESCRIPTION
- Put a numeric ban type with a datetime inside PMC data in a profile json file
- Start server, enter raid with that pmc profile
- End raid, client hangs, server throws an exception because client sent the banType in string format.

This fixes this exception. I also copied the BanType enum as it currently is on client side.