### PR TITLE
fixed missing import for customitemservice, added bundle loading sequence in the program.cs

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
@@ -7,6 +7,7 @@ using SPTarkov.Server.Core.Models.Spt.Mod;
 using SPTarkov.Server.Core.Models.Utils;
 using SPTarkov.Server.Core.Utils;
 using SPTarkov.Server.Core.Utils.Cloners;
+using System.Reflection;
 
 namespace SPTarkov.Server.Core.Services.Mod;
 

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using SPTarkov.Common.Semver;
 using SPTarkov.Common.Semver.Implementations;
 using SPTarkov.DI;
+using SPTarkov.Server.Core.Loaders;
 using SPTarkov.Server.Core.Models.Spt.Mod;
 using SPTarkov.Server.Core.Models.Utils;
 using SPTarkov.Server.Core.Servers;
@@ -44,7 +45,24 @@ public static class Program
         builder.Services.AddSingleton<IReadOnlyList<SptMod>>(loadedMods);
         var serviceProvider = builder.Services.BuildServiceProvider();
         var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger("Server");
+        // Load bundles for bundle mods
+        if (ProgramStatics.MODS())
+        {
+            var bundleLoader = serviceProvider.GetService<BundleLoader>();
+            foreach (var mod in loadedMods)
+            {
+                if (mod.ModMetadata?.IsBundleMod == true)
+                {
+                    // Convert to relative path
+                    string relativeModPath = Path.GetRelativePath(
+                        Directory.GetCurrentDirectory(),
+                        mod.Directory
+                    ).Replace('\\', '/');
 
+                    bundleLoader.AddBundles(relativeModPath);
+                }
+            }
+        }
         try
         {
             SetConsoleOutputMode();

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -37,6 +37,9 @@ public static class Program
             // validate and sort mods, this will also discard any mods that are invalid
             var sortedLoadedMods = ValidateMods(loadedMods);
 
+            // update the loadedMods list with our validated sorted mods
+            loadedMods = sortedLoadedMods;
+
             diHandler.AddInjectableTypesFromAssemblies(sortedLoadedMods.SelectMany(a => a.Assemblies));
         }
         diHandler.InjectAll();


### PR DESCRIPTION
Fixed a mistake in my last PR - forgot to add a using statement for reflection /bonk

Added bundle loading sequence in Program.cs. Bundle loading now occurs after DI container initialization, only processes valid mods with IsBundleMod = true, handles path conversion to relative format for the bundle loader.