### PR TITLE
Begin cleanup of quest model & nullability in Quests & Achievements

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
@@ -540,7 +540,7 @@ public class RepeatableQuestController(
             // Add repeatable quests of this loops sub-type (daily/weekly)
             for (var i = 0; i < GetQuestCount(repeatableConfig, fullProfile); i++)
             {
-                var quest = new RepeatableQuest();
+                RepeatableQuest? quest = null;
                 var lifeline = 0;
                 while (quest?.Id == null && questTypePool.Types.Count > 0)
                 {

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGenerator.cs
@@ -895,7 +895,6 @@ public class RepeatableQuestGenerator(
             ParentId = "",
             DynamicLocale = true,
             VisibilityConditions = [],
-            GlobalQuestCounterId = "",
             Target = new ListOrT<string>([itemTpl], null),
             Value = value,
             MinDurability = minDurability,

--- a/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
@@ -1380,7 +1380,7 @@ public class QuestHelper(
 
                 // Prereq does not have its status requirement fulfilled
                 // Some bsg status ids are strings, MUST convert to number before doing includes check
-                if (!conditionToFulfil.Status.Contains(prerequisiteQuest.Status.Value))
+                if (!conditionToFulfil.Status.Contains(prerequisiteQuest.Status))
                 {
                     haveCompletedPreviousQuest = false;
                     break;
@@ -1391,7 +1391,7 @@ public class QuestHelper(
                 {
                     // Compare current time to unlock time for previous quest
                     prerequisiteQuest.StatusTimers.TryGetValue(
-                        prerequisiteQuest.Status.Value,
+                        prerequisiteQuest.Status,
                         out var previousQuestCompleteTime
                     );
                     var unlockTime = previousQuestCompleteTime + conditionToFulfil.AvailableAfter;

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Achievement.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Achievement.cs
@@ -7,50 +7,47 @@ public record Achievement
     [JsonExtensionData]
     public Dictionary<string, object> ExtensionData { get; set; }
 
+    [JsonPropertyName("index")]
+    public required int Index { get; set; }
+
     [JsonPropertyName("id")]
-    public string? Id { get; set; }
+    public required string Id { get; set; }
 
     [JsonPropertyName("imageUrl")]
-    public string? ImageUrl { get; set; }
+    public required string ImageUrl { get; set; }
 
+    /// <summary>
+    /// Unused in the client
+    /// </summary>
     [JsonPropertyName("assetPath")]
-    public string? AssetPath { get; set; }
+    public string? AssetPath { get; set; }  
 
     [JsonPropertyName("rewards")]
-    public List<Reward>? Rewards { get; set; }
+    public required List<Reward> Rewards { get; set; }
 
     [JsonPropertyName("conditions")]
-    public AchievementQuestConditionTypes? Conditions { get; set; }
+    public required AchievementQuestConditionTypes Conditions { get; set; }
 
-    [JsonPropertyName("instantComplete")]
-    public bool? InstantComplete { get; set; }
-
-    [JsonPropertyName("showNotificationsInGame")]
-    public bool? ShowNotificationsInGame { get; set; }
-
+    /// <summary>
+    /// Unused in the client
+    /// </summary>
     [JsonPropertyName("showProgress")]
     public bool? ShowProgress { get; set; }
 
-    [JsonPropertyName("prefab")]
-    public string? Prefab { get; set; }
-
     [JsonPropertyName("rarity")]
-    public string? Rarity { get; set; }
+    public required string Rarity { get; set; }
 
     [JsonPropertyName("hidden")]
-    public bool? Hidden { get; set; }
+    public required bool Hidden { get; set; }
 
     [JsonPropertyName("showConditions")]
-    public bool? ShowConditions { get; set; }
+    public required bool ShowConditions { get; set; }
 
     [JsonPropertyName("progressBarEnabled")]
-    public bool? ProgressBarEnabled { get; set; }
+    public required bool ProgressBarEnabled { get; set; }
 
     [JsonPropertyName("side")]
-    public string? Side { get; set; }
-
-    [JsonPropertyName("index")]
-    public int? Index { get; set; }
+    public required string Side { get; set; }
 }
 
 public record AchievementQuestConditionTypes

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
@@ -20,44 +20,44 @@ public record Quest
     ///     _id
     /// </summary>
     [JsonPropertyName("_id")]
-    public string? Id { get; set; }
+    public required string Id { get; set; }
 
     [JsonPropertyName("canShowNotificationsInGame")]
-    public bool? CanShowNotificationsInGame { get; set; }
+    public required bool CanShowNotificationsInGame { get; set; }
 
     [JsonPropertyName("conditions")]
-    public QuestConditionTypes? Conditions { get; set; }
+    public required QuestConditionTypes Conditions { get; set; }
 
     [JsonPropertyName("description")]
-    public string? Description { get; set; }
+    public required string Description { get; set; }
 
     [JsonPropertyName("failMessageText")]
     public string? FailMessageText { get; set; }
 
     [JsonPropertyName("name")]
-    public string? Name { get; set; }
+    public required string Name { get; set; }
 
     [JsonPropertyName("note")]
     public string? Note { get; set; }
 
     [JsonPropertyName("traderId")]
-    public string? TraderId { get; set; }
+    public required string TraderId { get; set; }
 
     [JsonPropertyName("location")]
-    public string? Location { get; set; }
+    public required string Location { get; set; }
 
     [JsonPropertyName("image")]
-    public string? Image { get; set; }
+    public required string Image { get; set; }
 
     [JsonPropertyName("type")] // can be string or QuestTypeEnum
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public QuestTypeEnum? Type { get; set; }
+    public required QuestTypeEnum Type { get; set; }
 
     [JsonPropertyName("isKey")]
     public bool? IsKey { get; set; }
 
     [JsonPropertyName("restartable")]
-    public bool? Restartable { get; set; }
+    public required bool Restartable { get; set; }
 
     [JsonPropertyName("instantComplete")]
     public bool? InstantComplete { get; set; }
@@ -102,7 +102,7 @@ public record Quest
     ///     "Pmc" or "Scav"
     /// </summary>
     [JsonPropertyName("side")]
-    public string? Side { get; set; }
+    public required string Side { get; set; }
 
     [JsonPropertyName("acceptanceAndFinishingSource")]
     public string? AcceptanceAndFinishingSource { get; set; }
@@ -136,30 +136,24 @@ public record Quest
 }
 
 /// <summary>
-///     Same as BotBase.Quests
+///     Based on QuestDataClass in the client
 /// </summary>
 public record QuestStatus
 {
     [JsonExtensionData]
     public Dictionary<string, object> ExtensionData { get; set; }
 
-    [JsonPropertyName("id")]
-    public string? Id { get; set; }
-
-    [JsonPropertyName("uid")]
-    public string? Uid { get; set; }
-
     [JsonPropertyName("qid")]
-    public string? QId { get; set; }
+    public required string QId { get; set; }
 
     [JsonPropertyName("startTime")]
-    public double? StartTime { get; set; }
+    public required double StartTime { get; set; }
 
     [JsonPropertyName("status")]
-    public QuestStatusEnum? Status { get; set; }
+    public required QuestStatusEnum Status { get; set; }
 
     [JsonPropertyName("statusTimers")]
-    public Dictionary<QuestStatusEnum, double>? StatusTimers { get; set; }
+    public required Dictionary<QuestStatusEnum, double> StatusTimers { get; set; }
 
     [JsonPropertyName("completedConditions")]
     public List<string>? CompletedConditions { get; set; }
@@ -195,7 +189,7 @@ public record QuestCondition
     public Dictionary<string, object> ExtensionData { get; set; }
 
     [JsonPropertyName("id")]
-    public string? Id { get; set; }
+    public required string Id { get; set; }
 
     [JsonPropertyName("index")]
     public int? Index { get; set; }
@@ -204,14 +198,14 @@ public record QuestCondition
     public string? CompareMethod { get; set; }
 
     [JsonPropertyName("dynamicLocale")]
-    public bool? DynamicLocale { get; set; }
+    public required bool DynamicLocale { get; set; }
 
     [JsonPropertyName("visibilityConditions")]
     public List<VisibilityCondition>? VisibilityConditions { get; set; }
-
-    [JsonPropertyName("globalQuestCounterId")]
-    public string? GlobalQuestCounterId { get; set; }
-
+        
+    /// <summary>
+    /// This is set as nullable in the client
+    /// </summary>
     [JsonPropertyName("parentId")]
     public string? ParentId { get; set; }
 

--- a/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
@@ -1209,7 +1209,7 @@ public class LocationLifecycleService
                 continue;
             }
 
-            if (dbQuest.Restartable is not null)
+            if (dbQuest.Restartable)
             {
                 failedQuest.Status = QuestStatusEnum.Fail;
             }


### PR DESCRIPTION
This has been mostly the result of me going through the game and checking what the game reads, if the game reads these properties these are now set as 'required'