### PR TITLE
Removes duplicate property group for setting assembly info

### DIFF
--- a/SPTarkov.Server/SPTarkov.Server.csproj
+++ b/SPTarkov.Server/SPTarkov.Server.csproj
@@ -17,10 +17,6 @@
     <AssemblyName>SPT.Server</AssemblyName>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
-    <AssemblyName>SPTarkov.Server</AssemblyName>
-    <ApplicationIcon>..\Libraries\SPTarkov.Server.Assets\SPT_Data\images\icon.ico</ApplicationIcon>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
     <AssemblyName>SPT.Server.Linux</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
This property group is overriding the actual assembly name after recent changes. The PR removes it to actually apply the new server name & *.ico path correctly.

**edit** If I'd known there's that many reviews & workflows required for approval I'd just written a reminder on Discord... sry about that :)