### PR TITLE
fixed two bugs in commando commands

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/ProfileCommand/ProfileSptCommand.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/ProfileCommand/ProfileSptCommand.cs
@@ -61,9 +61,9 @@ public class ProfileSptCommand(
 
         var result = _commandRegex.Match(request.Text);
 
-        var command = result.Groups["command"].Captures[0].Value;
-        var skill = result.Groups["skill"].Captures[0].Value;
-        var quantity = int.Parse(result.Groups["quantity"].Captures[0].Value);
+        var command = result.Groups["command"].Length > 0 ? result.Groups["command"].Captures[0].Value : null;
+        var skill = result.Groups["skill"].Length > 0 ?  result.Groups["skill"].Captures[0].Value : null;
+        var quantity = int.Parse(result.Groups["quantity"].Length > 0 ? result.Groups["quantity"].Captures[0].Value : "0");
 
         ProfileChangeEvent profileChangeEvent;
         switch (command)

--- a/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/TraderCommand/TraderSptCommand.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/TraderCommand/TraderSptCommand.cs
@@ -48,11 +48,11 @@ public class TraderSptCommand(
 
         var result = _commandRegex.Match(request.Text);
 
-        var trader = result.Groups["trader"].Captures[0].Value;
-        var command = result.Groups["command"].Captures[0].Value;
-        var quantity = int.Parse(result.Groups["quantity"].Captures[0].Value);
+        var trader = result.Groups["trader"].Captures[0]?.Value;
+        var command = result.Groups["command"].Captures[0]?.Value;
+        var quantity = int.Parse(result.Groups["quantity"].Captures[0]?.Value ?? "0");
 
-        var dbTrader = _traderHelper.GetTrader(trader, sessionId);
+        var dbTrader = _traderHelper.GetTraderByNickName(trader);
         if (dbTrader == null)
         {
             _mailSendService.SendUserMessageToPlayer(

--- a/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/TraderCommand/TraderSptCommand.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/TraderCommand/TraderSptCommand.cs
@@ -48,9 +48,9 @@ public class TraderSptCommand(
 
         var result = _commandRegex.Match(request.Text);
 
-        var trader = result.Groups["trader"].Captures[0]?.Value;
-        var command = result.Groups["command"].Captures[0]?.Value;
-        var quantity = int.Parse(result.Groups["quantity"].Captures[0]?.Value ?? "0");
+        var trader = result.Groups["trader"].Captures.Count > 0 ? result.Groups["trader"].Captures[0].Value : null;
+        var command = result.Groups["command"].Captures.Count > 0 ? result.Groups["command"].Captures[0].Value : null;
+        var quantity = int.Parse(result.Groups["command"].Captures.Count > 0 ? result.Groups["quantity"].Captures[0].Value : "0");
 
         var dbTrader = _traderHelper.GetTraderByNickName(trader);
         if (dbTrader == null)

--- a/Libraries/SPTarkov.Server.Core/Helpers/TraderHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/TraderHelper.cs
@@ -35,6 +35,11 @@ public class TraderHelper(
     protected Dictionary<string, double> _highestTraderPriceItems = new();
     protected TraderConfig _traderConfig = _configServer.GetConfig<TraderConfig>();
 
+    public TraderBase? GetTraderByNickName(string traderName, string? sessionId = null)
+    {
+        return _databaseService.GetTraders().Select(dict => dict.Value.Base).First(t => t?.Nickname != null && string.Equals(t.Nickname, traderName, StringComparison.CurrentCultureIgnoreCase));
+    }
+
 
     /// <summary>
     ///     Get a trader base object, update profile to reflect players current standing in profile


### PR DESCRIPTION
Fixed two server crashing bugs when using commando:

1. In the case of `spt profile level x`, the server was crashing with an out of index error for the skill capture, as there were no captures for this regex.
2. In the case of changing spend with peacekeeper, the server was crashing as it could not find a trader with the id. This is troublesome in two ways, one is that this method should catch if a player presents a bad id. The second is that the text of the help message suggest you can use the trader's nickname instead of an id. I decided to fix the latter scenario, allowing for not matching.

