### PR TITLE
feat: Rolling file logs

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Utils/Logger/FileCheckpoint.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Logger/FileCheckpoint.cs
@@ -1,0 +1,7 @@
+﻿namespace SPTarkov.Server.Core.Utils.Logger;
+
+public record FileCheckpoint
+{
+    public DateTime Date { get; set; }
+    public int Sequence { get; set; }
+}

--- a/Libraries/SPTarkov.Server.Core/Utils/Logger/Handlers/FileLogHandler.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Logger/Handlers/FileLogHandler.cs
@@ -1,5 +1,5 @@
 using System.Collections.Concurrent;
-using System.Text;
+using System.Text.RegularExpressions;
 using SPTarkov.DI.Annotations;
 
 namespace SPTarkov.Server.Core.Utils.Logger.Handlers;
@@ -8,6 +8,7 @@ namespace SPTarkov.Server.Core.Utils.Logger.Handlers;
 public class FileLogHandler : BaseLogHandler
 {
     private static ConcurrentDictionary<string, Lock> _fileLocks = new();
+    private static Dictionary<string, DateTime> _checkpointCache = new();
 
     public override LoggerType LoggerType => LoggerType.File;
 
@@ -18,18 +19,82 @@ public class FileLogHandler : BaseLogHandler
         if (!_fileLocks.TryGetValue(config.FilePath, out var lockObject))
         {
             lockObject = new Lock();
-            while (!_fileLocks.TryAdd(config.FilePath, lockObject)) ;
+            while (!_fileLocks.TryAdd(config.FilePath, lockObject));
         }
 
         lock (lockObject)
         {
+            var logDirectory = Path.GetDirectoryName(config.FilePath);
             if (!Directory.Exists(Path.GetDirectoryName(config.FilePath)))
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(config.FilePath));
+                Directory.CreateDirectory(logDirectory);
+            }
+
+            string currentCheckpointFilePath = config.FilePath;
+
+            if (config.RollingInterval != RollingInterval.None)
+            {
+                if (_checkpointCache.TryGetValue(config.FilePath, out var nextCheckpoint))
+                {
+                    if (nextCheckpoint < config.RollingInterval.GetCurrentCheckpoint())
+                    {
+                        _checkpointCache[config.FilePath] = config.RollingInterval.GetNextCheckpoint().Date;
+                        currentCheckpointFilePath = GetCurrentCheckpointFile(config, false, true);
+                    }
+                    else
+                    {
+                        currentCheckpointFilePath = GetCurrentCheckpointFile(config);
+                    }
+                }
+                else
+                {
+                    _checkpointCache.Add(config.FilePath, config.RollingInterval.GetNextCheckpoint().Date);
+                    currentCheckpointFilePath = GetCurrentCheckpointFile(config, true);
+                }
             }
 
             // The AppendAllText will create the file as long as the directory exists
