### PR TITLE
Add Transformer to Lazyload, get rid of event

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
@@ -243,9 +243,17 @@ public class CustomItemService(
 
             newLocaleDetails ??= localeDetails[localeDetails.Keys.FirstOrDefault()];
 
-            localeService.AddCustomClientLocale(shortNameKey.Key, $"{newItemId} Name", newLocaleDetails.Name);
-            localeService.AddCustomClientLocale(shortNameKey.Key, $"{newItemId} ShortName", newLocaleDetails.ShortName);
-            localeService.AddCustomClientLocale(shortNameKey.Key, $"{newItemId} Description", newLocaleDetails.Description);
+            if (databaseService.GetLocales().Global.TryGetValue(shortNameKey.Key, out var lazyLoad))
+            {
+                lazyLoad.AddTransformer(localeData =>
+                {
+                    localeData.Add($"{newItemId} Name", newLocaleDetails.Name);
+                    localeData.Add($"{newItemId} ShortName", newLocaleDetails.ShortName);
+                    localeData.Add($"{newItemId} Description", newLocaleDetails.Description);
+
+                    return localeData;
+                });
+            }
         }
     }
 

--- a/Libraries/SPTarkov.Server.Core/Services/SeasonalEventService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/SeasonalEventService.cs
@@ -1030,8 +1030,16 @@ public class SeasonalEventService(
 
     protected void RenameBitcoin()
     {
-        _localeService.AddCustomClientLocale("en", $"{ItemTpl.BARTER_PHYSICAL_BITCOIN} Name", "Physical SPT Coin");
-        _localeService.AddCustomClientLocale("en", $"{ItemTpl.BARTER_PHYSICAL_BITCOIN} ShortName", "0.2SPT");
+        if(_databaseService.GetLocales().Global.TryGetValue("en", out var lazyLoad))
+        {
+            lazyLoad.AddTransformer(localeData =>
+            {
+                localeData[$"{ItemTpl.BARTER_PHYSICAL_BITCOIN} Name"] = "Physical SPT Coin";
+                localeData[$"{ItemTpl.BARTER_PHYSICAL_BITCOIN} ShortName"] = "0.2SPT";
+
+                return localeData;
+            });
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This will break mods and their examples!

In addition:
- Removes being able to add custom locales, modders should do .AddTransformer on the LazyLoaded value in the database!
- Fixes up PostDBLoad methods trying to use .Value which won't work as this data will be unloaded after 30 seconds
- Move all other SPT code to use .AddTransformer