### PR TITLE
Json util refactor

### DIFF
--- a/Benchmarks/ClonerBenchmarks.cs
+++ b/Benchmarks/ClonerBenchmarks.cs
@@ -3,6 +3,7 @@ using Benchmarks.Mock;
 using SPTarkov.Server.Core.Models.Spt.Templates;
 using SPTarkov.Server.Core.Utils;
 using SPTarkov.Server.Core.Utils.Cloners;
+using SPTarkov.Server.Core.Utils.Json.Converters;
 
 namespace Benchmarks;
 
@@ -19,7 +20,7 @@ public class ClonerBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        var jsonUtil = new JsonUtil();
+        var jsonUtil = new JsonUtil([ new SptJsonConverterRegistrator() ]);
         var importer = new ImporterUtil(new MockLogger<ImporterUtil>(), new FileUtil(),
             jsonUtil);
         var loadTask = importer.LoadRecursiveAsync<Templates>("./Assets/database/templates/");

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -616,6 +616,7 @@ public record Ban
     }
 }
 
+[EftEnumConverter]
 public enum BanType
 {
     Chat,

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Item.cs
@@ -408,6 +408,7 @@ public record LockableComponent
     public LockableKeyComponent? KeyComponent { get; set; }
 }
 
+[EftEnumConverter]
 public enum PinLockState
 {
     Free,

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Ws/NotificationEventType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Ws/NotificationEventType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Eft.Ws;
 
+[EftEnumConverter]
 public enum NotificationEventType
 {
     AssortmentUnlockRule,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/AirdropType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/AirdropType.cs
@@ -1,3 +1,5 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
 public enum AirdropTypeEnum
@@ -8,6 +10,7 @@ public enum AirdropTypeEnum
     Weapon
 }
 
+[EftEnumConverter]
 public enum SptAirdropTypeEnum
 {
     mixed,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/ArmorMaterial.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/ArmorMaterial.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum ArmorMaterial
 {
     UHMWPE,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/BodyPartColliderType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/BodyPartColliderType.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftEnumConverter]
 public enum BodyPartColliderType
 {
     None = -1,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/BonusSkillType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/BonusSkillType.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftEnumConverter]
 public enum BonusSkillType
 {
     Physical,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/BuffType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/BuffType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum BuffType
 {
     WeaponSpread,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/CurrencyType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/CurrencyType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum CurrencyType
 {
     RUB,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/DamageEffectType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/DamageEffectType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum DamageEffectType
 {
     HeavyBleeding,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/DamageType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/DamageType.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftListEnumConverter]
 public enum DamageType
 {
     Undefined = 1,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/EquipmentSlots.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/EquipmentSlots.cs
@@ -1,5 +1,9 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
+[EftListEnumConverter]
 public enum EquipmentSlots
 {
     Headwear,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/EventType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/EventType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum EventType
 {
     None,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/ExfiltrationType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/ExfiltrationType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum ExfiltrationType
 {
     Individual,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/ExitStatus.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/ExitStatus.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftEnumConverter]
 public enum ExitStatus
 {
     SURVIVED,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/GiftSenderType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/GiftSenderType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum GiftSenderType
 {
     System,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/MemberCategory.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/MemberCategory.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftEnumConverter]
 public enum MemberCategory
 {
     Default = 0,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/PlayerSide.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/PlayerSide.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftListEnumConverter]
 public enum PlayerSide
 {
     Usec = 1,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/PlayerSideMask.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/PlayerSideMask.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum PlayerSideMask
 {
     None,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/QuestStatusEnum.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/QuestStatusEnum.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftEnumConverter]
 public enum QuestStatusEnum
 {
     Locked = 0,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/QuestTypeEnum.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/QuestTypeEnum.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Enums;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftEnumConverter]
 public enum QuestTypeEnum
 {
     PickUp,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/RepairStrategyType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/RepairStrategyType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum RepairStrategyType
 {
     MeleeWeapon,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/RequirementState.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/RequirementState.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum RequirementState
 {
     None,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/RewardType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/RewardType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum RewardType
 {
     Experience,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/SeasonalEventType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/SeasonalEventType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum SeasonalEventType
 {
     None,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/SideType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/SideType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum SideType
 {
     Pmc,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/ThrowWeapType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/ThrowWeapType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum ThrowWeapType
 {
     frag_grenade,

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/TraderServiceType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/TraderServiceType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models.Enums;
 
+[EftEnumConverter]
 public enum TraderServiceType
 {
     ExUsecLoyalty,

--- a/Libraries/SPTarkov.Server.Core/Models/Logging/LogBackgroundColor.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Logging/LogBackgroundColor.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Logging;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Logging;
+
+[EftEnumConverter]
 public enum LogBackgroundColor
 {
     Black = 40,

--- a/Libraries/SPTarkov.Server.Core/Models/Logging/LogTextColor.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Logging/LogTextColor.cs
@@ -1,5 +1,8 @@
-﻿namespace SPTarkov.Server.Core.Models.Logging;
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
 
+namespace SPTarkov.Server.Core.Models.Logging;
+
+[EftEnumConverter]
 public enum LogTextColor
 {
     Black = 30,

--- a/Libraries/SPTarkov.Server.Core/Models/RadioStationType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/RadioStationType.cs
@@ -1,5 +1,8 @@
+using SPTarkov.Server.Core.Utils.Json.Converters;
+
 namespace SPTarkov.Server.Core.Models;
 
+[EftEnumConverter]
 public enum RadioStationType
 {
     None,

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Dialog/SendMessageDetails.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Dialog/SendMessageDetails.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Eft.Profile;
 using SPTarkov.Server.Core.Models.Enums;
+using SPTarkov.Server.Core.Utils.Json.Converters;
 
 namespace SPTarkov.Server.Core.Models.Spt.Dialog;
 
@@ -176,6 +177,7 @@ public record ProfileChangeEvent
     }
 }
 
+[EftEnumConverter]
 public enum ProfileChangeEventType
 {
     TraderSalesSum,

--- a/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/EftEnumConverter.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/EftEnumConverter.cs
@@ -85,3 +85,10 @@ public class EftEnumConverter<T> : JsonConverter<T>
         writer.WritePropertyName(propertyValue.ToString());
     }
 }
+
+/// <summary>
+/// This attribute should be applied to enums which should be added as a converter to the json converter
+/// </summary>
+[AttributeUsage(AttributeTargets.Enum)]
+public class EftEnumConverterAttribute : Attribute
+{ }

--- a/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/EftListEnumConverter.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/EftListEnumConverter.cs
@@ -34,3 +34,10 @@ public class EftListEnumConverter<T> : JsonConverter<List<T>>
         writer.WriteEndArray();
     }
 }
+
+/// <summary>
+/// This attribute should be applied to enums which should be added as a converter to the json converter
+/// </summary>
+[AttributeUsage(AttributeTargets.Enum)]
+public class EftListEnumConverterAttribute : Attribute
+{ }

--- a/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/IJsonConverterRegistrator.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/IJsonConverterRegistrator.cs
@@ -1,0 +1,8 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SPTarkov.Server.Core.Utils.Json.Converters;
+
+public interface IJsonConverterRegistrator
+{
+    public IEnumerable<JsonConverter> GetJsonConverters();
+}

--- a/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/SptJsonConverterRegistrator.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/SptJsonConverterRegistrator.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+using System.Text.Json.Serialization;
+using SPTarkov.DI.Annotations;
+
+namespace SPTarkov.Server.Core.Utils.Json.Converters;
+
+[Injectable]
+public class SptJsonConverterRegistrator : IJsonConverterRegistrator
+{
+    public IEnumerable<JsonConverter> GetJsonConverters()
+    {
+        return [
+            new BaseSptLoggerReferenceConverter(),
+            new ListOrTConverterFactory(),
+            new DictionaryOrListConverter(),
+
+            new EftEnumConverter<LogLevel>(), // Special case, this belongs to a lib.
+            new BaseInteractionRequestDataConverter(),
+
+            ..GetGenericJsonConverters()
+        ];
+    }
+
+    private static List<JsonConverter> GetGenericJsonConverters()
+    {
+        var enums = Assembly.GetExecutingAssembly().GetTypes()
+            .Where(type => type.IsEnum && type.GetCustomAttribute<EftEnumConverterAttribute>() != null);
+
+        var listEnums = Assembly.GetExecutingAssembly().GetTypes()
+            .Where(type => type.IsEnum && type.GetCustomAttribute<EftListEnumConverterAttribute>() != null);
+
+        var result = enums.Select(e => (JsonConverter) Activator.CreateInstance(typeof(EftEnumConverter<>).MakeGenericType(e))!).ToList();
+        result.AddRange(listEnums.Select(e => (JsonConverter) Activator.CreateInstance(typeof(EftListEnumConverter<>).MakeGenericType(e))!));
+
+        return result;
+    }
+}

--- a/UnitTests/Tests/Test.cs
+++ b/UnitTests/Tests/Test.cs
@@ -1,5 +1,6 @@
 using SPTarkov.Server.Core.Models.Spt.Templates;
 using SPTarkov.Server.Core.Utils;
+using SPTarkov.Server.Core.Utils.Json.Converters;
 using UnitTests.Mock;
 
 namespace UnitTests.Tests;
@@ -12,7 +13,7 @@ public class Test
     [TestInitialize]
     public void Setup()
     {
-        var importer = new ImporterUtil(new MockLogger<ImporterUtil>(), new FileUtil(), new JsonUtil());
+        var importer = new ImporterUtil(new MockLogger<ImporterUtil>(), new FileUtil(), new JsonUtil([ new SptJsonConverterRegistrator() ]));
         var loadTask = importer.LoadRecursiveAsync<Templates>("./TestAssets/");
         loadTask.Wait();
         _templates = loadTask.Result;
@@ -21,7 +22,7 @@ public class Test
     [TestMethod]
     public void TestMethod1()
     {
-        var result = new JsonUtil().Serialize(_templates);
+        var result = new JsonUtil([ new SptJsonConverterRegistrator() ]).Serialize(_templates);
         Console.WriteLine(result);
     }
 }

--- a/UnitTests/Tests/Utils/HashUtilTests.cs
+++ b/UnitTests/Tests/Utils/HashUtilTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using SPTarkov.Server.Core.Utils;
 using SPTarkov.Server.Core.Utils.Cloners;
+using SPTarkov.Server.Core.Utils.Json.Converters;
 using UnitTests.Mock;
 
 namespace UnitTests.Tests.Utils;
@@ -9,7 +10,7 @@ namespace UnitTests.Tests.Utils;
 [TestClass]
 public class HashUtilTests
 {
-    protected HashUtil _hashUtil = new(new RandomUtil(new MockLogger<RandomUtil>(), new JsonCloner(new JsonUtil())));
+    protected HashUtil _hashUtil = new(new RandomUtil(new MockLogger<RandomUtil>(), new JsonCloner(new JsonUtil([ new SptJsonConverterRegistrator() ]))));
 
     [TestMethod]
     public void GenerateTest()

--- a/UnitTests/Tests/Utils/JsonUtilTests.cs
+++ b/UnitTests/Tests/Utils/JsonUtilTests.cs
@@ -1,12 +1,13 @@
 using SPTarkov.Server.Core.Models.Enums;
 using SPTarkov.Server.Core.Utils;
+using SPTarkov.Server.Core.Utils.Json.Converters;
 
 namespace UnitTests.Tests.Utils;
 
 [TestClass]
 public class JsonUtilTests
 {
-    protected JsonUtil _jsonUtil = new();
+    protected JsonUtil _jsonUtil = new([ new SptJsonConverterRegistrator() ]);
 
     [TestMethod]
     public void SerializeAndDeserialize_WithDictionaryOfETFEnum_ExpectCorrectParsing()

--- a/UnitTests/Tests/Utils/RandomUtilTests.cs
+++ b/UnitTests/Tests/Utils/RandomUtilTests.cs
@@ -1,5 +1,6 @@
 using SPTarkov.Server.Core.Utils;
 using SPTarkov.Server.Core.Utils.Cloners;
+using SPTarkov.Server.Core.Utils.Json.Converters;
 using UnitTests.Mock;
 
 namespace UnitTests.Tests.Utils;
@@ -7,7 +8,7 @@ namespace UnitTests.Tests.Utils;
 [TestClass]
 public sealed class RandomUtilTests
 {
-    private readonly RandomUtil _randomUtil = new(new MockLogger<RandomUtil>(), new JsonCloner(new JsonUtil()));
+    private readonly RandomUtil _randomUtil = new(new MockLogger<RandomUtil>(), new JsonCloner(new JsonUtil([ new SptJsonConverterRegistrator() ])));
 
     [TestMethod]
     public void GetIntTest()


### PR DESCRIPTION
Adds an interface for mods to implement in order to inject new Json converters. This allows mods to easily add new json converters and have them available at the right time. 

```
[Injectable]
public class SptJsonConverterRegistrator : IJsonConverterRegistrator
{
  public IEnumerable<JsonConverter> GetJsonConverters()
  {
    return []; // the list of converters;
  }
}
```

Additionally, switches the server to use this implementation and add attributes and reflection to load json converters when the JsonUtil is constructed.

Adds 2 new attributes: `EftListEnumConverterAttribute` and `EftEnumConverterAttribute` which should be applied to enums that should be added as convertible as part of an `EftEnumConverter`. These get added through reflection.
