### PR TITLE
fix: Enumerable ordering

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
@@ -884,9 +884,7 @@ public class CircleOfCultistService(
 
     protected string CreateSacrificeCacheKey(IEnumerable<string> requiredItems)
     {
-        requiredItems.OrderBy(item => item);
-        var concat = string.Join(",", requiredItems);
-
+        var concat = string.Join(",", requiredItems.OrderBy(item => item));
         return _hashUtil.GenerateMd5ForData(concat);
     }
 


### PR DESCRIPTION
We need to re-assign after calling OrderBy, otherwise we won't be using the resulting ordered enumerable.
I got rid of the assignment, to concat straight away.