### PR TITLE
Move Router, Callbacks and GetResponse over to ValueTask

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Callbacks/AchievementCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/AchievementCallbacks.cs
@@ -15,17 +15,17 @@ public class AchievementCallbacks(
     ///     Handle client/achievement/list
     /// </summary>
     /// <returns></returns>
-    public string GetAchievements(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetAchievements(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_achievementController.GetAchievements(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_achievementController.GetAchievements(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/achievement/statistic
     /// </summary>
     /// <returns></returns>
-    public string Statistic(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> Statistic(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_achievementController.GetAchievementStatics(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_achievementController.GetAchievementStatics(sessionID)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/BotCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/BotCallbacks.cs
@@ -2,7 +2,6 @@ using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.Controllers;
 using SPTarkov.Server.Core.Models.Eft.Bot;
 using SPTarkov.Server.Core.Models.Eft.Common;
-using SPTarkov.Server.Core.Models.Eft.Match;
 using SPTarkov.Server.Core.Utils;
 
 namespace SPTarkov.Server.Core.Callbacks;
@@ -18,65 +17,65 @@ public class BotCallbacks(
     ///     Is called by client to define each bot roles wave limit
     /// </summary>
     /// <returns></returns>
-    public string GetBotLimit(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetBotLimit(string url, EmptyRequestData _, string sessionID)
     {
         var splitUrl = url.Split('/');
         var type = splitUrl[^1];
-        return _httpResponseUtil.NoBody(_botController.GetBotPresetGenerationLimit(type));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_botController.GetBotPresetGenerationLimit(type)));
     }
 
     /// <summary>
     ///     Handle singleplayer/settings/bot/difficulty
     /// </summary>
     /// <returns></returns>
-    public string GetBotDifficulty(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetBotDifficulty(string url, EmptyRequestData _, string sessionID)
     {
         var splitUrl = url.Split('/');
         var type = splitUrl[^2].ToLower();
         var difficulty = splitUrl[^1];
         if (difficulty == "core")
         {
-            return _httpResponseUtil.NoBody(_botController.GetBotCoreDifficulty());
+            return new ValueTask<string>(_httpResponseUtil.NoBody(_botController.GetBotCoreDifficulty()));
         }
 
-        return _httpResponseUtil.NoBody(_botController.GetBotDifficulty(sessionID, type, difficulty));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_botController.GetBotDifficulty(sessionID, type, difficulty)));
     }
 
     /// <summary>
     ///     Handle singleplayer/settings/bot/difficulties
     /// </summary>
     /// <returns></returns>
-    public string GetAllBotDifficulties(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetAllBotDifficulties(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_botController.GetAllBotDifficulties());
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_botController.GetAllBotDifficulties()));
     }
 
     /// <summary>
     ///     Handle client/game/bot/generate
     /// </summary>
     /// <returns></returns>
-    public string GenerateBots(string url, GenerateBotsRequestData info, string sessionID)
+    public ValueTask<string> GenerateBots(string url, GenerateBotsRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_botController.Generate(sessionID, info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_botController.Generate(sessionID, info)));
     }
 
     /// <summary>
     ///     Handle singleplayer/settings/bot/maxCap
     /// </summary>
     /// <returns></returns>
-    public string GetBotCap(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetBotCap(string url, EmptyRequestData _, string sessionID)
     {
         var splitUrl = url.Split('/');
         var location = splitUrl[^1];
-        return _httpResponseUtil.NoBody(_botController.GetBotCap(location));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_botController.GetBotCap(location)));
     }
 
     /// <summary>
     ///     Handle singleplayer/settings/bot/getBotBehaviours
     /// </summary>
     /// <returns></returns>
-    public string GetBotBehaviours()
+    public ValueTask<string> GetBotBehaviours()
     {
-        return _httpResponseUtil.NoBody(_botController.GetAiBotBrainTypes());
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_botController.GetAiBotBrainTypes()));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/BuildsCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/BuildsCallbacks.cs
@@ -17,9 +17,9 @@ public class BuildsCallbacks(
     ///     Handle client/builds/list
     /// </summary>
     /// <returns></returns>
-    public string GetBuilds(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetBuilds(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_buildController.GetUserBuilds(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_buildController.GetUserBuilds(sessionID)));
     }
 
     /// <summary>
@@ -29,39 +29,39 @@ public class BuildsCallbacks(
     /// <param name="request"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string CreateMagazineTemplate(string url, SetMagazineRequest request, string sessionID)
+    public ValueTask<string> CreateMagazineTemplate(string url, SetMagazineRequest request, string sessionID)
     {
         _buildController.CreateMagazineTemplate(sessionID, request);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/builds/weapon/save
     /// </summary>
     /// <returns></returns>
-    public string SetWeapon(string url, PresetBuildActionRequestData request, string sessionID)
+    public ValueTask<string> SetWeapon(string url, PresetBuildActionRequestData request, string sessionID)
     {
         _buildController.SaveWeaponBuild(sessionID, request);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/builds/equipment/save
     /// </summary>
     /// <returns></returns>
-    public string SetEquipment(string url, PresetBuildActionRequestData request, string sessionID)
+    public ValueTask<string> SetEquipment(string url, PresetBuildActionRequestData request, string sessionID)
     {
         _buildController.SaveEquipmentBuild(sessionID, request);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/builds/delete
     /// </summary>
     /// <returns></returns>
-    public string DeleteBuild(string url, RemoveBuildRequestData request, string sessionID)
+    public ValueTask<string> DeleteBuild(string url, RemoveBuildRequestData request, string sessionID)
     {
         _buildController.RemoveBuild(sessionID, request);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/BundleCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/BundleCallbacks.cs
@@ -14,17 +14,17 @@ public class BundleCallbacks(
     ///     Handle singleplayer/bundles
     /// </summary>
     /// <returns></returns>
-    public string GetBundles(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetBundles(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_bundleLoader.GetBundles());
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_bundleLoader.GetBundles()));
     }
 
     /// <summary>
     ///     TODO: what does it do
     /// </summary>
     /// <returns></returns>
-    public string GetBundle(string url, object info, string sessionID)
+    public ValueTask<string> GetBundle(string url, object info, string sessionID)
     {
-        return "BUNDLE";
+        return new ValueTask<string>("BUNDLE");
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/ClientLogCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/ClientLogCallbacks.cs
@@ -15,24 +15,24 @@ public class ClientLogCallbacks(
     ClientLogController _clientLogController,
     ConfigServer _configServer,
     LocalisationService _localisationService
-    // ModLoadOrder _modLoadOrder // TODO: needs implementing
+// ModLoadOrder _modLoadOrder // TODO: needs implementing
 )
 {
     /// <summary>
     ///     Handle /singleplayer/log
     /// </summary>
     /// <returns></returns>
-    public string ClientLog(string url, ClientLogRequest request, string sessionID)
+    public ValueTask<string> ClientLog(string url, ClientLogRequest request, string sessionID)
     {
         _clientLogController.ClientLog(request);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle /singleplayer/release
     /// </summary>
     /// <returns></returns>
-    public string ReleaseNotes()
+    public ValueTask<string> ReleaseNotes()
     {
         var data = _configServer.GetConfig<CoreConfig>().Release;
 
@@ -52,16 +52,16 @@ public class ClientLogCallbacks(
         data.IsModdable = ProgramStatics.MODS();
         data.IsModded = false; // TODO
 
-        return _httpResponseUtil.NoBody(data);
+        return new ValueTask<string>(_httpResponseUtil.NoBody(data));
     }
 
     /// <summary>
     ///     Handle /singleplayer/enableBSGlogging
     /// </summary>
     /// <returns></returns>
-    public string BsgLogging()
+    public ValueTask<string> BsgLogging()
     {
         var data = _configServer.GetConfig<CoreConfig>().BsgLogging;
-        return _httpResponseUtil.NoBody(data);
+        return new ValueTask<string>(_httpResponseUtil.NoBody(data));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/CustomizationCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/CustomizationCallbacks.cs
@@ -19,21 +19,21 @@ public class CustomizationCallbacks(
     ///     Handle client/trading/customization/storage
     /// </summary>
     /// <returns></returns>
-    public string GetCustomisationUnlocks(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetCustomisationUnlocks(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_saveServer.GetProfile(sessionID).CustomisationUnlocks);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_saveServer.GetProfile(sessionID).CustomisationUnlocks));
     }
 
     /// <summary>
     ///     Handle client/trading/customization
     /// </summary>
     /// <returns></returns>
-    public string GetTraderSuits(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTraderSuits(string url, EmptyRequestData _, string sessionID)
     {
         var splitUrl = url.Split('/');
         var traderId = splitUrl[^3];
 
-        return _httpResponseUtil.GetBody(_customizationController.GetTraderSuits(traderId, sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_customizationController.GetTraderSuits(traderId, sessionID)));
     }
 
     /// <summary>
@@ -49,18 +49,18 @@ public class CustomizationCallbacks(
     ///     Handle client/hideout/customization/offer/list
     /// </summary>
     /// <returns></returns>
-    public string GetHideoutCustomisation(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetHideoutCustomisation(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_customizationController.GetHideoutCustomisation(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_customizationController.GetHideoutCustomisation(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/customization/storage
     /// </summary>
     /// <returns></returns>
-    public string GetStorage(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetStorage(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_customizationController.GetCustomisationStorage(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_customizationController.GetCustomisationStorage(sessionID)));
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Callbacks/DataCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/DataCallbacks.cs
@@ -19,101 +19,101 @@ public class DataCallbacks(
     ///     Handle client/settings
     /// </summary>
     /// <returns></returns>
-    public string GetSettings(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetSettings(string url, EmptyRequestData _, string sessionID)
     {
         var returns = _httpResponseUtil.GetBody(_databaseService.GetSettings());
-        return returns;
+        return new ValueTask<string>(returns);
     }
 
     /// <summary>
     ///     Handle client/globals
     /// </summary>
     /// <returns></returns>
-    public string GetGlobals(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetGlobals(string url, EmptyRequestData _, string sessionID)
     {
         var globals = _databaseService.GetGlobals();
         var returns = _httpResponseUtil.GetBody(globals);
 
-        return returns;
+        return new ValueTask<string>(returns);
     }
 
     /// <summary>
     ///     Handle client/items
     /// </summary>
     /// <returns></returns>
-    public string GetTemplateItems(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTemplateItems(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetUnclearedBody(_databaseService.GetItems());
+        return new ValueTask<string>(_httpResponseUtil.GetUnclearedBody(_databaseService.GetItems()));
     }
 
     /// <summary>
     ///     Handle client/handbook/templates
     /// </summary>
     /// <returns></returns>
-    public string GetTemplateHandbook(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTemplateHandbook(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetHandbook());
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetHandbook()));
     }
 
     /// <summary>
     ///     Handle client/customization
     /// </summary>
     /// <returns></returns>
-    public string GetTemplateSuits(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTemplateSuits(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetTemplates().Customization);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetTemplates().Customization));
     }
 
     /// <summary>
     ///     Handle client/account/customization
     /// </summary>
     /// <returns></returns>
-    public string GetTemplateCharacter(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTemplateCharacter(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetTemplates().Character);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetTemplates().Character));
     }
 
     /// <summary>
     ///     Handle client/hideout/settings
     /// </summary>
     /// <returns></returns>
-    public string GetHideoutSettings(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetHideoutSettings(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetHideout().Settings);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetHideout().Settings));
     }
 
     /// <summary>
     ///     Handle client/hideout/areas
     /// </summary>
     /// <returns></returns>
-    public string GetHideoutAreas(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetHideoutAreas(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetHideout().Areas);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetHideout().Areas));
     }
 
     /// <summary>
     ///     Handle client/hideout/production/recipes
     /// </summary>
     /// <returns></returns>
-    public string GetHideoutProduction(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetHideoutProduction(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetHideout().Production);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetHideout().Production));
     }
 
     /// <summary>
     ///     Handle client/languages
     /// </summary>
     /// <returns></returns>
-    public string GetLocalesLanguages(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetLocalesLanguages(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetLocales().Languages);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetLocales().Languages));
     }
 
     /// <summary>
     ///     Handle client/menu/locale
     /// </summary>
     /// <returns></returns>
-    public string GetLocalesMenu(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetLocalesMenu(string url, EmptyRequestData _, string sessionID)
     {
         var localeId = url.Replace("/client/menu/locale/", "");
         var locales = _databaseService.GetLocales();
@@ -124,38 +124,38 @@ public class DataCallbacks(
             throw new Exception($"Unable to determine locale for request with {localeId}");
         }
 
-        return _httpResponseUtil.GetBody(result);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(result));
     }
 
     /// <summary>
     ///     Handle client/locale
     /// </summary>
     /// <returns></returns>
-    public string GetLocalesGlobal(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetLocalesGlobal(string url, EmptyRequestData _, string sessionID)
     {
         var localeId = url.Replace("/client/locale/", "");
         var locales = _localeService.GetLocaleDb(localeId);
 
-        return _httpResponseUtil.GetUnclearedBody(locales);
+        return new ValueTask<string>(_httpResponseUtil.GetUnclearedBody(locales));
     }
 
     /// <summary>
     ///     Handle client/hideout/qte/list
     /// </summary>
     /// <returns></returns>
-    public string GetQteList(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetQteList(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetUnclearedBody(_hideoutController.GetQteList(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetUnclearedBody(_hideoutController.GetQteList(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/items/prices/
     /// </summary>
     /// <returns></returns>
-    public string GetItemPrices(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetItemPrices(string url, EmptyRequestData _, string sessionID)
     {
         var traderId = url.Replace("/client/items/prices/", "");
 
-        return _httpResponseUtil.GetBody(_traderController.GetItemPrices(sessionID, traderId));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_traderController.GetItemPrices(sessionID, traderId)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/DialogueCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/DialogueCallbacks.cs
@@ -27,16 +27,16 @@ public class DialogueCallbacks(
     ///     Handle client/friend/list
     /// </summary>
     /// <returns></returns>
-    public virtual string GetFriendList(string url, EmptyRequestData _, string sessionID)
+    public virtual ValueTask<string> GetFriendList(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_dialogueController.GetFriendList(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_dialogueController.GetFriendList(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/chatServer/list
     /// </summary>
     /// <returns></returns>
-    public virtual string GetChatServerList(string url, GetChatServerListRequestData request, string sessionID)
+    public virtual ValueTask<string> GetChatServerList(string url, GetChatServerListRequestData request, string sessionID)
     {
         var chatServer = new List<ChatServer>
         {
@@ -61,7 +61,7 @@ public class DialogueCallbacks(
             }
         };
 
-        return _httpResponseUtil.GetBody(chatServer);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(chatServer));
     }
 
     /// <summary>
@@ -69,9 +69,9 @@ public class DialogueCallbacks(
     ///     TODO: request properties are not handled
     /// </summary>
     /// <returns></returns>
-    public virtual string GetMailDialogList(string url, GetMailDialogListRequestData request, string sessionID)
+    public virtual ValueTask<string> GetMailDialogList(string url, GetMailDialogListRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_dialogueController.GenerateDialogueList(sessionID), 0, null, false);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_dialogueController.GenerateDialogueList(sessionID), 0, null, false));
     }
 
     /// <summary>
@@ -81,191 +81,191 @@ public class DialogueCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public virtual string GetMailDialogView(string url, GetMailDialogViewRequestData request, string sessionID)
+    public virtual ValueTask<string> GetMailDialogView(string url, GetMailDialogViewRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_dialogueController.GenerateDialogueView(request, sessionID), 0, null, false);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_dialogueController.GenerateDialogueView(request, sessionID), 0, null, false));
     }
 
     /// <summary>
     ///     Handle client/mail/dialog/info
     /// </summary>
     /// <returns></returns>
-    public virtual string GetMailDialogInfo(string url, GetMailDialogInfoRequestData request, string sessionID)
+    public virtual ValueTask<string> GetMailDialogInfo(string url, GetMailDialogInfoRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_dialogueController.GetDialogueInfo(request.DialogId, sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_dialogueController.GetDialogueInfo(request.DialogId, sessionID)));
     }
 
     /// <summary>
     ///     Handle client/mail/dialog/remove
     /// </summary>
     /// <returns></returns>
-    public virtual string RemoveDialog(string url, RemoveDialogRequestData request, string sessionID)
+    public virtual ValueTask<string> RemoveDialog(string url, RemoveDialogRequestData request, string sessionID)
     {
         _dialogueController.RemoveDialogue(request.DialogId, sessionID);
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
     /// <summary>
     ///     Handle client/mail/dialog/pin
     /// </summary>
     /// <returns></returns>
-    public virtual string PinDialog(string url, PinDialogRequestData request, string sessionID)
+    public virtual ValueTask<string> PinDialog(string url, PinDialogRequestData request, string sessionID)
     {
         _dialogueController.SetDialoguePin(request.DialogId, true, sessionID);
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
     /// <summary>
     ///     Handle client/mail/dialog/unpin
     /// </summary>
     /// <returns></returns>
-    public virtual string UnpinDialog(string url, PinDialogRequestData request, string sessionID)
+    public virtual ValueTask<string> UnpinDialog(string url, PinDialogRequestData request, string sessionID)
     {
         _dialogueController.SetDialoguePin(request.DialogId, false, sessionID);
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
     /// <summary>
     ///     Handle client/mail/dialog/read
     /// </summary>
     /// <returns></returns>
-    public virtual string SetRead(string url, SetDialogReadRequestData request, string sessionID)
+    public virtual ValueTask<string> SetRead(string url, SetDialogReadRequestData request, string sessionID)
     {
         _dialogueController.SetRead(request.Dialogs, sessionID);
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
     /// <summary>
     ///     Handle client/mail/dialog/getAllAttachments
     /// </summary>
     /// <returns></returns>
-    public virtual string GetAllAttachments(string url, GetAllAttachmentsRequestData request, string sessionID)
+    public virtual ValueTask<string> GetAllAttachments(string url, GetAllAttachmentsRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_dialogueController.GetAllAttachments(request.DialogId, sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_dialogueController.GetAllAttachments(request.DialogId, sessionID)));
     }
 
     /// <summary>
     ///     Handle client/mail/msg/send
     /// </summary>
     /// <returns></returns>
-    public virtual string SendMessage(string url, SendMessageRequest request, string sessionID)
+    public virtual ValueTask<string> SendMessage(string url, SendMessageRequest request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_dialogueController.SendMessage(sessionID, request));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_dialogueController.SendMessage(sessionID, request)));
     }
 
     /// <summary>
     ///     Handle client/friend/request/list/outbox
     /// </summary>
     /// <returns></returns>
-    public virtual string ListOutbox(string url, EmptyRequestData _, string sessionID)
+    public virtual ValueTask<string> ListOutbox(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
     /// <summary>
     ///     Handle client/friend/request/list/inbox
     /// </summary>
     /// <returns></returns>
-    public virtual string ListInbox(string url, EmptyRequestData _, string sessionID)
+    public virtual ValueTask<string> ListInbox(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
     /// <summary>
     ///     Handle client/friend/request/send
     /// </summary>
     /// <returns></returns>
-    public virtual string SendFriendRequest(string url, FriendRequestData request, string sessionID)
+    public virtual ValueTask<string> SendFriendRequest(string url, FriendRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_dialogueController.SendFriendRequest(sessionID, request));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_dialogueController.SendFriendRequest(sessionID, request)));
     }
 
     /// <summary>
     ///     Handle client/friend/request/accept-all
     /// </summary>
     /// <returns></returns>
-    public virtual string AcceptAllFriendRequests(string url, EmptyRequestData _, string sessionID)
+    public virtual ValueTask<string> AcceptAllFriendRequests(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/friend/request/accept
     /// </summary>
     /// <returns></returns>
-    public virtual string AcceptFriendRequest(string url, AcceptFriendRequestData request, string sessionID)
+    public virtual ValueTask<string> AcceptFriendRequest(string url, AcceptFriendRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/friend/request/decline
     /// </summary>
     /// <returns></returns>
-    public virtual string DeclineFriendRequest(string url, DeclineFriendRequestData request, string sessionID)
+    public virtual ValueTask<string> DeclineFriendRequest(string url, DeclineFriendRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/friend/request/cancel
     /// </summary>
     /// <returns></returns>
-    public virtual string CancelFriendRequest(string url, CancelFriendRequestData request, string sessionID)
+    public virtual ValueTask<string> CancelFriendRequest(string url, CancelFriendRequestData request, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/friend/delete
     /// </summary>
     /// <returns></returns>
-    public virtual string DeleteFriend(string url, DeleteFriendRequest request, string sessionID)
+    public virtual ValueTask<string> DeleteFriend(string url, DeleteFriendRequest request, string sessionID)
     {
         _dialogueController.DeleteFriend(sessionID, request);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/friend/ignore/set
     /// </summary>
     /// <returns></returns>
-    public virtual string IgnoreFriend(string url, UIDRequestData request, string sessionID)
+    public virtual ValueTask<string> IgnoreFriend(string url, UIDRequestData request, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/friend/ignore/remove
     /// </summary>
     /// <returns></returns>
-    public virtual string UnIgnoreFriend(string url, UIDRequestData request, string sessionID)
+    public virtual ValueTask<string> UnIgnoreFriend(string url, UIDRequestData request, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
-    public virtual string ClearMail(string url, ClearMailMessageRequest request, string sessionID)
+    public virtual ValueTask<string> ClearMail(string url, ClearMailMessageRequest request, string sessionID)
     {
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
-    public virtual string CreateGroupMail(string url, CreateGroupMailRequest request, string sessionID)
+    public virtual ValueTask<string> CreateGroupMail(string url, CreateGroupMailRequest request, string sessionID)
     {
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
-    public virtual string ChangeMailGroupOwner(string url, ChangeGroupMailOwnerRequest request, string sessionID)
+    public virtual ValueTask<string> ChangeMailGroupOwner(string url, ChangeGroupMailOwnerRequest request, string sessionID)
     {
-        return "Not Implemented!"; // Not implemented in Node
+        return new ValueTask<string>("Not Implemented!"); // Not implemented in Node
     }
 
-    public virtual string AddUserToMail(string url, AddUserGroupMailRequest request, string sessionID)
+    public virtual ValueTask<string> AddUserToMail(string url, AddUserGroupMailRequest request, string sessionID)
     {
-        return "Not Implemented!"; // Not implemented in Node
+        return new ValueTask<string>("Not Implemented!"); // Not implemented in Node
     }
 
-    public virtual string RemoveUserFromMail(string url, RemoveUserGroupMailRequest request, string sessionID)
+    public virtual ValueTask<string> RemoveUserFromMail(string url, RemoveUserGroupMailRequest request, string sessionID)
     {
-        return "Not Implemented!"; // Not implemented in Node
+        return new ValueTask<string>("Not Implemented!"); // Not implemented in Node
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/GameCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/GameCallbacks.cs
@@ -28,25 +28,25 @@ public class GameCallbacks(
     ///     Handle client/game/version/validate
     /// </summary>
     /// <returns></returns>
-    public string VersionValidate(string url, VersionValidateRequestData info, string sessionID)
+    public ValueTask<string> VersionValidate(string url, VersionValidateRequestData info, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/game/start
     /// </summary>
     /// <returns></returns>
-    public string GameStart(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GameStart(string url, EmptyRequestData _, string sessionID)
     {
         var startTimestampSec = _timeUtil.GetTimeStamp();
         _gameController.GameStart(url, sessionID, startTimestampSec);
-        return _httpResponseUtil.GetBody(
+        return new ValueTask<string>(_httpResponseUtil.GetBody(
             new GameStartResponse
             {
                 UtcTime = startTimestampSec
             }
-        );
+        ));
     }
 
     /// <summary>
@@ -54,128 +54,128 @@ public class GameCallbacks(
     ///     Save profiles on game close
     /// </summary>
     /// <returns></returns>
-    public string GameLogout(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GameLogout(string url, EmptyRequestData _, string sessionID)
     {
         _saveServer.SaveProfile(sessionID);
-        return _httpResponseUtil.GetBody(
+        return new ValueTask<string>(_httpResponseUtil.GetBody(
             new GameLogoutResponseData
             {
                 Status = "ok"
             }
-        );
+        ));
     }
 
     /// <summary>
     ///     Handle client/game/config
     /// </summary>
     /// <returns></returns>
-    public string GetGameConfig(string url, GameEmptyCrcRequestData info, string sessionID)
+    public ValueTask<string> GetGameConfig(string url, GameEmptyCrcRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_gameController.GetGameConfig(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_gameController.GetGameConfig(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/game/mode
     /// </summary>
     /// <returns></returns>
-    public string GetGameMode(string url, GameModeRequestData info, string sessionID)
+    public ValueTask<string> GetGameMode(string url, GameModeRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_gameController.GetGameMode(sessionID, info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_gameController.GetGameMode(sessionID, info)));
     }
 
     /// <summary>
     ///     Handle client/server/list
     /// </summary>
     /// <returns></returns>
-    public string GetServer(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetServer(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_gameController.GetServer(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_gameController.GetServer(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/match/group/current
     /// </summary>
     /// <returns></returns>
-    public string GetCurrentGroup(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetCurrentGroup(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_gameController.GetCurrentGroup(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_gameController.GetCurrentGroup(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/checkVersion
     /// </summary>
     /// <returns></returns>
-    public string ValidateGameVersion(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> ValidateGameVersion(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_gameController.GetValidGameVersion(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_gameController.GetValidGameVersion(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/game/keepalive
     /// </summary>
     /// <returns></returns>
-    public string GameKeepalive(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GameKeepalive(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_gameController.GetKeepAlive(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_gameController.GetKeepAlive(sessionID)));
     }
 
     /// <summary>
     ///     Handle singleplayer/settings/version
     /// </summary>
     /// <returns></returns>
-    public string GetVersion(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetVersion(string url, EmptyRequestData _, string sessionID)
     {
         // change to be a proper type
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new
             {
                 Version = _watermark.GetInGameVersionLabel()
             }
-        );
+        ));
     }
 
     /// <summary>
     ///     Handle /client/report/send & /client/reports/lobby/send
     /// </summary>
     /// <returns></returns>
-    public string ReportNickname(string url, UIDRequestData request, string sessionID)
+    public ValueTask<string> ReportNickname(string url, UIDRequestData request, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle singleplayer/settings/getRaidTime
     /// </summary>
     /// <returns></returns>
-    public string GetRaidTime(string url, GetRaidTimeRequest request, string sessionID)
+    public ValueTask<string> GetRaidTime(string url, GetRaidTimeRequest request, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_gameController.GetRaidTime(sessionID, request));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_gameController.GetRaidTime(sessionID, request)));
     }
 
     /// <summary>
     ///     Handle /client/survey
     /// </summary>
     /// <returns></returns>
-    public string GetSurvey(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetSurvey(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_gameController.GetSurvey(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_gameController.GetSurvey(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/survey/view
     /// </summary>
     /// <returns></returns>
-    public string GetSurveyView(string url, SendSurveyOpinionRequest request, string sessionID)
+    public ValueTask<string> GetSurveyView(string url, SendSurveyOpinionRequest request, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/survey/opinion
     /// </summary>
     /// <returns></returns>
-    public string SendSurveyOpinion(string url, SendSurveyOpinionRequest request, string sessionID)
+    public ValueTask<string> SendSurveyOpinion(string url, SendSurveyOpinionRequest request, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/HealthCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/HealthCallbacks.cs
@@ -22,10 +22,10 @@ public class HealthCallbacks(
     /// <param name="info">HealthListener.Instance.CurrentHealth class</param>
     /// <param name="sessionID">session id</param>
     /// <returns>empty response, no data sent back to client</returns>
-    public string HandleWorkoutEffects(string url, WorkoutData info, string sessionID)
+    public ValueTask<string> HandleWorkoutEffects(string url, WorkoutData info, string sessionID)
     {
         _healthController.ApplyWorkoutChanges(_profileHelper.GetPmcProfile(sessionID), info, sessionID);
-        return _httpResponseUtil.EmptyResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyResponse());
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Callbacks/InraidCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/InraidCallbacks.cs
@@ -20,10 +20,10 @@ public class InraidCallbacks(
     /// <param name="info">register player request</param>
     /// <param name="sessionID">Session id</param>
     /// <returns>Null http response</returns>
-    public string RegisterPlayer(string url, RegisterPlayerRequestData info, string sessionID)
+    public ValueTask<string> RegisterPlayer(string url, RegisterPlayerRequestData info, string sessionID)
     {
         _inRaidController.AddPlayer(sessionID, info);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
@@ -33,36 +33,36 @@ public class InraidCallbacks(
     /// <param name="info">Save progress request</param>
     /// <param name="sessionID">Session id</param>
     /// <returns>Null http response</returns>
-    public string SaveProgress(string url, ScavSaveRequestData info, string sessionID)
+    public ValueTask<string> SaveProgress(string url, ScavSaveRequestData info, string sessionID)
     {
         _inRaidController.SavePostRaidProfileForScav(info, sessionID);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle singleplayer/settings/raid/menu
     /// </summary>
     /// <returns>JSON as string</returns>
-    public string GetRaidMenuSettings()
+    public ValueTask<string> GetRaidMenuSettings()
     {
-        return _httpResponseUtil.NoBody(_inRaidController.GetInRaidConfig().RaidMenuSettings);
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_inRaidController.GetInRaidConfig().RaidMenuSettings));
     }
 
     /// <summary>
     ///     Handle singleplayer/scav/traitorscavhostile
     /// </summary>
     /// <returns></returns>
-    public string GetTraitorScavHostileChance(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTraitorScavHostileChance(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_inRaidController.GetTraitorScavHostileChance(url, sessionID));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_inRaidController.GetTraitorScavHostileChance(url, sessionID)));
     }
 
     /// <summary>
     ///     Handle singleplayer/bosstypes
     /// </summary>
     /// <returns></returns>
-    public string GetBossTypes(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetBossTypes(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_inRaidController.GetBossTypes(url, sessionID));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_inRaidController.GetBossTypes(url, sessionID)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/InsuranceCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/InsuranceCallbacks.cs
@@ -40,9 +40,9 @@ public class InsuranceCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetInsuranceCost(string url, GetInsuranceCostRequestData info, string sessionID)
+    public ValueTask<string> GetInsuranceCost(string url, GetInsuranceCostRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_insuranceController.Cost(info, sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_insuranceController.Cost(info, sessionID)));
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Callbacks/ItemEventCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/ItemEventCallbacks.cs
@@ -9,14 +9,14 @@ namespace SPTarkov.Server.Core.Callbacks;
 [Injectable]
 public class ItemEventCallbacks(HttpResponseUtil _httpResponseUtil, ItemEventRouter _itemEventRouter)
 {
-    public string HandleEvents(string url, ItemEventRouterRequest info, string sessionID)
+    public ValueTask<string> HandleEvents(string url, ItemEventRouterRequest info, string sessionID)
     {
         var eventResponse = _itemEventRouter.HandleEvents(info, sessionID);
         var result = IsCriticalError(eventResponse.Warnings)
             ? _httpResponseUtil.GetBody(eventResponse, GetErrorCode(eventResponse.Warnings), eventResponse.Warnings[0].ErrorMessage)
             : _httpResponseUtil.GetBody(eventResponse);
 
-        return result;
+        return new ValueTask<string>(result);
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Callbacks/LauncherCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/LauncherCallbacks.cs
@@ -15,74 +15,74 @@ public class LauncherCallbacks(
     Watermark _watermark
 )
 {
-    public string Connect()
+    public ValueTask<string> Connect()
     {
-        return _httpResponseUtil.NoBody(_launcherController.Connect());
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_launcherController.Connect()));
     }
 
-    public string Login(string url, LoginRequestData info, string sessionID)
+    public ValueTask<string> Login(string url, LoginRequestData info, string sessionID)
     {
         var output = _launcherController.Login(info);
-        return output ?? "FAILED";
+        return new ValueTask<string>(output ?? "FAILED");
     }
 
-    public string Register(string url, RegisterData info, string sessionID)
+    public ValueTask<string> Register(string url, RegisterData info, string sessionID)
     {
         var output = _launcherController.Register(info);
-        return string.IsNullOrEmpty(output) ? "FAILED" : "OK";
+        return new ValueTask<string>(string.IsNullOrEmpty(output) ? "FAILED" : "OK");
     }
 
-    public string Get(string url, LoginRequestData info, string sessionID)
+    public ValueTask<string> Get(string url, LoginRequestData info, string sessionID)
     {
         var output = _launcherController.Find(_launcherController.Login(info));
-        return _httpResponseUtil.NoBody(output);
+        return new ValueTask<string>(_httpResponseUtil.NoBody(output));
     }
 
-    public string ChangeUsername(string url, ChangeRequestData info, string sessionID)
+    public ValueTask<string> ChangeUsername(string url, ChangeRequestData info, string sessionID)
     {
         var output = _launcherController.ChangeUsername(info);
-        return string.IsNullOrEmpty(output) ? "FAILED" : "OK";
+        return new ValueTask<string>(string.IsNullOrEmpty(output) ? "FAILED" : "OK");
     }
 
-    public string ChangePassword(string url, ChangeRequestData info, string sessionID)
+    public ValueTask<string> ChangePassword(string url, ChangeRequestData info, string sessionID)
     {
         var output = _launcherController.ChangePassword(info);
-        return string.IsNullOrEmpty(output) ? "FAILED" : "OK";
+        return new ValueTask<string>(string.IsNullOrEmpty(output) ? "FAILED" : "OK");
     }
 
-    public string Wipe(string url, RegisterData info, string sessionID)
+    public ValueTask<string> Wipe(string url, RegisterData info, string sessionID)
     {
         var output = _launcherController.Wipe(info);
-        return string.IsNullOrEmpty(output) ? "FAILED" : "OK";
+        return new ValueTask<string>(string.IsNullOrEmpty(output) ? "FAILED" : "OK");
     }
 
-    public string GetServerVersion()
+    public ValueTask<string> GetServerVersion()
     {
-        return _httpResponseUtil.NoBody(_watermark.GetVersionTag());
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_watermark.GetVersionTag()));
     }
 
-    public string Ping(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> Ping(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NoBody("pong!");
+        return new ValueTask<string>(_httpResponseUtil.NoBody("pong!"));
     }
 
-    public string RemoveProfile(string url, RemoveProfileData info, string sessionID)
+    public ValueTask<string> RemoveProfile(string url, RemoveProfileData info, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_saveServer.RemoveProfile(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_saveServer.RemoveProfile(sessionID)));
     }
 
-    public string GetCompatibleTarkovVersion()
+    public ValueTask<string> GetCompatibleTarkovVersion()
     {
-        return _httpResponseUtil.NoBody(_launcherController.GetCompatibleTarkovVersion());
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_launcherController.GetCompatibleTarkovVersion()));
     }
 
-    public string GetLoadedServerMods()
+    public ValueTask<string> GetLoadedServerMods()
     {
-        return _httpResponseUtil.NoBody(_launcherController.GetLoadedServerMods());
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_launcherController.GetLoadedServerMods()));
     }
 
-    public string GetServerModsProfileUsed(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetServerModsProfileUsed(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_launcherController.GetServerModsProfileUsed(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_launcherController.GetServerModsProfileUsed(sessionID)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/LauncherV2Callbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/LauncherV2Callbacks.cs
@@ -13,72 +13,72 @@ public class LauncherV2Callbacks(
     ProfileController _profileController
 )
 {
-    public string Ping()
+    public ValueTask<string> Ping()
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2PingResponse
             {
                 Response = _launcherV2Controller.Ping()
             }
-        );
+        ));
     }
 
-    public string Types()
+    public ValueTask<string> Types()
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2TypesResponse
             {
                 Response = _launcherV2Controller.Types()
             }
-        );
+        ));
     }
 
-    public string Login(LoginRequestData info)
+    public ValueTask<string> Login(LoginRequestData info)
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2LoginResponse
             {
                 Response = _launcherV2Controller.Login(info)
             }
-        );
+        ));
     }
 
-    public string Register(RegisterData info)
+    public ValueTask<string> Register(RegisterData info)
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2RegisterResponse
             {
                 Response = _launcherV2Controller.Register(info),
                 Profiles = _profileController.GetMiniProfiles()
             }
-        );
+        ));
     }
 
-    public string PasswordChange(ChangeRequestData info)
+    public ValueTask<string> PasswordChange(ChangeRequestData info)
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2PasswordChangeResponse
             {
                 Response = _launcherV2Controller.PasswordChange(info),
                 Profiles = _profileController.GetMiniProfiles()
             }
-        );
+        ));
     }
 
-    public string Remove(LoginRequestData info)
+    public ValueTask<string> Remove(LoginRequestData info)
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2RemoveResponse
             {
                 Response = _launcherV2Controller.Remove(info),
                 Profiles = _profileController.GetMiniProfiles()
             }
-        );
+        ));
     }
 
-    public string CompatibleVersion()
+    public ValueTask<string> CompatibleVersion()
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2VersionResponse
             {
                 Response = new LauncherV2CompatibleVersion
@@ -87,36 +87,36 @@ public class LauncherV2Callbacks(
                     EftVersion = _launcherV2Controller.EftVersion()
                 }
             }
-        );
+        ));
     }
 
-    public string Mods()
+    public ValueTask<string> Mods()
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2ModsResponse
             {
                 Response = _launcherV2Controller.LoadedMods()
             }
-        );
+        ));
     }
 
-    public string Profiles()
+    public ValueTask<string> Profiles()
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2ProfilesResponse
             {
                 Response = _profileController.GetMiniProfiles()
             }
-        );
+        ));
     }
 
-    public object Profile(string? sessionId)
+    public ValueTask<string> Profile(string? sessionId)
     {
-        return _httpResponseUtil.NoBody(
+        return new ValueTask<string>(_httpResponseUtil.NoBody(
             new LauncherV2ProfileResponse
             {
                 Response = _launcherV2Controller.GetProfile(sessionId)
             }
-        );
+        ));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/LocationCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/LocationCallbacks.cs
@@ -16,17 +16,17 @@ public class LocationCallbacks(
     ///     Handle client/locations
     /// </summary>
     /// <returns></returns>
-    public string GetLocationData(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetLocationData(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_locationController.GenerateAll(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_locationController.GenerateAll(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/airdrop/loot
     /// </summary>
     /// <returns></returns>
-    public string GetAirdropLoot(string url, GetAirdropLootRequest info, string sessionID)
+    public ValueTask<string> GetAirdropLoot(string url, GetAirdropLootRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_locationController.GetAirDropLoot(info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_locationController.GetAirDropLoot(info)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/MatchCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/MatchCallbacks.cs
@@ -22,9 +22,9 @@ public class MatchCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string UpdatePing(string url, UpdatePingRequestData info, string sessionID)
+    public ValueTask<string> UpdatePing(string url, UpdatePingRequestData info, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
@@ -34,73 +34,73 @@ public class MatchCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string ExitMatch(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> ExitMatch(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/match/group/exit_from_menu
     /// </summary>
     /// <returns></returns>
-    public string ExitFromMenu(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> ExitFromMenu(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/match/group/current
     /// </summary>
     /// <returns></returns>
-    public string GroupCurrent(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GroupCurrent(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(
+        return new ValueTask<string>(_httpResponseUtil.GetBody(
             new MatchGroupCurrentResponse
             {
                 Squad = []
             }
-        );
+        ));
     }
 
     /// <summary>
     ///     Handle client/match/group/looking/start
     /// </summary>
     /// <returns></returns>
-    public string StartGroupSearch(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> StartGroupSearch(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/match/group/looking/stop
     /// </summary>
     /// <returns></returns>
-    public string StopGroupSearch(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> StopGroupSearch(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/match/group/invite/send
     /// </summary>
     /// <returns></returns>
-    public string SendGroupInvite(string url, MatchGroupInviteSendRequest info, string sessionID)
+    public ValueTask<string> SendGroupInvite(string url, MatchGroupInviteSendRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody("2427943f23698ay9f2863735");
+        return new ValueTask<string>(_httpResponseUtil.GetBody("2427943f23698ay9f2863735"));
     }
 
     /// <summary>
     ///     Handle client/match/group/invite/accept
     /// </summary>
     /// <returns></returns>
-    public string AcceptGroupInvite(string url, RequestIdRequest info, string sessionID)
+    public ValueTask<string> AcceptGroupInvite(string url, RequestIdRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(
+        return new ValueTask<string>(_httpResponseUtil.GetBody(
             new List<GroupCharacter>
             {
                 new()
             }
-        );
+        ));
     }
 
     /// <summary>
@@ -110,9 +110,9 @@ public class MatchCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string DeclineGroupInvite(string url, RequestIdRequest info, string sessionID)
+    public ValueTask<string> DeclineGroupInvite(string url, RequestIdRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
@@ -122,9 +122,9 @@ public class MatchCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string CancelGroupInvite(string url, RequestIdRequest info, string sessionID)
+    public ValueTask<string> CancelGroupInvite(string url, RequestIdRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
@@ -134,63 +134,63 @@ public class MatchCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string TransferGroup(string url, MatchGroupTransferRequest info, string sessionID)
+    public ValueTask<string> TransferGroup(string url, MatchGroupTransferRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/match/group/invite/cancel-all
     /// </summary>
     /// <returns></returns>
-    public string CancelAllGroupInvite(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> CancelAllGroupInvite(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/putMetrics
     /// </summary>
     /// <returns></returns>
-    public string PutMetrics(string url, PutMetricsRequestData info, string sessionID)
+    public ValueTask<string> PutMetrics(string url, PutMetricsRequestData info, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/analytics/event-disconnect
     /// </summary>
     /// <returns></returns>
-    public string EventDisconnect(string url, PutMetricsRequestData info, string sessionID)
+    public ValueTask<string> EventDisconnect(string url, PutMetricsRequestData info, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/match/available
     /// </summary>
     /// <returns></returns>
-    public string ServerAvailable(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> ServerAvailable(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_matchController.GetEnabled());
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_matchController.GetEnabled()));
     }
 
     /// <summary>
     ///     Handle match/group/start_game
     /// </summary>
     /// <returns></returns>
-    public string JoinMatch(string url, MatchGroupStartGameRequest info, string sessionID)
+    public ValueTask<string> JoinMatch(string url, MatchGroupStartGameRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_matchController.JoinMatch(info, sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_matchController.JoinMatch(info, sessionID)));
     }
 
     /// <summary>
     ///     Handle client/getMetricsConfig
     /// </summary>
     /// <returns></returns>
-    public string GetMetrics(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetMetrics(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_databaseService.GetMatch().Metrics);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_databaseService.GetMatch().Metrics));
     }
 
     /// <summary>
@@ -198,66 +198,66 @@ public class MatchCallbacks(
     ///     Handle client/match/group/status
     /// </summary>
     /// <returns></returns>
-    public string GetGroupStatus(string url, MatchGroupStatusRequest info, string sessionID)
+    public ValueTask<string> GetGroupStatus(string url, MatchGroupStatusRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_matchController.GetGroupStatus(info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_matchController.GetGroupStatus(info)));
     }
 
     /// <summary>
     ///     Handle client/match/group/delete
     /// </summary>
     /// <returns></returns>
-    public string DeleteGroup(string url, DeleteGroupRequest info, string sessionID)
+    public ValueTask<string> DeleteGroup(string url, DeleteGroupRequest info, string sessionID)
     {
         _matchController.DeleteGroup(info);
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/match/group/leave
     /// </summary>
     /// <returns></returns>
-    public string LeaveGroup(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> LeaveGroup(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/match/group/player/remove
     /// </summary>
     /// <returns></returns>
-    public string RemovePlayerFromGroup(string url, MatchGroupPlayerRemoveRequest info, string sessionID)
+    public ValueTask<string> RemovePlayerFromGroup(string url, MatchGroupPlayerRemoveRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
     ///     Handle client/match/local/start
     /// </summary>
     /// <returns></returns>
-    public string StartLocalRaid(string url, StartLocalRaidRequestData info, string sessionID)
+    public ValueTask<string> StartLocalRaid(string url, StartLocalRaidRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_matchController.StartLocalRaid(sessionID, info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_matchController.StartLocalRaid(sessionID, info)));
     }
 
     /// <summary>
     ///     Handle client/match/local/end
     /// </summary>
     /// <returns></returns>
-    public string EndLocalRaid(string url, EndLocalRaidRequestData info, string sessionID)
+    public ValueTask<string> EndLocalRaid(string url, EndLocalRaidRequestData info, string sessionID)
     {
         _matchController.EndLocalRaid(sessionID, info);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/raid/configuration
     /// </summary>
     /// <returns></returns>
-    public string GetRaidConfiguration(string url, GetRaidConfigurationRequestData info, string sessionID)
+    public ValueTask<string> GetRaidConfiguration(string url, GetRaidConfigurationRequestData info, string sessionID)
     {
         _matchController.ConfigureOfflineRaid(info, sessionID);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
@@ -267,18 +267,18 @@ public class MatchCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetConfigurationByProfile(string url, GetRaidConfigurationRequestData info, string sessionID)
+    public ValueTask<string> GetConfigurationByProfile(string url, GetRaidConfigurationRequestData info, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
     ///     Handle client/match/group/raid/ready
     /// </summary>
     /// <returns></returns>
-    public string RaidReady(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> RaidReady(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 
     /// <summary>
@@ -288,8 +288,8 @@ public class MatchCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string NotRaidReady(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> NotRaidReady(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(true);
+        return new ValueTask<string>(_httpResponseUtil.GetBody(true));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/NotifierCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/NotifierCallbacks.cs
@@ -44,39 +44,39 @@ public class NotifierCallbacks(
     ///     Handle push/notifier/getwebsocket
     /// </summary>
     /// <returns></returns>
-    public string GetNotifier(string url, IRequestData info, string sessionID)
+    public ValueTask<string> GetNotifier(string url, IRequestData info, string sessionID)
     {
-        return _httpResponseUtil.EmptyArrayResponse();
+        return new ValueTask<string>(_httpResponseUtil.EmptyArrayResponse());
     }
 
     /// <summary>
     ///     Handle client/notifier/channel/create
     /// </summary>
     /// <returns></returns>
-    public string CreateNotifierChannel(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> CreateNotifierChannel(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_notifierController.GetChannel(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_notifierController.GetChannel(sessionID)));
     }
 
     /// <summary>
     ///     Handle client/game/profile/select
     /// </summary>
     /// <returns></returns>
-    public string SelectProfile(string url, UIDRequestData info, string sessionID)
+    public ValueTask<string> SelectProfile(string url, UIDRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(
+        return new ValueTask<string>(_httpResponseUtil.GetBody(
             new SelectProfileResponse
             {
                 Status = "ok"
             }
-        );
+        ));
     }
 
     /// <summary>
     /// </summary>
     /// <returns></returns>
-    public string Notify(string url, object info, string sessionID)
+    public ValueTask<string> Notify(string url, object info, string sessionID)
     {
-        return "NOTIFY";
+        return new ValueTask<string>("NOTIFY");
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/PrestigeCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/PrestigeCallbacks.cs
@@ -19,9 +19,9 @@ public class PrestigeCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetPrestige(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetPrestige(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_prestigeController.GetPrestige(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_prestigeController.GetPrestige(sessionID)));
     }
 
     /// <summary>
@@ -31,10 +31,10 @@ public class PrestigeCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string ObtainPrestige(string url, ObtainPrestigeRequestList info, string sessionID)
+    public ValueTask<string> ObtainPrestige(string url, ObtainPrestigeRequestList info, string sessionID)
     {
         _prestigeController.ObtainPrestige(sessionID, info);
 
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/ProfileCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/ProfileCallbacks.cs
@@ -22,15 +22,15 @@ public class ProfileCallbacks(
     ///     Handle client/game/profile/create
     /// </summary>
     /// <returns></returns>
-    public string CreateProfile(string url, ProfileCreateRequestData info, string sessionID)
+    public ValueTask<string> CreateProfile(string url, ProfileCreateRequestData info, string sessionID)
     {
         var id = _profileController.CreateProfile(info, sessionID);
-        return _httpResponse.GetBody(
+        return new ValueTask<string>(_httpResponse.GetBody(
             new CreateProfileResponse
             {
                 UserId = id
             }
-        );
+        ));
     }
 
     /// <summary>
@@ -38,9 +38,9 @@ public class ProfileCallbacks(
     ///     Get the complete player profile (scav + pmc character)
     /// </summary>
     /// <returns></returns>
-    public string GetProfileData(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetProfileData(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponse.GetBody(_profileController.GetCompleteProfile(sessionID));
+        return new ValueTask<string>(_httpResponse.GetBody(_profileController.GetCompleteProfile(sessionID)));
     }
 
     /// <summary>
@@ -49,24 +49,24 @@ public class ProfileCallbacks(
     ///     Occurs post-raid and when profile first created immediately after character details are confirmed by player
     /// </summary>
     /// <returns></returns>
-    public string RegenerateScav(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> RegenerateScav(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponse.GetBody(
+        return new ValueTask<string>(_httpResponse.GetBody(
             new List<PmcData>
             {
                 _profileController.GeneratePlayerScav(sessionID)
             }
-        );
+        ));
     }
 
     /// <summary>
     ///     Handle client/game/profile/voice/change event
     /// </summary>
     /// <returns></returns>
-    public string ChangeVoice(string url, ProfileChangeVoiceRequestData info, string sessionID)
+    public ValueTask<string> ChangeVoice(string url, ProfileChangeVoiceRequestData info, string sessionID)
     {
         _profileController.ChangeVoice(info, sessionID);
-        return _httpResponse.NullResponse();
+        return new ValueTask<string>(_httpResponse.NullResponse());
     }
 
     /// <summary>
@@ -74,21 +74,21 @@ public class ProfileCallbacks(
     ///     Client allows player to adjust their profile name
     /// </summary>
     /// <returns>Client response as string</returns>
-    public string ChangeNickname(string url, ProfileChangeNicknameRequestData info, string sessionId)
+    public ValueTask<string> ChangeNickname(string url, ProfileChangeNicknameRequestData info, string sessionId)
     {
         var output = _profileController.ChangeNickname(info, sessionId);
 
         return output switch
         {
-            NicknameValidationResult.Taken => _httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotUnique, $"{BackendErrorCodes.NicknameNotUnique} - "),
-            NicknameValidationResult.Short => _httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotValid, $"{BackendErrorCodes.NicknameNotValid} - "),
-            _ => _httpResponse.GetBody<object>(
+            NicknameValidationResult.Taken => new ValueTask<string>(_httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotUnique, $"{BackendErrorCodes.NicknameNotUnique} - ")),
+            NicknameValidationResult.Short => new ValueTask<string>(_httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotValid, $"{BackendErrorCodes.NicknameNotValid} - ")),
+            _ => new ValueTask<string>(_httpResponse.GetBody<object>(
                 new
                 {
                     status = 0,
                     NicknameChangeDate = _timeUtil.GetTimeStamp()
                 }
-            )
+            ))
         };
     }
 
@@ -96,18 +96,18 @@ public class ProfileCallbacks(
     ///     Handle client/game/profile/nickname/validate
     /// </summary>
     /// <returns>Client response as string</returns>
-    public string ValidateNickname(string url, ValidateNicknameRequestData info, string sessionId)
+    public ValueTask<string> ValidateNickname(string url, ValidateNicknameRequestData info, string sessionId)
     {
         return _profileController.ValidateNickname(info, sessionId) switch
         {
-            NicknameValidationResult.Taken => _httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotUnique, $"{BackendErrorCodes.NicknameNotUnique} - "),
-            NicknameValidationResult.Short => _httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotValid, $"{BackendErrorCodes.NicknameNotValid} - "),
-            _ => _httpResponse.GetBody(
+            NicknameValidationResult.Taken => new ValueTask<string>(_httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotUnique, $"{BackendErrorCodes.NicknameNotUnique} - ")),
+            NicknameValidationResult.Short => new ValueTask<string>(_httpResponse.GetBody<object?>(null, BackendErrorCodes.NicknameNotValid, $"{BackendErrorCodes.NicknameNotValid} - ")),
+            _ => new ValueTask<string>(_httpResponse.GetBody(
                 new
                 {
                     status = "ok"
                 }
-            )
+            ))
         };
     }
 
@@ -115,16 +115,16 @@ public class ProfileCallbacks(
     ///     Handle client/game/profile/nickname/reserved
     /// </summary>
     /// <returns></returns>
-    public string GetReservedNickname(string url, EmptyRequestData _, string sessionId)
+    public ValueTask<string> GetReservedNickname(string url, EmptyRequestData _, string sessionId)
     {
         var fullProfile = _profileHelper.GetFullProfile(sessionId);
         if (fullProfile?.ProfileInfo?.Username is not null)
         {
             // Send players name back to them
-            return _httpResponse.GetBody(fullProfile?.ProfileInfo?.Username);
+            return new ValueTask<string>(_httpResponse.GetBody(fullProfile?.ProfileInfo?.Username));
         }
 
-        return _httpResponse.GetBody("SPTarkov");
+        return new ValueTask<string>(_httpResponse.GetBody("SPTarkov"));
     }
 
     /// <summary>
@@ -132,9 +132,9 @@ public class ProfileCallbacks(
     ///     Called when creating a character when choosing a character face/voice
     /// </summary>
     /// <returns></returns>
-    public string GetProfileStatus(string url, EmptyRequestData _, string sessionId)
+    public ValueTask<string> GetProfileStatus(string url, EmptyRequestData _, string sessionId)
     {
-        return _httpResponse.GetBody(_profileController.GetProfileStatus(sessionId));
+        return new ValueTask<string>(_httpResponse.GetBody(_profileController.GetProfileStatus(sessionId)));
     }
 
     /// <summary>
@@ -142,44 +142,44 @@ public class ProfileCallbacks(
     ///     Called when viewing another players profile
     /// </summary>
     /// <returns></returns>
-    public string GetOtherProfile(string url, GetOtherProfileRequest request, string sessionID)
+    public ValueTask<string> GetOtherProfile(string url, GetOtherProfileRequest request, string sessionID)
     {
-        return _httpResponse.GetBody(_profileController.GetOtherProfile(sessionID, request));
+        return new ValueTask<string>(_httpResponse.GetBody(_profileController.GetOtherProfile(sessionID, request)));
     }
 
     /// <summary>
     ///     Handle client/profile/settings
     /// </summary>
     /// <returns></returns>
-    public string GetProfileSettings(string url, GetProfileSettingsRequest info, string sessionID)
+    public ValueTask<string> GetProfileSettings(string url, GetProfileSettingsRequest info, string sessionID)
     {
-        return _httpResponse.GetBody(_profileController.SetChosenProfileIcon(sessionID, info));
+        return new ValueTask<string>(_httpResponse.GetBody(_profileController.SetChosenProfileIcon(sessionID, info)));
     }
 
     /// <summary>
     ///     Handle client/game/profile/search
     /// </summary>
     /// <returns></returns>
-    public string SearchProfiles(string url, SearchProfilesRequestData info, string sessionID)
+    public ValueTask<string> SearchProfiles(string url, SearchProfilesRequestData info, string sessionID)
     {
-        return _httpResponse.GetBody(_profileController.SearchProfiles(info, sessionID));
+        return new ValueTask<string>(_httpResponse.GetBody(_profileController.SearchProfiles(info, sessionID)));
     }
 
     /// <summary>
     ///     Handle launcher/profile/info
     /// </summary>
     /// <returns></returns>
-    public string GetMiniProfile(string url, GetMiniProfileRequestData info, string sessionID)
+    public ValueTask<string> GetMiniProfile(string url, GetMiniProfileRequestData info, string sessionID)
     {
-        return _httpResponse.NoBody(_profileController.GetMiniProfile(sessionID));
+        return new ValueTask<string>(_httpResponse.NoBody(_profileController.GetMiniProfile(sessionID)));
     }
 
     /// <summary>
     ///     Handle /launcher/profiles
     /// </summary>
     /// <returns></returns>
-    public string GetAllMiniProfiles(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetAllMiniProfiles(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponse.NoBody(_profileController.GetMiniProfiles());
+        return new ValueTask<string>(_httpResponse.NoBody(_profileController.GetMiniProfiles()));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/QuestCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/QuestCallbacks.cs
@@ -74,9 +74,9 @@ public class QuestCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string ListQuests(string url, ListQuestsRequestData info, string sessionID)
+    public ValueTask<string> ListQuests(string url, ListQuestsRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_questController.GetClientQuests(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_questController.GetClientQuests(sessionID)));
     }
 
     /// <summary>
@@ -86,8 +86,8 @@ public class QuestCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string ActivityPeriods(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> ActivityPeriods(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_repeatableQuestController.GetClientRepeatableQuests(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_repeatableQuestController.GetClientRepeatableQuests(sessionID)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/RagfairCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/RagfairCallbacks.cs
@@ -57,9 +57,9 @@ public class RagfairCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string Search(string url, SearchRequestData info, string sessionID)
+    public ValueTask<string> Search(string url, SearchRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_ragfairController.GetOffers(sessionID, info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_ragfairController.GetOffers(sessionID, info)));
     }
 
     /// <summary>
@@ -69,9 +69,9 @@ public class RagfairCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetMarketPrice(string url, GetMarketPriceRequestData info, string sessionID)
+    public ValueTask<string> GetMarketPrice(string url, GetMarketPriceRequestData info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_ragfairController.GetItemMinAvgMaxFleaPriceValues(info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_ragfairController.GetItemMinAvgMaxFleaPriceValues(info)));
     }
 
     /// <summary>
@@ -118,9 +118,9 @@ public class RagfairCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetFleaPrices(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetFleaPrices(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_ragfairController.GetAllFleaPrices());
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_ragfairController.GetAllFleaPrices()));
     }
 
     /// <summary>
@@ -130,15 +130,15 @@ public class RagfairCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string SendReport(string url, SendRagfairReportRequestData info, string sessionID)
+    public ValueTask<string> SendReport(string url, SendRagfairReportRequestData info, string sessionID)
     {
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
-    public string StorePlayerOfferTaxAmount(string url, StorePlayerOfferTaxAmountRequestData info, string sessionID)
+    public ValueTask<string> StorePlayerOfferTaxAmount(string url, StorePlayerOfferTaxAmountRequestData info, string sessionID)
     {
         _ragfairTaxService.StoreClientOfferTaxValue(sessionID, info);
-        return _httpResponseUtil.NullResponse();
+        return new ValueTask<string>(_httpResponseUtil.NullResponse());
     }
 
     /// <summary>
@@ -148,8 +148,8 @@ public class RagfairCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetFleaOfferById(string url, GetRagfairOfferByIdRequest info, string sessionID)
+    public ValueTask<string> GetFleaOfferById(string url, GetRagfairOfferByIdRequest info, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_ragfairController.GetOfferByInternalId(sessionID, info));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_ragfairController.GetOfferByInternalId(sessionID, info)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/TraderCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/TraderCallbacks.cs
@@ -35,9 +35,9 @@ public class TraderCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetTraderSettings(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTraderSettings(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_traderController.GetAllTraders(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_traderController.GetAllTraders(sessionID)));
     }
 
     /// <summary>
@@ -47,10 +47,10 @@ public class TraderCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetTrader(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetTrader(string url, EmptyRequestData _, string sessionID)
     {
         var traderID = url.Replace("/client/trading/api/getTrader/", "");
-        return _httpResponseUtil.GetBody(_traderController.GetTrader(sessionID, traderID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_traderController.GetTrader(sessionID, traderID)));
     }
 
     /// <summary>
@@ -60,10 +60,10 @@ public class TraderCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetAssort(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetAssort(string url, EmptyRequestData _, string sessionID)
     {
         var traderID = url.Replace("/client/trading/api/getTraderAssort/", "");
-        return _httpResponseUtil.GetBody(_traderController.GetAssort(sessionID, traderID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_traderController.GetAssort(sessionID, traderID)));
     }
 
     /// <summary>
@@ -73,8 +73,8 @@ public class TraderCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetModdedTraderData(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetModdedTraderData(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.NoBody(_traderConfig.ModdedTraders);
+        return new ValueTask<string>(_httpResponseUtil.NoBody(_traderConfig.ModdedTraders));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/WeatherCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/WeatherCallbacks.cs
@@ -18,9 +18,9 @@ public class WeatherCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetWeather(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetWeather(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_weatherController.Generate());
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_weatherController.Generate()));
     }
 
     /// <summary>
@@ -30,8 +30,8 @@ public class WeatherCallbacks(
     /// <param name="info"></param>
     /// <param name="sessionID">Session/player id</param>
     /// <returns></returns>
-    public string GetLocalWeather(string url, EmptyRequestData _, string sessionID)
+    public ValueTask<string> GetLocalWeather(string url, EmptyRequestData _, string sessionID)
     {
-        return _httpResponseUtil.GetBody(_weatherController.GenerateLocal(sessionID));
+        return new ValueTask<string>(_httpResponseUtil.GetBody(_weatherController.GenerateLocal(sessionID)));
     }
 }

--- a/Libraries/SPTarkov.Server.Core/DI/Router.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/Router.cs
@@ -54,7 +54,7 @@ public abstract class StaticRouter : Router
         _jsonUtil = jsonUtil;
     }
 
-    public object HandleStatic(string url, string? body, string sessionID, string output)
+    public async ValueTask<object> HandleStatic(string url, string? body, string sessionID, string output)
     {
         var action = _actions.Single(route => route.url == url);
         var type = action.bodyType;
@@ -64,7 +64,7 @@ public abstract class StaticRouter : Router
             info = (IRequestData?) _jsonUtil.Deserialize(body, type);
         }
 
-        return action.action(url, info, sessionID, output);
+        return await action.action(url, info, sessionID, output);
     }
 
     protected override List<HandledRoute> GetHandledRoutes()
@@ -84,7 +84,7 @@ public abstract class DynamicRouter : Router
         _jsonUtil = jsonUtil;
     }
 
-    public object HandleDynamic(string url, string? body, string sessionID, string output)
+    public async ValueTask<object> HandleDynamic(string url, string? body, string sessionID, string output)
     {
         var action = actions.First(r => url.Contains(r.url));
         var type = action.bodyType;
@@ -94,7 +94,7 @@ public abstract class DynamicRouter : Router
             info = (IRequestData?) _jsonUtil.Deserialize(body, type);
         }
 
-        return action.action(url, info, sessionID, output);
+        return await action.action(url, info, sessionID, output);
     }
 
     protected override List<HandledRoute> GetHandledRoutes()
@@ -123,7 +123,7 @@ public record HandledRoute(string route, bool dynamic);
 
 public record RouteAction(
     string url,
-    Func<string, IRequestData?, string?, string?, object> action,
+    Func<string, IRequestData?, string?, string?, ValueTask<object>> action,
     Type? bodyType = null
 );
 //public action: (url: string, info: any, sessionID: string, output: string) => Promise<any>,

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BotDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BotDynamicRouter.cs
@@ -17,48 +17,48 @@ public class BotDynamicRouter : DynamicRouter
         [
             new RouteAction(
                 "/singleplayer/settings/bot/limit/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => botCallbacks.GetBotLimit(url, info as EmptyRequestData, sessionID)
+                ) => await botCallbacks.GetBotLimit(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/singleplayer/settings/bot/difficulty/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => botCallbacks.GetBotDifficulty(url, info as EmptyRequestData, sessionID)
+                ) => await botCallbacks.GetBotDifficulty(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/singleplayer/settings/bot/difficulties",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => botCallbacks.GetAllBotDifficulties(url, info as EmptyRequestData, sessionID)
+                ) => await botCallbacks.GetAllBotDifficulties(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/singleplayer/settings/bot/maxCap",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => botCallbacks.GetBotCap(url, info as EmptyRequestData, sessionID)
+                ) => await botCallbacks.GetBotCap(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/singleplayer/settings/bot/getBotBehaviours/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => botCallbacks.GetBotBehaviours()
+                ) => await botCallbacks.GetBotBehaviours()
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BundleDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BundleDynamicRouter.cs
@@ -17,12 +17,12 @@ public class BundleDynamicRouter : DynamicRouter
         [
             new RouteAction(
                 "/files/bundle",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => bundleCallbacks.GetBundle(url, info as EmptyRequestData, sessionID)
+                ) => await bundleCallbacks.GetBundle(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/CustomizationDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/CustomizationDynamicRouter.cs
@@ -17,12 +17,12 @@ public class CustomizationDynamicRouter : DynamicRouter
         [
             new RouteAction(
                 "/client/trading/customization/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => customizationCallbacks.GetTraderSuits(url, info as EmptyRequestData, sessionID)
+                ) => await customizationCallbacks.GetTraderSuits(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/DataDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/DataDynamicRouter.cs
@@ -17,30 +17,30 @@ public class DataDynamicRouter : DynamicRouter
         [
             new RouteAction(
                 "/client/menu/locale/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetLocalesMenu(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetLocalesMenu(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/locale/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetLocalesGlobal(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetLocalesGlobal(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/items/prices/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetItemPrices(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetItemPrices(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/HttpDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/HttpDynamicRouter.cs
@@ -10,9 +10,9 @@ public class HttpDynamicRouter : DynamicRouter
     public HttpDynamicRouter(ImageRouter imageRouter, JsonUtil jsonUtil) : base(
         jsonUtil,
         [
-            new RouteAction(".jpg", (_, _, _, _) => imageRouter.GetImage()),
-            new RouteAction(".png", (_, _, _, _) => imageRouter.GetImage()),
-            new RouteAction(".ico", (_, _, _, _) => imageRouter.GetImage())
+            new RouteAction(".jpg", async (_, _, _, _) => await imageRouter.GetImage()),
+            new RouteAction(".png", async (_, _, _, _) => await imageRouter.GetImage()),
+            new RouteAction(".ico", async (_, _, _, _) => await imageRouter.GetImage())
         ]
     )
     {

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/InraidDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/InraidDynamicRouter.cs
@@ -17,12 +17,12 @@ public class InraidDynamicRouter : DynamicRouter
         [
             new RouteAction(
                 "/client/location/getLocalloot",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => inraidCallbacks.RegisterPlayer(url, info as RegisterPlayerRequestData, sessionID),
+                ) => await inraidCallbacks.RegisterPlayer(url, info as RegisterPlayerRequestData, sessionID),
                 typeof(RegisterPlayerRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/NotifierDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/NotifierDynamicRouter.cs
@@ -16,39 +16,39 @@ public class NotifierDynamicRouter : DynamicRouter
         [
             new RouteAction(
                 "/?last_id",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     _
-                ) => notifierCallbacks.Notify(url, info, sessionID)
+                ) => await notifierCallbacks.Notify(url, info, sessionID)
             ),
             new RouteAction(
                 "/notifierServer",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     _
-                ) => notifierCallbacks.Notify(url, info, sessionID)
+                ) => await notifierCallbacks.Notify(url, info, sessionID)
             ),
             new RouteAction(
                 "/push/notifier/get/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     _
-                ) => notifierCallbacks.GetNotifier(url, info, sessionID)
+                ) => await notifierCallbacks.GetNotifier(url, info, sessionID)
             ),
             new RouteAction(
                 "/push/notifier/get/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     _
-                ) => notifierCallbacks.GetNotifier(url, info, sessionID)
+                ) => await notifierCallbacks.GetNotifier(url, info, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/TraderDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/TraderDynamicRouter.cs
@@ -17,21 +17,21 @@ public class TraderDynamicRouter : DynamicRouter
         [
             new RouteAction(
                 "/client/trading/api/getTrader/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => traderCallbacks.GetTrader(url, info as EmptyRequestData, sessionID)
+                ) => await traderCallbacks.GetTrader(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/trading/api/getTraderAssort/",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => traderCallbacks.GetAssort(url, info as EmptyRequestData, sessionID)
+                ) => await traderCallbacks.GetAssort(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/EventOutputHolder.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/EventOutputHolder.cs
@@ -198,7 +198,7 @@ public class EventOutputHolder
         foreach (var production in productions)
         {
             if (production.Value is null)
-                // Could be cancelled production, skip item to save processing
+            // Could be cancelled production, skip item to save processing
             {
                 continue;
             }

--- a/Libraries/SPTarkov.Server.Core/Routers/HttpRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/HttpRouter.cs
@@ -34,31 +34,29 @@ public class HttpRouter
     }
     */
 
-    public string? GetResponse(HttpRequest req, string sessionID, string? body, out object deserializedObject)
+    public async ValueTask<string?> GetResponse(HttpRequest req, string sessionID, string? body)
     {
         var wrapper = new ResponseWrapper("");
 
-        var handled = HandleRoute(req, sessionID, wrapper, _staticRouters, false, body, out deserializedObject);
+        var handled = await HandleRoute(req, sessionID, wrapper, _staticRouters, false, body);
         if (!handled)
         {
-            HandleRoute(req, sessionID, wrapper, _dynamicRoutes, true, body, out deserializedObject);
+            await HandleRoute(req, sessionID, wrapper, _dynamicRoutes, true, body);
         }
 
         return wrapper.Output;
     }
 
-    protected bool HandleRoute(
+    protected async ValueTask<bool> HandleRoute(
         HttpRequest request,
         string sessionID,
         ResponseWrapper wrapper,
         IEnumerable<Router> routers,
         bool dynamic,
-        string? body,
-        out object deserializedObject
+        string? body
     )
     {
         var url = request.Path.Value;
-        deserializedObject = null;
 
         // remove retry from url
         if (url?.Contains("?retry=") ?? false)
@@ -73,11 +71,11 @@ public class HttpRouter
             {
                 if (dynamic)
                 {
-                    wrapper.Output = (route as DynamicRouter).HandleDynamic(url, body, sessionID, wrapper.Output) as string;
+                    wrapper.Output = await (route as DynamicRouter).HandleDynamic(url, body, sessionID, wrapper.Output) as string;
                 }
                 else
                 {
-                    wrapper.Output = (route as StaticRouter).HandleStatic(url, body, sessionID, wrapper.Output) as string;
+                    wrapper.Output = await (route as StaticRouter).HandleStatic(url, body, sessionID, wrapper.Output) as string;
                 }
 
                 matched = true;

--- a/Libraries/SPTarkov.Server.Core/Routers/ImageRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/ImageRouter.cs
@@ -47,8 +47,8 @@ public class ImageRouter
         _logger.Warning($"IMAGE: {url} not found");
     }
 
-    public string GetImage()
+    public ValueTask<string> GetImage()
     {
-        return "IMAGE";
+        return new ValueTask<string>("IMAGE");
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/AchievementStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/AchievementStaticRouter.cs
@@ -17,21 +17,21 @@ public class AchievementStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/achievement/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => achievementCallbacks.GetAchievements(url, info as EmptyRequestData, sessionID)
+                ) => await achievementCallbacks.GetAchievements(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/achievement/statistic",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => achievementCallbacks.Statistic(url, info as EmptyRequestData, sessionID)
+                ) => await achievementCallbacks.Statistic(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/BotStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/BotStaticRouter.cs
@@ -17,12 +17,12 @@ public class BotStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/game/bot/generate",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     outout
-                ) => botCallbacks.GenerateBots(url, info as GenerateBotsRequestData, sessionID),
+                ) => await botCallbacks.GenerateBots(url, info as GenerateBotsRequestData, sessionID),
                 typeof(GenerateBotsRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/BuildStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/BuildStaticRouter.cs
@@ -19,51 +19,51 @@ public class BuildStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/builds/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => buildsCallbacks.GetBuilds(url, info as EmptyRequestData, sessionID)
+                ) => await buildsCallbacks.GetBuilds(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/builds/magazine/save",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => buildsCallbacks.CreateMagazineTemplate(url, info as SetMagazineRequest, sessionID),
+                ) => await buildsCallbacks.CreateMagazineTemplate(url, info as SetMagazineRequest, sessionID),
                 typeof(SetMagazineRequest)
             ),
             new RouteAction(
                 "/client/builds/weapon/save",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => buildsCallbacks.SetWeapon(url, info as PresetBuildActionRequestData, sessionID),
+                ) => await buildsCallbacks.SetWeapon(url, info as PresetBuildActionRequestData, sessionID),
                 typeof(PresetBuildActionRequestData)
             ),
             new RouteAction(
                 "/client/builds/equipment/save",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => buildsCallbacks.SetEquipment(url, info as PresetBuildActionRequestData, sessionID),
+                ) => await buildsCallbacks.SetEquipment(url, info as PresetBuildActionRequestData, sessionID),
                 typeof(PresetBuildActionRequestData)
             ),
             new RouteAction(
                 "/client/builds/delete",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => buildsCallbacks.DeleteBuild(url, info as RemoveBuildRequestData, sessionID),
+                ) => await buildsCallbacks.DeleteBuild(url, info as RemoveBuildRequestData, sessionID),
                 typeof(RemoveBuildRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/BundleStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/BundleStaticRouter.cs
@@ -17,12 +17,12 @@ public class BundleStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/singleplayer/bundles",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => bundleCallbacks.GetBundles(url, info as EmptyRequestData, sessionID)
+                ) => await bundleCallbacks.GetBundles(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/ClientLogStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/ClientLogStaticRouter.cs
@@ -17,31 +17,31 @@ public class ClientLogStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/singleplayer/log",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => clientLogCallbacks.ClientLog(url, info as ClientLogRequest, sessionID),
+                ) => await clientLogCallbacks.ClientLog(url, info as ClientLogRequest, sessionID),
                 typeof(ClientLogRequest)
             ),
             new RouteAction(
                 "/singleplayer/release",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => clientLogCallbacks.ReleaseNotes()
+                ) => await clientLogCallbacks.ReleaseNotes()
             ),
             new RouteAction(
                 "/singleplayer/enableBSGlogging",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => clientLogCallbacks.BsgLogging()
+                ) => await clientLogCallbacks.BsgLogging()
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/CustomizationStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/CustomizationStaticRouter.cs
@@ -17,30 +17,30 @@ public class CustomizationStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/trading/customization/storage",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => customizationCallbacks.GetCustomisationUnlocks(url, info as EmptyRequestData, sessionID)
+                ) => await customizationCallbacks.GetCustomisationUnlocks(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/hideout/customization/offer/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => customizationCallbacks.GetHideoutCustomisation(url, info as EmptyRequestData, sessionID)
+                ) => await customizationCallbacks.GetHideoutCustomisation(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/customization/storage",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => customizationCallbacks.GetStorage(url, info as EmptyRequestData, sessionID)
+                ) => await customizationCallbacks.GetStorage(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/DataStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/DataStaticRouter.cs
@@ -17,102 +17,102 @@ public class DataStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/settings",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetSettings(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetSettings(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/globals",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetGlobals(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetGlobals(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/items",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetTemplateItems(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetTemplateItems(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/handbook/templates",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetTemplateHandbook(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetTemplateHandbook(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/customization",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetTemplateSuits(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetTemplateSuits(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/account/customization",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetTemplateCharacter(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetTemplateCharacter(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/hideout/production/recipes",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetHideoutProduction(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetHideoutProduction(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/hideout/settings",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetHideoutSettings(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetHideoutSettings(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/hideout/areas",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetHideoutAreas(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetHideoutAreas(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/languages",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetLocalesLanguages(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetLocalesLanguages(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/hideout/qte/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dataCallbacks.GetQteList(url, info as EmptyRequestData, sessionID)
+                ) => await dataCallbacks.GetQteList(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/DialogStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/DialogStaticRouter.cs
@@ -19,258 +19,258 @@ public class DialogStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/chatServer/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.GetChatServerList(url, info as GetChatServerListRequestData, sessionID),
+                ) => await dialogueCallbacks.GetChatServerList(url, info as GetChatServerListRequestData, sessionID),
                 typeof(GetChatServerListRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.GetMailDialogList(url, info as GetMailDialogListRequestData, sessionID),
+                ) => await dialogueCallbacks.GetMailDialogList(url, info as GetMailDialogListRequestData, sessionID),
                 typeof(GetMailDialogListRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/view",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.GetMailDialogView(url, info as GetMailDialogViewRequestData, sessionID),
+                ) => await dialogueCallbacks.GetMailDialogView(url, info as GetMailDialogViewRequestData, sessionID),
                 typeof(GetMailDialogViewRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/info",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.GetMailDialogInfo(url, info as GetMailDialogInfoRequestData, sessionID),
+                ) => await dialogueCallbacks.GetMailDialogInfo(url, info as GetMailDialogInfoRequestData, sessionID),
                 typeof(GetMailDialogInfoRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/remove",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.RemoveDialog(url, info as RemoveDialogRequestData, sessionID),
+                ) => await dialogueCallbacks.RemoveDialog(url, info as RemoveDialogRequestData, sessionID),
                 typeof(RemoveDialogRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/pin",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.PinDialog(url, info as PinDialogRequestData, sessionID),
+                ) => await dialogueCallbacks.PinDialog(url, info as PinDialogRequestData, sessionID),
                 typeof(PinDialogRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/unpin",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.UnpinDialog(url, info as PinDialogRequestData, sessionID),
+                ) => await dialogueCallbacks.UnpinDialog(url, info as PinDialogRequestData, sessionID),
                 typeof(PinDialogRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/read",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.SetRead(url, info as SetDialogReadRequestData, sessionID),
+                ) => await dialogueCallbacks.SetRead(url, info as SetDialogReadRequestData, sessionID),
                 typeof(SetDialogReadRequestData)
             ),
             new RouteAction(
                 "/client/mail/dialog/getAllAttachments",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.GetAllAttachments(url, info as GetAllAttachmentsRequestData, sessionID),
+                ) => await dialogueCallbacks.GetAllAttachments(url, info as GetAllAttachmentsRequestData, sessionID),
                 typeof(GetAllAttachmentsRequestData)
             ),
             new RouteAction(
                 "/client/mail/msg/send",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.SendMessage(url, info as SendMessageRequest, sessionID),
+                ) => await dialogueCallbacks.SendMessage(url, info as SendMessageRequest, sessionID),
                 typeof(SendMessageRequest)
             ),
             new RouteAction(
                 "client/mail/dialog/clear",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.ClearMail(url, info as ClearMailMessageRequest, sessionID),
+                ) => await dialogueCallbacks.ClearMail(url, info as ClearMailMessageRequest, sessionID),
                 typeof(ClearMailMessageRequest)
             ),
             new RouteAction(
                 "/client/mail/dialog/group/create",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.CreateGroupMail(url, info as CreateGroupMailRequest, sessionID),
+                ) => await dialogueCallbacks.CreateGroupMail(url, info as CreateGroupMailRequest, sessionID),
                 typeof(CreateGroupMailRequest)
             ),
             new RouteAction(
                 "/client/mail/dialog/group/owner/change",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.ChangeMailGroupOwner(url, info as ChangeGroupMailOwnerRequest, sessionID),
+                ) => await dialogueCallbacks.ChangeMailGroupOwner(url, info as ChangeGroupMailOwnerRequest, sessionID),
                 typeof(ChangeGroupMailOwnerRequest)
             ),
             new RouteAction(
                 "/client/mail/dialog/group/users/add",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.AddUserToMail(url, info as AddUserGroupMailRequest, sessionID),
+                ) => await dialogueCallbacks.AddUserToMail(url, info as AddUserGroupMailRequest, sessionID),
                 typeof(AddUserGroupMailRequest)
             ),
             new RouteAction(
                 "/client/mail/dialog/group/users/remove",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.RemoveUserFromMail(url, info as RemoveUserGroupMailRequest, sessionID),
+                ) => await dialogueCallbacks.RemoveUserFromMail(url, info as RemoveUserGroupMailRequest, sessionID),
                 typeof(RemoveUserGroupMailRequest)
             ),
             new RouteAction(
                 "/client/friend/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.GetFriendList(url, info as EmptyRequestData, sessionID)
+                ) => await dialogueCallbacks.GetFriendList(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/friend/request/list/outbox",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.ListOutbox(url, info as EmptyRequestData, sessionID)
+                ) => await dialogueCallbacks.ListOutbox(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/friend/request/list/inbox",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.ListInbox(url, info as EmptyRequestData, sessionID)
+                ) => await dialogueCallbacks.ListInbox(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/friend/request/send",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.SendFriendRequest(url, info as FriendRequestData, sessionID),
+                ) => await dialogueCallbacks.SendFriendRequest(url, info as FriendRequestData, sessionID),
                 typeof(FriendRequestData)
             ),
             new RouteAction(
                 "/client/friend/request/accept-all",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.AcceptAllFriendRequests(url, info as EmptyRequestData, sessionID)
+                ) => await dialogueCallbacks.AcceptAllFriendRequests(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/friend/request/accept",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.AcceptFriendRequest(url, info as AcceptFriendRequestData, sessionID),
+                ) => await dialogueCallbacks.AcceptFriendRequest(url, info as AcceptFriendRequestData, sessionID),
                 typeof(AcceptFriendRequestData)
             ),
             new RouteAction(
                 "/client/friend/request/decline",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.DeclineFriendRequest(url, info as DeclineFriendRequestData, sessionID),
+                ) => await dialogueCallbacks.DeclineFriendRequest(url, info as DeclineFriendRequestData, sessionID),
                 typeof(DeclineFriendRequestData)
             ),
             new RouteAction(
                 "/client/friend/request/cancel",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.CancelFriendRequest(url, info as CancelFriendRequestData, sessionID),
+                ) => await dialogueCallbacks.CancelFriendRequest(url, info as CancelFriendRequestData, sessionID),
                 typeof(CancelFriendRequestData)
             ),
             new RouteAction(
                 "/client/friend/delete",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.DeleteFriend(url, info as DeleteFriendRequest, sessionID),
+                ) => await dialogueCallbacks.DeleteFriend(url, info as DeleteFriendRequest, sessionID),
                 typeof(DeleteFriendRequest)
             ),
             new RouteAction(
                 "/client/friend/ignore/set",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.IgnoreFriend(url, info as UIDRequestData, sessionID),
+                ) => await dialogueCallbacks.IgnoreFriend(url, info as UIDRequestData, sessionID),
                 typeof(UIDRequestData)
             ),
             new RouteAction(
                 "/client/friend/ignore/remove",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => dialogueCallbacks.UnIgnoreFriend(url, info as UIDRequestData, sessionID),
+                ) => await dialogueCallbacks.UnIgnoreFriend(url, info as UIDRequestData, sessionID),
                 typeof(UIDRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/GameStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/GameStaticRouter.cs
@@ -19,155 +19,155 @@ public class GameStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/game/config",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetGameConfig(url, info as GameEmptyCrcRequestData, sessionID),
+                ) => await gameCallbacks.GetGameConfig(url, info as GameEmptyCrcRequestData, sessionID),
                 typeof(GameEmptyCrcRequestData)
             ),
             new RouteAction(
                 "/client/game/mode",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetGameMode(url, info as GameModeRequestData, sessionID),
+                ) => await gameCallbacks.GetGameMode(url, info as GameModeRequestData, sessionID),
                 typeof(GameModeRequestData)
             ),
             new RouteAction(
                 "/client/server/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetServer(url, info as EmptyRequestData, sessionID)
+                ) => await gameCallbacks.GetServer(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/current",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetCurrentGroup(url, info as EmptyRequestData, sessionID),
+                ) => await gameCallbacks.GetCurrentGroup(url, info as EmptyRequestData, sessionID),
                 typeof(GameModeRequestData)
             ),
             new RouteAction(
                 "/client/game/version/validate",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.VersionValidate(url, info as VersionValidateRequestData, sessionID),
+                ) => await gameCallbacks.VersionValidate(url, info as VersionValidateRequestData, sessionID),
                 typeof(VersionValidateRequestData)
             ),
             new RouteAction(
                 "/client/game/start",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GameStart(url, info as EmptyRequestData, sessionID)
+                ) => await gameCallbacks.GameStart(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/game/logout",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GameLogout(url, info as EmptyRequestData, sessionID)
+                ) => await gameCallbacks.GameLogout(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/checkVersion",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.ValidateGameVersion(url, info as EmptyRequestData, sessionID)
+                ) => await gameCallbacks.ValidateGameVersion(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/game/keepalive",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GameKeepalive(url, info as EmptyRequestData, sessionID)
+                ) => await gameCallbacks.GameKeepalive(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/singleplayer/settings/version",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetVersion(url, info as EmptyRequestData, sessionID)
+                ) => await gameCallbacks.GetVersion(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/reports/lobby/send",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.ReportNickname(url, info as UIDRequestData, sessionID),
+                ) => await gameCallbacks.ReportNickname(url, info as UIDRequestData, sessionID),
                 typeof(UIDRequestData)
             ),
             new RouteAction(
                 "/client/report/send",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.ReportNickname(url, info as UIDRequestData, sessionID),
+                ) => await gameCallbacks.ReportNickname(url, info as UIDRequestData, sessionID),
                 typeof(GameModeRequestData)
             ),
             new RouteAction(
                 "/singleplayer/settings/getRaidTime",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetRaidTime(url, info as GetRaidTimeRequest, sessionID),
+                ) => await gameCallbacks.GetRaidTime(url, info as GetRaidTimeRequest, sessionID),
                 typeof(GetRaidTimeRequest)
             ),
             new RouteAction(
                 "/client/survey",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetSurvey(url, info as EmptyRequestData, sessionID)
+                ) => await gameCallbacks.GetSurvey(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/survey/view",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.GetSurveyView(url, info as SendSurveyOpinionRequest, sessionID),
+                ) => await gameCallbacks.GetSurveyView(url, info as SendSurveyOpinionRequest, sessionID),
                 typeof(SendSurveyOpinionRequest)
             ),
             new RouteAction(
                 "/client/survey/opinion",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => gameCallbacks.SendSurveyOpinion(url, info as SendSurveyOpinionRequest, sessionID),
+                ) => await gameCallbacks.SendSurveyOpinion(url, info as SendSurveyOpinionRequest, sessionID),
                 typeof(SendSurveyOpinionRequest)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/HealthStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/HealthStaticRouter.cs
@@ -17,12 +17,12 @@ public class HealthStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/hideout/workout",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => healthCallbacks.HandleWorkoutEffects(url, info as WorkoutData, sessionID),
+                ) => await healthCallbacks.HandleWorkoutEffects(url, info as WorkoutData, sessionID),
                 typeof(WorkoutData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/InraidStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/InraidStaticRouter.cs
@@ -15,40 +15,40 @@ public class InraidStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/raid/profile/scavsave",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => inraidCallbacks.SaveProgress(url, info as ScavSaveRequestData, sessionID),
+                ) => await inraidCallbacks.SaveProgress(url, info as ScavSaveRequestData, sessionID),
                 typeof(ScavSaveRequestData)
             ),
             new RouteAction(
                 "/singleplayer/settings/raid/menu",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => inraidCallbacks.GetRaidMenuSettings()
+                ) => await inraidCallbacks.GetRaidMenuSettings()
             ),
             new RouteAction(
                 "/singleplayer/scav/traitorscavhostile",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => inraidCallbacks.GetTraitorScavHostileChance(url, info as EmptyRequestData, sessionID)
+                ) => await inraidCallbacks.GetTraitorScavHostileChance(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/singleplayer/bosstypes",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => inraidCallbacks.GetBossTypes(url, info as EmptyRequestData, sessionID)
+                ) => await inraidCallbacks.GetBossTypes(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/InsuranceStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/InsuranceStaticRouter.cs
@@ -17,12 +17,12 @@ public class InsuranceStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/insurance/items/list/cost",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => insuranceCallbacks.GetInsuranceCost(url, info as GetInsuranceCostRequestData, sessionID),
+                ) => await insuranceCallbacks.GetInsuranceCost(url, info as GetInsuranceCostRequestData, sessionID),
                 typeof(GetInsuranceCostRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/ItemEventStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/ItemEventStaticRouter.cs
@@ -17,12 +17,12 @@ public class ItemEventStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/game/profile/items/moving",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => itemEventCallbacks.HandleEvents(url, info as ItemEventRouterRequest, sessionID),
+                ) => await itemEventCallbacks.HandleEvents(url, info as ItemEventRouterRequest, sessionID),
                 typeof(ItemEventRouterRequest)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherStaticRouter.cs
@@ -15,65 +15,65 @@ public class LauncherStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/launcher/ping",
-                (url, _, sessionID, _) => launcherCallbacks.Ping(url, null, sessionID)
+                async (url, _, sessionID, _) => await launcherCallbacks.Ping(url, null, sessionID)
             ),
             new RouteAction(
                 "/launcher/server/connect",
-                (_, _, _, _) => launcherCallbacks.Connect()
+                async (_, _, _, _) => await launcherCallbacks.Connect()
             ),
             new RouteAction(
                 "/launcher/profile/login",
-                (url, info, sessionID, _) => launcherCallbacks.Login(url, info as LoginRequestData, sessionID),
+                async (url, info, sessionID, _) => await launcherCallbacks.Login(url, info as LoginRequestData, sessionID),
                 typeof(LoginRequestData)
             ),
             new RouteAction(
                 "/launcher/profile/register",
-                (url, info, sessionID, _) => launcherCallbacks.Register(url, info as RegisterData, sessionID),
+                async (url, info, sessionID, _) => await launcherCallbacks.Register(url, info as RegisterData, sessionID),
                 typeof(RegisterData)
             ),
             new RouteAction(
                 "/launcher/profile/get",
-                (url, info, sessionID, _) => launcherCallbacks.Get(url, info as LoginRequestData, sessionID),
+                async (url, info, sessionID, _) => await launcherCallbacks.Get(url, info as LoginRequestData, sessionID),
                 typeof(LoginRequestData)
             ),
             new RouteAction(
                 "/launcher/profile/change/username",
-                (url, info, sessionID, _) =>
-                    launcherCallbacks.ChangeUsername(url, info as ChangeRequestData, sessionID),
+                async (url, info, sessionID, _) =>
+                    await launcherCallbacks.ChangeUsername(url, info as ChangeRequestData, sessionID),
                 typeof(ChangeRequestData)
             ),
             new RouteAction(
                 "/launcher/profile/change/password",
-                (url, info, sessionID, _) =>
-                    launcherCallbacks.ChangePassword(url, info as ChangeRequestData, sessionID),
+                async (url, info, sessionID, _) =>
+                    await launcherCallbacks.ChangePassword(url, info as ChangeRequestData, sessionID),
                 typeof(ChangeRequestData)
             ),
             new RouteAction(
                 "/launcher/profile/change/wipe",
-                (url, info, sessionID, _) => launcherCallbacks.Wipe(url, info as RegisterData, sessionID),
+                async (url, info, sessionID, _) => await launcherCallbacks.Wipe(url, info as RegisterData, sessionID),
                 typeof(RegisterData)
             ),
             new RouteAction(
                 "/launcher/profile/remove",
-                (url, info, sessionID, _) => launcherCallbacks.RemoveProfile(url, info as RemoveProfileData, sessionID),
+                async (url, info, sessionID, _) => await launcherCallbacks.RemoveProfile(url, info as RemoveProfileData, sessionID),
                 typeof(RemoveProfileData)
             ),
             new RouteAction(
                 "/launcher/profile/compatibleTarkovVersion",
-                (_, _, _, _) => launcherCallbacks.GetCompatibleTarkovVersion()
+                async (_, _, _, _) => await launcherCallbacks.GetCompatibleTarkovVersion()
             ),
             new RouteAction(
                 "/launcher/server/version",
-                (_, _, _, _) => launcherCallbacks.GetServerVersion()
+                async (_, _, _, _) => await launcherCallbacks.GetServerVersion()
             ),
             new RouteAction(
                 "/launcher/server/loadedServerMods",
-                (_, _, _, _) => launcherCallbacks.GetLoadedServerMods()
+                async (_, _, _, _) => await launcherCallbacks.GetLoadedServerMods()
             ),
             new RouteAction(
                 "/launcher/server/serverModsUsedByProfile",
-                (url, info, sessionID, _) =>
-                    launcherCallbacks.GetServerModsProfileUsed(url, info as EmptyRequestData, sessionID),
+                async (url, info, sessionID, _) =>
+                    await launcherCallbacks.GetServerModsProfileUsed(url, info as EmptyRequestData, sessionID),
                 typeof(EmptyRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherV2StaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherV2StaticRouter.cs
@@ -14,47 +14,47 @@ public class LauncherV2StaticRouter : StaticRouter
         [
             new RouteAction(
                 "/launcher/v2/ping",
-                (url, _, sessionID, _) => launcherV2Callbacks.Ping()
+                async (url, _, sessionID, _) => await launcherV2Callbacks.Ping()
             ),
             new RouteAction(
                 "/launcher/v2/types",
-                (url, _, sessionID, _) => launcherV2Callbacks.Types()
+                async (url, _, sessionID, _) => await launcherV2Callbacks.Types()
             ),
             new RouteAction(
                 "/launcher/v2/login",
-                (url, info, sessionID, _) => launcherV2Callbacks.Login(info as LoginRequestData),
+                async (url, info, sessionID, _) => await launcherV2Callbacks.Login(info as LoginRequestData),
                 typeof(LoginRequestData)
             ),
             new RouteAction(
                 "/launcher/v2/register",
-                (url, info, sessionID, _) => launcherV2Callbacks.Register(info as RegisterData),
+                async (url, info, sessionID, _) => await launcherV2Callbacks.Register(info as RegisterData),
                 typeof(RegisterData)
             ),
             new RouteAction(
                 "/launcher/v2/passwordChange",
-                (url, info, sessionID, _) => launcherV2Callbacks.PasswordChange(info as ChangeRequestData),
+                async (url, info, sessionID, _) => await launcherV2Callbacks.PasswordChange(info as ChangeRequestData),
                 typeof(ChangeRequestData)
             ),
             new RouteAction(
                 "/launcher/v2/remove",
-                (url, info, sessionID, _) => launcherV2Callbacks.Remove(info as LoginRequestData),
+                async (url, info, sessionID, _) => await launcherV2Callbacks.Remove(info as LoginRequestData),
                 typeof(LoginRequestData)
             ),
             new RouteAction(
                 "/launcher/v2/version",
-                (url, _, sessionID, _) => launcherV2Callbacks.CompatibleVersion()
+                async (url, _, sessionID, _) => await launcherV2Callbacks.CompatibleVersion()
             ),
             new RouteAction(
                 "/launcher/v2/mods",
-                (url, _, sessionID, _) => launcherV2Callbacks.Mods()
+                async (url, _, sessionID, _) => await launcherV2Callbacks.Mods()
             ),
             new RouteAction(
                 "/launcher/v2/profiles",
-                (url, _, sessionID, _) => launcherV2Callbacks.Profiles()
+                async (url, _, sessionID, _) => await launcherV2Callbacks.Profiles()
             ),
             new RouteAction(
                 "/launcher/v2/profile",
-                (url, _, sessionID, _) => launcherV2Callbacks.Profile(sessionID)
+                async (url, _, sessionID, _) => await launcherV2Callbacks.Profile(sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/LocationStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/LocationStaticRouter.cs
@@ -18,21 +18,21 @@ public class LocationStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/locations",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => locationCallbacks.GetLocationData(url, info as EmptyRequestData, sessionID)
+                ) => await locationCallbacks.GetLocationData(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/airdrop/loot",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => locationCallbacks.GetAirdropLoot(url, info as GetAirdropLootRequest, sessionID),
+                ) => await locationCallbacks.GetAirdropLoot(url, info as GetAirdropLootRequest, sessionID),
                 typeof(GetAirdropLootRequest)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/MatchStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/MatchStaticRouter.cs
@@ -19,270 +19,270 @@ public class MatchStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/match/available",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.ServerAvailable(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.ServerAvailable(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/updatePing",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.UpdatePing(url, info as UpdatePingRequestData, sessionID),
+                ) => await matchCallbacks.UpdatePing(url, info as UpdatePingRequestData, sessionID),
                 typeof(UpdatePingRequestData)
             ),
             new RouteAction(
                 "/client/match/join",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.JoinMatch(url, info as MatchGroupStartGameRequest, sessionID),
+                ) => await matchCallbacks.JoinMatch(url, info as MatchGroupStartGameRequest, sessionID),
                 typeof(MatchGroupStartGameRequest)
             ),
             new RouteAction(
                 "/client/match/exit",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.ExitMatch(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.ExitMatch(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/delete",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.DeleteGroup(url, info as DeleteGroupRequest, sessionID)
+                ) => await matchCallbacks.DeleteGroup(url, info as DeleteGroupRequest, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/leave",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.LeaveGroup(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.LeaveGroup(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/status",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.GetGroupStatus(url, info as MatchGroupStatusRequest, sessionID),
+                ) => await matchCallbacks.GetGroupStatus(url, info as MatchGroupStatusRequest, sessionID),
                 typeof(MatchGroupStatusRequest)
             ),
             new RouteAction(
                 "/client/match/group/start_game",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.JoinMatch(url, info as MatchGroupStartGameRequest, sessionID),
+                ) => await matchCallbacks.JoinMatch(url, info as MatchGroupStartGameRequest, sessionID),
                 typeof(MatchGroupStartGameRequest)
             ),
             new RouteAction(
                 "/client/match/group/exit_from_menu",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.ExitFromMenu(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.ExitFromMenu(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/current",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.GroupCurrent(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.GroupCurrent(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/looking/start",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.StartGroupSearch(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.StartGroupSearch(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/looking/stop",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.StopGroupSearch(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.StopGroupSearch(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/invite/send",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.SendGroupInvite(url, info as MatchGroupInviteSendRequest, sessionID),
+                ) => await matchCallbacks.SendGroupInvite(url, info as MatchGroupInviteSendRequest, sessionID),
                 typeof(MatchGroupInviteSendRequest)
             ),
             new RouteAction(
                 "/client/match/group/invite/accept",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.AcceptGroupInvite(url, info as RequestIdRequest, sessionID),
+                ) => await matchCallbacks.AcceptGroupInvite(url, info as RequestIdRequest, sessionID),
                 typeof(RequestIdRequest)
             ),
             new RouteAction(
                 "/client/match/group/invite/decline",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.DeclineGroupInvite(url, info as RequestIdRequest, sessionID),
+                ) => await matchCallbacks.DeclineGroupInvite(url, info as RequestIdRequest, sessionID),
                 typeof(RequestIdRequest)
             ),
             new RouteAction(
                 "/client/match/group/invite/cancel",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.CancelGroupInvite(url, info as RequestIdRequest, sessionID),
+                ) => await matchCallbacks.CancelGroupInvite(url, info as RequestIdRequest, sessionID),
                 typeof(RequestIdRequest)
             ),
             new RouteAction(
                 "/client/match/group/invite/cancel-all",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.CancelAllGroupInvite(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.CancelAllGroupInvite(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/transfer",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.TransferGroup(url, info as MatchGroupTransferRequest, sessionID),
+                ) => await matchCallbacks.TransferGroup(url, info as MatchGroupTransferRequest, sessionID),
                 typeof(MatchGroupTransferRequest)
             ),
             new RouteAction(
                 "/client/match/group/raid/ready",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.RaidReady(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.RaidReady(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/match/group/raid/not-ready",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.NotRaidReady(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.NotRaidReady(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/putMetrics",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.PutMetrics(url, info as PutMetricsRequestData, sessionID),
+                ) => await matchCallbacks.PutMetrics(url, info as PutMetricsRequestData, sessionID),
                 typeof(PutMetricsRequestData)
             ),
             new RouteAction(
                 "/client/analytics/event-disconnect",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.EventDisconnect(url, info as PutMetricsRequestData, sessionID),
+                ) => await matchCallbacks.EventDisconnect(url, info as PutMetricsRequestData, sessionID),
                 typeof(PutMetricsRequestData)
             ),
             new RouteAction(
                 "/client/getMetricsConfig",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.GetMetrics(url, info as EmptyRequestData, sessionID)
+                ) => await matchCallbacks.GetMetrics(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/raid/configuration",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.GetRaidConfiguration(url, info as GetRaidConfigurationRequestData, sessionID),
+                ) => await matchCallbacks.GetRaidConfiguration(url, info as GetRaidConfigurationRequestData, sessionID),
                 typeof(GetRaidConfigurationRequestData)
             ),
             new RouteAction(
                 "/client/raid/configuration-by-profile",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.GetConfigurationByProfile(url, info as GetRaidConfigurationRequestData, sessionID),
+                ) => await matchCallbacks.GetConfigurationByProfile(url, info as GetRaidConfigurationRequestData, sessionID),
                 typeof(GetRaidConfigurationRequestData)
             ),
             new RouteAction(
                 "/client/match/group/player/remove",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.RemovePlayerFromGroup(url, info as MatchGroupPlayerRemoveRequest, sessionID),
+                ) => await matchCallbacks.RemovePlayerFromGroup(url, info as MatchGroupPlayerRemoveRequest, sessionID),
                 typeof(MatchGroupPlayerRemoveRequest)
             ),
             new RouteAction(
                 "/client/match/local/start",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.StartLocalRaid(url, info as StartLocalRaidRequestData, sessionID),
+                ) => await matchCallbacks.StartLocalRaid(url, info as StartLocalRaidRequestData, sessionID),
                 typeof(StartLocalRaidRequestData)
             ),
             new RouteAction(
                 "/client/match/local/end",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => matchCallbacks.EndLocalRaid(url, info as EndLocalRaidRequestData, sessionID),
+                ) => await matchCallbacks.EndLocalRaid(url, info as EndLocalRaidRequestData, sessionID),
                 typeof(EndLocalRaidRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/NotifierStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/NotifierStaticRouter.cs
@@ -18,21 +18,21 @@ public class NotifierStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/notifier/channel/create",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => notifierCallbacks.CreateNotifierChannel(url, info as EmptyRequestData, sessionID)
+                ) => await notifierCallbacks.CreateNotifierChannel(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/game/profile/select",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => notifierCallbacks.SelectProfile(url, info as UIDRequestData, sessionID),
+                ) => await notifierCallbacks.SelectProfile(url, info as UIDRequestData, sessionID),
                 typeof(UIDRequestData)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/PrestigeStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/PrestigeStaticRouter.cs
@@ -18,21 +18,21 @@ public class PrestigeStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/prestige/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => prestigeCallbacks.GetPrestige(url, info as EmptyRequestData, sessionID)
+                ) => await prestigeCallbacks.GetPrestige(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/prestige/obtain",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => prestigeCallbacks.ObtainPrestige(url, info as ObtainPrestigeRequestList, sessionID),
+                ) => await prestigeCallbacks.ObtainPrestige(url, info as ObtainPrestigeRequestList, sessionID),
                 typeof(ObtainPrestigeRequestList)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/ProfileStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/ProfileStaticRouter.cs
@@ -16,116 +16,116 @@ public class ProfileStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/game/profile/create",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.CreateProfile(url, info as ProfileCreateRequestData, sessionID),
+                ) => await profileCallbacks.CreateProfile(url, info as ProfileCreateRequestData, sessionID),
                 typeof(ProfileCreateRequestData)
             ),
             new RouteAction(
                 "/client/game/profile/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.GetProfileData(url, info as EmptyRequestData, sessionID)
+                ) => await profileCallbacks.GetProfileData(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/game/profile/savage/regenerate",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.RegenerateScav(url, info as EmptyRequestData, sessionID)
+                ) => await profileCallbacks.RegenerateScav(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/game/profile/voice/change",
-                (url, info, sessionID, output) =>
-                    profileCallbacks.ChangeVoice(url, info as ProfileChangeVoiceRequestData, sessionID),
+                async (url, info, sessionID, output) =>
+                    await profileCallbacks.ChangeVoice(url, info as ProfileChangeVoiceRequestData, sessionID),
                 typeof(ProfileChangeVoiceRequestData)
             ),
             new RouteAction(
                 "/client/game/profile/nickname/change",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.ChangeNickname(url, info as ProfileChangeNicknameRequestData, sessionID),
+                ) => await profileCallbacks.ChangeNickname(url, info as ProfileChangeNicknameRequestData, sessionID),
                 typeof(ProfileChangeNicknameRequestData)
             ),
             new RouteAction(
                 "/client/game/profile/nickname/validate",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.ValidateNickname(url, info as ValidateNicknameRequestData, sessionID),
+                ) => await profileCallbacks.ValidateNickname(url, info as ValidateNicknameRequestData, sessionID),
                 typeof(ValidateNicknameRequestData)
             ),
             new RouteAction(
                 "/client/game/profile/nickname/reserved",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.GetReservedNickname(url, info as EmptyRequestData, sessionID)
+                ) => await profileCallbacks.GetReservedNickname(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/profile/status",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.GetProfileStatus(url, info as EmptyRequestData, sessionID)
+                ) => await profileCallbacks.GetProfileStatus(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/profile/view",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.GetOtherProfile(url, info as GetOtherProfileRequest, sessionID),
+                ) => await profileCallbacks.GetOtherProfile(url, info as GetOtherProfileRequest, sessionID),
                 typeof(GetOtherProfileRequest)
             ),
             new RouteAction(
                 "/client/profile/settings",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.GetProfileSettings(url, info as GetProfileSettingsRequest, sessionID),
+                ) => await profileCallbacks.GetProfileSettings(url, info as GetProfileSettingsRequest, sessionID),
                 typeof(GetProfileSettingsRequest)
             ),
             new RouteAction(
                 "/client/game/profile/search",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => profileCallbacks.SearchProfiles(url, info as SearchProfilesRequestData, sessionID),
+                ) => await profileCallbacks.SearchProfiles(url, info as SearchProfilesRequestData, sessionID),
                 typeof(SearchProfilesRequestData)
             ),
             new RouteAction(
                 "/launcher/profile/info",
-                (url, info, sessionID, output) =>
-                    profileCallbacks.GetMiniProfile(url, info as GetMiniProfileRequestData, sessionID),
+                async (url, info, sessionID, output) =>
+                    await profileCallbacks.GetMiniProfile(url, info as GetMiniProfileRequestData, sessionID),
                 typeof(GetMiniProfileRequestData)
             ),
             new RouteAction(
                 "/launcher/profiles",
-                (url, info, sessionID, output) =>
-                    profileCallbacks.GetAllMiniProfiles(url, info as EmptyRequestData, sessionID)
+                async (url, info, sessionID, output) =>
+                    await profileCallbacks.GetAllMiniProfiles(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/QuestStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/QuestStaticRouter.cs
@@ -18,22 +18,22 @@ public class QuestStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/quest/list",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => questCallbacks.ListQuests(url, info as ListQuestsRequestData, sessionID),
+                ) => await questCallbacks.ListQuests(url, info as ListQuestsRequestData, sessionID),
                 typeof(ListQuestsRequestData)
             ),
             new RouteAction(
                 "/client/repeatalbeQuests/activityPeriods",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => questCallbacks.ActivityPeriods(url, info as EmptyRequestData, sessionID)
+                ) => await questCallbacks.ActivityPeriods(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/RagfairStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/RagfairStaticRouter.cs
@@ -18,71 +18,71 @@ public class RagfairStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/ragfair/search",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => ragfairCallbacks.Search(url, info as SearchRequestData, sessionID),
+                ) => await ragfairCallbacks.Search(url, info as SearchRequestData, sessionID),
                 typeof(SearchRequestData)
             ),
             new RouteAction(
                 "/client/ragfair/find",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => ragfairCallbacks.Search(url, info as SearchRequestData, sessionID),
+                ) => await ragfairCallbacks.Search(url, info as SearchRequestData, sessionID),
                 typeof(SearchRequestData)
             ),
             new RouteAction(
                 "/client/ragfair/itemMarketPrice",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => ragfairCallbacks.GetMarketPrice(url, info as GetMarketPriceRequestData, sessionID),
+                ) => await ragfairCallbacks.GetMarketPrice(url, info as GetMarketPriceRequestData, sessionID),
                 typeof(GetMarketPriceRequestData)
             ),
             new RouteAction(
                 "/client/ragfair/offerfees",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => ragfairCallbacks.StorePlayerOfferTaxAmount(url, info as StorePlayerOfferTaxAmountRequestData, sessionID),
+                ) => await ragfairCallbacks.StorePlayerOfferTaxAmount(url, info as StorePlayerOfferTaxAmountRequestData, sessionID),
                 typeof(StorePlayerOfferTaxAmountRequestData)
             ),
             new RouteAction(
                 "/client/reports/ragfair/send",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => ragfairCallbacks.SendReport(url, info as SendRagfairReportRequestData, sessionID),
+                ) => await ragfairCallbacks.SendReport(url, info as SendRagfairReportRequestData, sessionID),
                 typeof(SendRagfairReportRequestData)
             ),
             new RouteAction(
                 "/client/items/prices",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => ragfairCallbacks.GetFleaPrices(url, info as EmptyRequestData, sessionID)
+                ) => await ragfairCallbacks.GetFleaPrices(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/ragfair/offer/findbyid",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => ragfairCallbacks.GetFleaOfferById(url, info as GetRagfairOfferByIdRequest, sessionID),
+                ) => await ragfairCallbacks.GetFleaOfferById(url, info as GetRagfairOfferByIdRequest, sessionID),
                 typeof(GetRagfairOfferByIdRequest)
             )
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/TraderStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/TraderStaticRouter.cs
@@ -17,21 +17,21 @@ public class TraderStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/trading/api/traderSettings",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => traderCallbacks.GetTraderSettings(url, info as EmptyRequestData, sessionID)
+                ) => await traderCallbacks.GetTraderSettings(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/singleplayer/moddedTraders",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => traderCallbacks.GetModdedTraderData(url, info as EmptyRequestData, sessionID)
+                ) => await traderCallbacks.GetModdedTraderData(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/WeatherStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/WeatherStaticRouter.cs
@@ -17,21 +17,21 @@ public class WeatherStaticRouter : StaticRouter
         [
             new RouteAction(
                 "/client/weather",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => weatherCallbacks.GetWeather(url, info as EmptyRequestData, sessionID)
+                ) => await weatherCallbacks.GetWeather(url, info as EmptyRequestData, sessionID)
             ),
             new RouteAction(
                 "/client/localGame/weather",
-                (
+                async (
                     url,
                     info,
                     sessionID,
                     output
-                ) => weatherCallbacks.GetLocalWeather(url, info as EmptyRequestData, sessionID)
+                ) => await weatherCallbacks.GetLocalWeather(url, info as EmptyRequestData, sessionID)
             )
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -43,7 +43,7 @@ public class SptHttpListener(
         {
             case "GET":
                 {
-                    var response = GetResponse(sessionId, req, null);
+                    var response = await GetResponse(sessionId, req, null);
                     await SendResponse(sessionId, req, resp, null, response);
                     break;
                 }
@@ -98,7 +98,7 @@ public class SptHttpListener(
                         }
                     }
 
-                    var response = GetResponse(sessionId, req, body);
+                    var response = await GetResponse(sessionId, req, body);
                     await SendResponse(sessionId, req, resp, body, response);
                     break;
                 }
@@ -154,7 +154,7 @@ public class SptHttpListener(
             await serialiser.Serialize(sessionID, req, resp, bodyInfo);
         }
         else
-            // No serializer can handle the request (majority of requests dont), zlib the output and send response back
+        // No serializer can handle the request (majority of requests dont), zlib the output and send response back
         {
             await SendZlibJson(resp, output, sessionID);
         }
@@ -186,22 +186,24 @@ public class SptHttpListener(
         }
     }
 
-    public string GetResponse(string sessionID, HttpRequest req, string? body)
+    public async ValueTask<string> GetResponse(string sessionID, HttpRequest req, string? body)
     {
-        var output = _router.GetResponse(req, sessionID, body, out var deserializedObject);
+        //Todo: deserializedObject was an out in GetResponse but it was never assigned to anything in GetResponse, is this still necessary?
+        //object deserializedObject = new();
+        var output = await _router.GetResponse(req, sessionID, body);
         /* route doesn't exist or response is not properly set up */
         if (string.IsNullOrEmpty(output))
         {
             _logger.Error(_localisationService.GetText("unhandled_response", req.Path.ToString()));
-            _logger.Info(_jsonUtil.Serialize(deserializedObject));
+            //_logger.Info(_jsonUtil.Serialize(deserializedObject));
             output = _httpResponseUtil.GetBody<object?>(null, BackendErrorCodes.HTTPNotFound, $"UNHANDLED RESPONSE: {req.Path.ToString()}");
         }
 
         if (ProgramStatics.ENTRY_TYPE() != EntryType.RELEASE)
         {
             // Parse quest info into object
-            var log = new Request(req.Method, new RequestData(req.Path, req.Headers, deserializedObject));
-            _requestsLogger.Info($"REQUEST={_jsonUtil.Serialize(log)}");
+            //var log = new Request(req.Method, new RequestData(req.Path, req.Headers, deserializedObject));
+            //_requestsLogger.Info($"REQUEST={_jsonUtil.Serialize(log)}");
         }
 
         return output;

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -189,12 +189,18 @@ public class SptHttpListener(
     public async ValueTask<string> GetResponse(string sessionID, HttpRequest req, string? body)
     {
         var output = await _router.GetResponse(req, sessionID, body);
-
         /* route doesn't exist or response is not properly set up */
         if (string.IsNullOrEmpty(output))
         {
             _logger.Error(_localisationService.GetText("unhandled_response", req.Path.ToString()));
             output = _httpResponseUtil.GetBody<object?>(null, BackendErrorCodes.HTTPNotFound, $"UNHANDLED RESPONSE: {req.Path.ToString()}");
+        }
+
+        if (ProgramStatics.ENTRY_TYPE() != EntryType.RELEASE)
+        {
+            // Parse quest info into object
+            var log = new Request(req.Method, new RequestData(req.Path, req.Headers));
+            _requestsLogger.Info($"REQUEST={_jsonUtil.Serialize(log)}");
         }
 
         return output;
@@ -235,5 +241,5 @@ public class SptHttpListener(
 
     private record Request(string Method, object output);
 
-    private record RequestData(string Url, object Headers, object Data);
+    private record RequestData(string Url, object Headers);
 }

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -188,22 +188,13 @@ public class SptHttpListener(
 
     public async ValueTask<string> GetResponse(string sessionID, HttpRequest req, string? body)
     {
-        //Todo: deserializedObject was an out in GetResponse but it was never assigned to anything in GetResponse, is this still necessary?
-        object deserializedObject = new();
         var output = await _router.GetResponse(req, sessionID, body);
+
         /* route doesn't exist or response is not properly set up */
         if (string.IsNullOrEmpty(output))
         {
             _logger.Error(_localisationService.GetText("unhandled_response", req.Path.ToString()));
-            _logger.Info(_jsonUtil.Serialize(deserializedObject));
             output = _httpResponseUtil.GetBody<object?>(null, BackendErrorCodes.HTTPNotFound, $"UNHANDLED RESPONSE: {req.Path.ToString()}");
-        }
-
-        if (ProgramStatics.ENTRY_TYPE() != EntryType.RELEASE)
-        {
-            // Parse quest info into object
-            var log = new Request(req.Method, new RequestData(req.Path, req.Headers, deserializedObject));
-            _requestsLogger.Info($"REQUEST={_jsonUtil.Serialize(log)}");
         }
 
         return output;

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -189,21 +189,21 @@ public class SptHttpListener(
     public async ValueTask<string> GetResponse(string sessionID, HttpRequest req, string? body)
     {
         //Todo: deserializedObject was an out in GetResponse but it was never assigned to anything in GetResponse, is this still necessary?
-        //object deserializedObject = new();
+        object deserializedObject = new();
         var output = await _router.GetResponse(req, sessionID, body);
         /* route doesn't exist or response is not properly set up */
         if (string.IsNullOrEmpty(output))
         {
             _logger.Error(_localisationService.GetText("unhandled_response", req.Path.ToString()));
-            //_logger.Info(_jsonUtil.Serialize(deserializedObject));
+            _logger.Info(_jsonUtil.Serialize(deserializedObject));
             output = _httpResponseUtil.GetBody<object?>(null, BackendErrorCodes.HTTPNotFound, $"UNHANDLED RESPONSE: {req.Path.ToString()}");
         }
 
         if (ProgramStatics.ENTRY_TYPE() != EntryType.RELEASE)
         {
             // Parse quest info into object
-            //var log = new Request(req.Method, new RequestData(req.Path, req.Headers, deserializedObject));
-            //_requestsLogger.Info($"REQUEST={_jsonUtil.Serialize(log)}");
+            var log = new Request(req.Method, new RequestData(req.Path, req.Headers, deserializedObject));
+            _requestsLogger.Info($"REQUEST={_jsonUtil.Serialize(log)}");
         }
 
         return output;


### PR DESCRIPTION
Moves async further down into the routes themselves, allows routes to either run synchronous by just returning a new `ValueTask<T>(result)` or by going asynchronous and returning a Task or ValueTask

Also adds a todo in the SptHttpListener, I had to remove `deserializedObject` as out is not supported in aync but this was always assigned the value of null, is this still necessary?