-            File.AppendAllText(config.FilePath, FormatMessage(message.Message + "\n", message, reference));
+            File.AppendAllText(currentCheckpointFilePath, FormatMessage(message.Message + "\n", message, reference));
+        }
+    }
+
+    private string GetCurrentCheckpointFile(FileSptLoggerReference config, bool startup = false, bool roll = false)
+    {
+        var logDirectory = Path.GetDirectoryName(config.FilePath);
+        var regex = new Regex($"{Path.GetFileNameWithoutExtension(config.FilePath)}_(\\d+)-(\\d+)-(\\d+)-(\\d+)-\\d+-\\d+(_\\d+)?\\.txt");
+        var allCheckpointFiles = Directory.GetFiles(logDirectory);
+        var checkpoints = new List<FileCheckpoint>();
+        foreach (var checkpointFile in allCheckpointFiles)
+        {
+            var match = regex.Match(Path.GetFileName(checkpointFile));
+            if (match.Success)
+            {
+                var date = new DateTime(
+                    int.Parse(match.Groups[1].Value),
+                    int.Parse(match.Groups[2].Value),
+                    int.Parse(match.Groups[3].Value),
+                    int.Parse(match.Groups[4].Value),
+                    0, 0);
+                var sequence = match.Groups[5].Success ? int.Parse(match.Groups[5].Value.TrimStart('_')) : 0;
+                checkpoints.Add(new FileCheckpoint { Date = date, Sequence = sequence });
+            }
+        }
+
+        FileCheckpoint latestCheckpoint = checkpoints
+            .OrderByDescending(c => c.Date)
+            .ThenByDescending(c => c.Sequence)
+            .FirstOrDefault();
+
+        DateTime currentCheckpoint = roll ? config.RollingInterval.GetNextCheckpoint() : config.RollingInterval.GetCurrentCheckpoint();
+
+        if (latestCheckpoint == null || latestCheckpoint.Date != currentCheckpoint.Date)
+        {
+            return Path.Combine(logDirectory, $"{Path.GetFileNameWithoutExtension(config.FilePath)}_{currentCheckpoint.Date:yyyy-MM-dd-HH-mm-ss}.txt");
+        }
+        else
+        {
+            int sequence = startup ? latestCheckpoint.Sequence + 1 : latestCheckpoint.Sequence;
+            return Path.Combine(logDirectory, $"{Path.GetFileNameWithoutExtension(config.FilePath)}_{currentCheckpoint.Date:yyyy-MM-dd-HH-mm-ss}{(sequence == 0 ? string.Empty : $"_{sequence}")}.txt");
         }
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Utils/Logger/RollingIntervalExtensions.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Logger/RollingIntervalExtensions.cs
@@ -4,7 +4,7 @@ public static class RollingIntervalExtensions
 {
     public static DateTime GetCurrentCheckpoint(this RollingInterval interval)
     {
-        var now = DateTime.UtcNow.AddMinutes(93);
+        var now = DateTime.UtcNow;
 
         return interval switch
         {

--- a/Libraries/SPTarkov.Server.Core/Utils/Logger/RollingIntervalExtensions.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Logger/RollingIntervalExtensions.cs
@@ -1,0 +1,32 @@
+﻿namespace SPTarkov.Server.Core.Utils.Logger;
+
+public static class RollingIntervalExtensions
+{
+    public static DateTime GetCurrentCheckpoint(this RollingInterval interval)
+    {
+        var now = DateTime.UtcNow.AddMinutes(93);
+
+        return interval switch
+        {
+            RollingInterval.Hour => new DateTime(now.Year, now.Month, now.Day, now.Hour , 0, 0, DateTimeKind.Utc),
+            RollingInterval.Day => new DateTime(now.Year, now.Month, now.Day, 0 , 0, 0, DateTimeKind.Utc),
+            RollingInterval.Week => now.Date.AddDays(-(int)now.DayOfWeek).AddHours(-now.Hour).AddMinutes(-now.Minute).AddSeconds(-now.Second),
+            RollingInterval.Month => new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc),
+            _ => throw new ArgumentOutOfRangeException(nameof(interval), interval, null)
+        };
+    }
+
+    public static DateTime GetNextCheckpoint(this RollingInterval interval)
+    {
+        var now = interval.GetCurrentCheckpoint();
+
+        return interval switch
+        {
+            RollingInterval.Hour => now.AddHours(1),
+            RollingInterval.Day => now.AddDays(1),
+            RollingInterval.Week => now.AddDays(7),
+            RollingInterval.Month => now.AddMonths(1),
+            _ => throw new ArgumentOutOfRangeException(nameof(interval), interval, null)
+        };
+    }
+}

--- a/Libraries/SPTarkov.Server.Core/Utils/Logger/SptLoggerConfiguration.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Logger/SptLoggerConfiguration.cs
@@ -119,6 +119,14 @@ public class FileSptLoggerReference : BaseSptLoggerReference
         get;
         set;
     }
+
+    [JsonPropertyName("rollingInterval")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public RollingInterval RollingInterval
+    {
+        get;
+        set;
+    } = RollingInterval.None;
 }
 
 public class ConsoleSptLoggerReference : BaseSptLoggerReference
@@ -142,6 +150,15 @@ public enum SptLoggerFilterType
 {
     Exclude,
     Include
+}
+
+public enum RollingInterval
+{
+    None,
+    Hour,
+    Day,
+    Week,
+    Month
 }
 
 public static class SptLoggerFilterExtensions


### PR DESCRIPTION
My attempt to accomplish #299 in part.
Add `"rollingInterval" : "Hour"` (or Day or Week or Month) into any of the file logging configurations in sptLogger(.Development).json and you're good to go. Default is `None`, current behavior.

We'll probably wanna add something like `maxFileSize` and `filesToKeep` too later.