### PR TITLE
Disable static web assets and only copy relevant logging json for configuration

### DIFF
--- a/Libraries/SPTarkov.Server.Core/SPTarkov.Server.Core.csproj
+++ b/Libraries/SPTarkov.Server.Core/SPTarkov.Server.Core.csproj
@@ -13,6 +13,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SPTarkov.Server/SPTarkov.Server.csproj
+++ b/SPTarkov.Server/SPTarkov.Server.csproj
@@ -15,6 +15,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
@@ -44,10 +45,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <ExcludeFromSingleFile>True</ExcludeFromSingleFile>
     </Content>
-    <None Update="sptLogger.json">
+    <None Update="sptLogger.json" Condition="'$(Configuration)' == 'RELEASE'">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="sptLogger.Development.json">
+    <None Update="sptLogger.Development.json" Condition="'$(Configuration)' == 'DEBUG'">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Disable building static web asset manifest and only copy the relevant logging config for the build configuration selected