### PR TITLE
Repeatable quest generation (Part 1)

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
@@ -268,7 +268,7 @@ public class CompletionQuestGenerator(
     /// <param name="itemSelection">Filtered item selection</param>
     /// <param name="roublesBudget">Budget in roubles</param>
     /// <returns>Chosen item template Ids</returns>
-    public List<string> GenerateAvailableForFinish(
+    protected List<string> GenerateAvailableForFinish(
         RepeatableQuest quest,
         Completion completionConfig,
         RepeatableQuestConfig repeatableConfig,

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
@@ -1,0 +1,421 @@
+﻿using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.Helpers;
+using SPTarkov.Server.Core.Models.Eft.Common.Tables;
+using SPTarkov.Server.Core.Models.Enums;
+using SPTarkov.Server.Core.Models.Spt.Config;
+using SPTarkov.Server.Core.Models.Utils;
+using SPTarkov.Server.Core.Servers;
+using SPTarkov.Server.Core.Services;
+using SPTarkov.Server.Core.Utils;
+using SPTarkov.Server.Core.Utils.Json;
+
+namespace SPTarkov.Server.Core.Generators.RepeatableQuestGeneration;
+
+[Injectable]
+public class CompletionQuestGenerator(
+    ISptLogger<CompletionQuestGenerator> logger,
+    RepeatableQuestHelper repeatableQuestHelper,
+    RepeatableQuestRewardGenerator repeatableQuestRewardGenerator,
+    DatabaseService databaseService,
+    SeasonalEventService  seasonalEventService,
+    LocalisationService localisationService,
+    RandomUtil randomUtil,
+    MathUtil mathUtil,
+    HashUtil hashUtil,
+    ItemHelper itemHelper
+    )
+{
+    protected const int MaxRandomNumberAttempts = 6;
+
+    /// <summary>
+    ///     Generates a valid Completion quest
+    /// </summary>
+    /// <param name="sessionId">session Id to generate the quest for</param>
+    /// <param name="pmcLevel">player's level for requested items and reward generation</param>
+    /// <param name="traderId">trader from which the quest will be provided</param>
+    /// <param name="repeatableConfig">
+    ///     The configuration for the repeatably kind (daily, weekly) as configured in QuestConfig
+    ///     for the requested quest
+    /// </param>
+    /// <returns>quest type format for "Completion" (see assets/database/templates/repeatableQuests.json)</returns>
+    public RepeatableQuest? Generate(
+        string sessionId,
+        int pmcLevel,
+        string traderId,
+        RepeatableQuestConfig repeatableConfig
+        )
+    {
+        var completionConfig = repeatableConfig.QuestConfig.Completion;
+        var levelsConfig = repeatableConfig.RewardScaling.Levels;
+        var roublesConfig = repeatableConfig.RewardScaling.Roubles;
+
+        var quest = repeatableQuestHelper.GenerateRepeatableTemplate(
+            RepeatableQuestType.Completion,
+            traderId,
+            repeatableConfig.Side,
+            sessionId
+        );
+
+        if (quest is null)
+        {
+            logger.Error("Quest template null when attempting to create completion operational task.");
+            return null;
+        }
+
+        // Filter the items.json items to items the player must retrieve to complete quest: shouldn't be a quest item or "non-existent"
+        var itemsToRetrievePool = GetItemsToRetrievePool(
+            completionConfig,
+            repeatableConfig.RewardBlacklist
+        );
+
+        // Filter items within our budget
+        var (hashSet, budget) = GetItemsWithinBudget(pmcLevel, levelsConfig, roublesConfig, itemsToRetrievePool);
+        itemsToRetrievePool = hashSet;
+
+        // We also have the option to use whitelist and/or blacklist which is defined in repeatableQuests.json as
+        // [{"minPlayerLevel": 1, "itemIds": ["id1",...]}, {"minPlayerLevel": 15, "itemIds": ["id3",...]}]
+        if (repeatableConfig.QuestConfig.Completion.UseWhitelist)
+        {
+            itemsToRetrievePool = GetWhitelistedItemSelection(itemsToRetrievePool, pmcLevel);
+        }
+
+        if (repeatableConfig.QuestConfig.Completion.UseBlacklist)
+        {
+            itemsToRetrievePool = GetBlacklistedItemSelection(itemsToRetrievePool, pmcLevel);
+        }
+
+        // Filtering too harsh
+        if (itemsToRetrievePool.Count == 0)
+        {
+            logger.Error(
+                localisationService.GetText(
+                    "repeatable-completion_quest_whitelist_too_small_or_blacklist_too_restrictive"
+                )
+            );
+
+            return null;
+        }
+
+
+        var selectedItems = GenerateAvailableForFinish(
+            quest, completionConfig, repeatableConfig, itemsToRetrievePool.ToList(), budget
+            );
+
+        quest.Rewards = repeatableQuestRewardGenerator.GenerateReward(
+            pmcLevel,
+            1,
+            traderId,
+            repeatableConfig,
+            completionConfig,
+            selectedItems
+        );
+
+        return quest;
+    }
+
+    /// <summary>
+    /// Generate a pool of item tpls the player should reasonably be able to retrieve
+    /// </summary>
+    /// <param name="completionConfig">Completion quest type config</param>
+    /// <param name="itemTplBlacklist">Item tpls to not add to pool</param>
+    /// <returns>Set of item tpls</returns>
+    protected HashSet<string> GetItemsToRetrievePool(
+        Completion completionConfig,
+        HashSet<string> itemTplBlacklist
+    )
+    {
+        // Get seasonal items that should not be added to pool as seasonal event is not active
+        var seasonalItems = seasonalEventService.GetInactiveSeasonalEventItems();
+
+        // Check for specific base classes which don't make sense as reward item
+        // also check if the price is greater than 0; there are some items whose price can not be found
+        return databaseService
+            .GetItems()
+            .Values.Where(itemTemplate =>
+            {
+                // Base "Item" item has no parent, ignore it
+                if (itemTemplate.Parent == string.Empty)
+                {
+                    return false;
+                }
+
+                if (seasonalItems.Contains(itemTemplate.Id))
+                {
+                    return false;
+                }
+
+                // Valid reward items share same logic as items to retrieve
+                return repeatableQuestRewardGenerator.IsValidRewardItem(
+                    itemTemplate.Id,
+                    itemTplBlacklist,
+                    completionConfig.RequiredItemTypeBlacklist
+                );
+            })
+            .Select(item => item.Id)
+            .ToHashSet();
+    }
+
+    /// <summary>
+    ///     Filter item pool down to items we can afford on our budget
+    /// </summary>
+    /// <param name="pmcLevel">Level of pmc</param>
+    /// <param name="levelsConfig">Levels config</param>
+    /// <param name="roublesConfig">Roubles config</param>
+    /// <param name="itemsToRetrievePool">Item pool</param>
+    /// <returns>Filtered items and roubles budget</returns>
+    protected (HashSet<string>, double) GetItemsWithinBudget(
+        int pmcLevel,
+        List<double> levelsConfig,
+        List<double> roublesConfig,
+        HashSet<string> itemsToRetrievePool)
+    {
+        // Be fair, don't value the items be more expensive than the reward
+        var multiplier = randomUtil.GetDouble(0.5, 1);
+        var roublesBudget = Math.Floor(
+            mathUtil.Interp1(pmcLevel, levelsConfig, roublesConfig) * multiplier
+        );
+
+        // Make sure there is always a 5000 rouble budget available for selection
+        roublesBudget = Math.Max(roublesBudget, 5000d);
+
+        return (
+            itemsToRetrievePool.Where(itemTpl => itemHelper.GetItemPrice(itemTpl) < roublesBudget).ToHashSet(),
+            roublesBudget
+            );
+    }
+
+    /// <summary>
+    ///     Filter item selection to items in the whitelist
+    /// </summary>
+    /// <param name="itemSelection">Item selection to filter</param>
+    /// <param name="pmcLevel">Level of pmc</param>
+    /// <returns>Filtered selection, or original if null or empty</returns>
+    protected HashSet<string> GetWhitelistedItemSelection(HashSet<string> itemSelection, int pmcLevel)
+    {
+        var itemWhitelist = databaseService
+            .GetTemplates()
+            .RepeatableQuests?.Data?.Completion?.ItemsWhitelist;
+
+        // Whitelist doesn't exist or is empty, return original
+        if (itemWhitelist is null || itemWhitelist.Count == 0)
+        {
+            return itemSelection;
+        }
+
+        // Filter and concatenate items according to current player level
+        var itemIdsWhitelisted = itemWhitelist
+            .Where(p => p.MinPlayerLevel <= pmcLevel)
+            .SelectMany(x => x.ItemIds)
+            .ToHashSet(); //.Aggregate((a, p) => a.Concat(p.ItemIds), []);
+
+        var filteredSelection = itemSelection
+            .Where(x =>
+            {
+                // Whitelist can contain item tpls and item base type ids
+                return itemIdsWhitelisted.Any(v => itemHelper.IsOfBaseclass(x, v))
+                       || itemIdsWhitelisted.Contains(x);
+            })
+            .ToHashSet();
+
+        // check if items are missing
+        // var flatList = itemSelection.reduce((a, il) => a.concat(il[0]), []);
+        // var missing = itemIdsWhitelisted.filter(l => !flatList.includes(l));
+
+        return filteredSelection;
+    }
+
+    /// <summary>
+    ///     Filter item selection based on the blacklist
+    /// </summary>
+    /// <param name="itemSelection">Item selection to filter</param>
+    /// <param name="pmcLevel">Level of pmc</param>
+    /// <returns>Filtered selection, or original if null or empty</returns>
+    protected HashSet<string> GetBlacklistedItemSelection(HashSet<string> itemSelection, int pmcLevel)
+    {
+        var itemBlacklist = databaseService
+            .GetTemplates()
+            .RepeatableQuests?.Data?.Completion?.ItemsBlacklist;
+
+        // Blacklist doesn't exist or is empty, return original
+        if (itemBlacklist is null || itemBlacklist.Count == 0)
+        {
+            return itemSelection;
+        }
+
+        // Filter and concatenate the arrays according to current player level
+        var itemIdsBlacklisted = itemBlacklist
+            .Where(p => p.MinPlayerLevel <= pmcLevel)
+            .SelectMany(x => x.ItemIds)
+            .ToHashSet(); //.Aggregate(List<ItemsBlacklist> , (a, p) => a.Concat(p.ItemIds) );
+
+        var filteredSelection = itemSelection
+            .Where(x =>
+            {
+                return itemIdsBlacklisted.All(v => !itemHelper.IsOfBaseclass(x, v))
+                       || !itemIdsBlacklisted.Contains(x);
+            })
+            .ToHashSet();
+
+        return filteredSelection;
+    }
+
+    /// <summary>
+    ///     Generate the available for finish conditions for this quest
+    /// </summary>
+    /// <param name="quest">Quest to add the conditions to</param>
+    /// <param name="completionConfig">Completion config</param>
+    /// <param name="repeatableConfig">Repeatable config</param>
+    /// <param name="itemSelection">Filtered item selection</param>
+    /// <param name="roublesBudget">Budget in roubles</param>
+    /// <returns>Chosen item template Ids</returns>
+    public List<string> GenerateAvailableForFinish(
+        RepeatableQuest quest,
+        Completion completionConfig,
+        RepeatableQuestConfig repeatableConfig,
+        List<string> itemSelection,
+        double roublesBudget
+        )
+    {
+        // Store the indexes of items we are asking player to supply
+        var distinctItemsToRetrieveCount = randomUtil.GetInt(1, completionConfig.UniqueItemCount);
+        var chosenRequirementItemsTpls = new List<string>();
+        var usedItemIndexes = new HashSet<int>();
+
+        for (var i = 0; i < distinctItemsToRetrieveCount; i++)
+        {
+            var chosenItemIndex = randomUtil.RandInt(itemSelection.Count);
+            var found = false;
+
+            for (var j = 0; j < MaxRandomNumberAttempts; j++)
+            {
+                if (usedItemIndexes.Contains(chosenItemIndex))
+                {
+                    chosenItemIndex = randomUtil.RandInt(itemSelection.Count);
+                }
+                else
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                logger.Error(
+                    localisationService.GetText(
+                        "repeatable-no_reward_item_found_in_price_range",
+                        new { minPrice = 0, roublesBudget }
+                    )
+                );
+
+                return chosenRequirementItemsTpls;
+            }
+
+            // Store index of item we've already chosen for later checking
+            usedItemIndexes.Add(chosenItemIndex);
+
+            var tplChosen = itemSelection[chosenItemIndex];
+            var itemPrice = itemHelper.GetItemPrice(tplChosen).Value;
+            var minValue = completionConfig.MinimumRequestedAmount;
+            var maxValue = completionConfig.MaximumRequestedAmount;
+
+            var value = minValue;
+
+            // Get the value range within budget
+            var x = (int)Math.Floor(roublesBudget / itemPrice);
+            maxValue = Math.Min(maxValue, x);
+            if (maxValue > minValue)
+            // If it doesn't blow the budget we have for the request, draw a random amount of the selected
+            // Item type to be requested
+            {
+                value = randomUtil.RandInt(minValue, maxValue + 1);
+            }
+
+            roublesBudget -= value * itemPrice;
+
+            // Push a CompletionCondition with the item and the amount of the item into quest
+            chosenRequirementItemsTpls.Add(tplChosen);
+            quest.Conditions.AvailableForFinish.Add(
+                GenerateCondition(
+                    tplChosen,
+                    value,
+                    repeatableConfig.QuestConfig.Completion
+                )
+            );
+
+            // Is there budget left for more items
+            if (roublesBudget > 0)
+            {
+                // Reduce item pool to fit budget
+                itemSelection = itemSelection
+                    .Where(tpl => itemHelper.GetItemPrice(tpl) < roublesBudget)
+                    .ToList();
+
+                if (itemSelection.Count == 0)
+                {
+                    // Nothing fits new budget, exit
+                    break;
+                }
+
+                continue;
+            }
+
+            break;
+        }
+
+        return chosenRequirementItemsTpls;
+    }
+
+    /// <summary>
+    ///     A repeatable quest, besides some more or less static components, exists of reward and condition (see
+    ///     assets/database/templates/repeatableQuests.json)
+    ///     This is a helper method for GenerateCompletionQuest to create a completion condition (of which a completion quest
+    ///     theoretically can have many)
+    /// </summary>
+    /// <param name="itemTpl">Id of the item to request</param>
+    /// <param name="value">Amount of items of this specific type to request</param>
+    /// <param name="completionConfig">Completion config from quest.json</param>
+    /// <returns>object of "Completion"-condition</returns>
+    protected QuestCondition GenerateCondition(
+        string itemTpl,
+        double value,
+        Completion completionConfig
+    )
+    {
+        var onlyFoundInRaid = completionConfig.RequiredItemsAreFiR;
+        var minDurability = itemHelper.IsOfBaseclasses(
+            itemTpl,
+            [BaseClasses.WEAPON, BaseClasses.ARMOR]
+        )
+            ? randomUtil.GetArrayValue(
+                [
+                    completionConfig.RequiredItemMinDurabilityMinMax.Min,
+                    completionConfig.RequiredItemMinDurabilityMinMax.Max,
+                ]
+            )
+            : 0;
+
+        // Dog tags MUST NOT be FiR for them to work
+        if (itemHelper.IsDogtag(itemTpl))
+        {
+            onlyFoundInRaid = false;
+        }
+
+        return new QuestCondition
+        {
+            Id = hashUtil.Generate(),
+            Index = 0,
+            ParentId = "",
+            DynamicLocale = true,
+            VisibilityConditions = [],
+            Target = new ListOrT<string>([itemTpl], null),
+            Value = value,
+            MinDurability = minDurability,
+            MaxDurability = 100,
+            DogtagLevel = 0,
+            OnlyFoundInRaid = onlyFoundInRaid,
+            IsEncoded = false,
+            ConditionType = "HandoverItem",
+        };
+    }
+}

--- a/Libraries/SPTarkov.Server.Core/Helpers/RepeatableQuestHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RepeatableQuestHelper.cs
@@ -1,18 +1,25 @@
 using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Enums;
 using SPTarkov.Server.Core.Models.Spt.Config;
 using SPTarkov.Server.Core.Models.Utils;
 using SPTarkov.Server.Core.Servers;
+using SPTarkov.Server.Core.Services;
+using SPTarkov.Server.Core.Utils;
+using SPTarkov.Server.Core.Utils.Cloners;
 
 namespace SPTarkov.Server.Core.Helpers;
 
 [Injectable]
 public class RepeatableQuestHelper(
-    ISptLogger<RepeatableQuestHelper> _logger,
-    ConfigServer _configServer
+    ISptLogger<RepeatableQuestHelper> logger,
+    DatabaseService  databaseService,
+    HashUtil hashUtil,
+    ICloner cloner,
+    ConfigServer configServer
 )
 {
-    protected QuestConfig _questConfig = _configServer.GetConfig<QuestConfig>();
+    protected QuestConfig _questConfig = configServer.GetConfig<QuestConfig>();
 
     /// <summary>
     ///     Get the relevant elimination config based on the current players PMC level
@@ -36,7 +43,7 @@ public class RepeatableQuestHelper(
     /// <param name="playerGroup">Side to get the templates for</param>
     /// <returns></returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-    public Dictionary<string, string>? GetRepeatableQuestTemplatesByGroup(PlayerGroup playerGroup)
+    public Dictionary<string, string> GetRepeatableQuestTemplatesByGroup(PlayerGroup playerGroup)
     {
         var templates = _questConfig.RepeatableQuestTemplates;
 
@@ -46,5 +53,146 @@ public class RepeatableQuestHelper(
             PlayerGroup.Scav => templates.Scav,
             _ => throw new ArgumentOutOfRangeException(nameof(playerGroup), playerGroup, null),
         };
+    }
+
+    /// <summary>
+    ///     Gets a cloned repeatable quest template for the provided type with a unique id
+    /// </summary>
+    /// <param name="type">Type of template to retrieve</param>
+    /// <param name="traderId">TraderId that should provide this quest</param>
+    /// <returns>Cloned quest template</returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public RepeatableQuest? GetClonedQuestTemplateForType(
+        RepeatableQuestType type,
+        string traderId
+        )
+    {
+        var quest = type switch
+        {
+            RepeatableQuestType.Elimination => cloner.Clone(
+                databaseService.GetTemplates().RepeatableQuests?.Templates?.Elimination),
+            RepeatableQuestType.Completion => cloner.Clone(
+                databaseService.GetTemplates().RepeatableQuests?.Templates?.Completion),
+            RepeatableQuestType.Exploration => cloner.Clone(
+                databaseService.GetTemplates().RepeatableQuests?.Templates?.Exploration),
+            RepeatableQuestType.Pickup => cloner.Clone(
+                databaseService.GetTemplates().RepeatableQuests?.Templates?.Pickup),
+            _ => null
+        };
+
+        if (quest is null)
+        {
+            return null;
+        }
+
+        quest.Id = hashUtil.Generate();
+        quest.TraderId = traderId;
+
+        return quest;
+    }
+
+    /// <summary>
+    ///     Generates the base object of quest type format given as templates in
+    ///     assets/database/templates/repeatableQuests.json
+    ///     The templates include Elimination, Completion and Extraction quest types
+    /// </summary>
+    /// <param name="type">Quest type: "Elimination", "Completion" or "Extraction"</param>
+    /// <param name="traderId">Trader from which the quest will be provided</param>
+    /// <param name="playerGroup">Scav daily or pmc daily/weekly quest</param>
+    /// <param name="sessionId">sessionId to generate template for</param>
+    /// <returns>
+    ///     Object which contains the base elements for repeatable quests of the requests type
+    ///     (needs to be filled with reward and conditions by called to make a valid quest)
+    /// </returns>
+    public RepeatableQuest? GenerateRepeatableTemplate(
+        RepeatableQuestType type,
+        string traderId,
+        PlayerGroup playerGroup,
+        string sessionId
+    )
+    {
+        var questData = GetClonedQuestTemplateForType(type, traderId);
+
+        if (questData is null)
+        {
+            // TODO: Localize me!
+            logger.Error($"No repeatable quest template found for type {type}");
+            return null;
+        }
+
+        // Get template id from config based on side and type of quest
+        var typeIds = GetRepeatableQuestTemplatesByGroup(playerGroup);
+
+        var templateName = Enum.GetName(type);
+
+        if (templateName is null)
+        {
+            // TODO: Localize me!
+            logger.Error($"Could not resolve template name for {type}");
+            return null;
+        }
+
+        questData.TemplateId = typeIds[templateName];
+
+        // Force REF templates to use prapors ID - solves missing text issue
+        var desiredTraderId = traderId == Traders.REF ? Traders.PRAPOR : traderId;
+
+        /*  in locale, these id correspond to the text of quests
+            template ids -pmc  : Elimination = 616052ea3054fc0e2c24ce6e / Completion = 61604635c725987e815b1a46 / Exploration = 616041eb031af660100c9967
+            template ids -scav : Elimination = 62825ef60e88d037dc1eb428 / Completion = 628f588ebb558574b2260fe5 / Exploration = 62825ef60e88d037dc1eb42c
+        */
+
+        questData.Name = questData
+            .Name.Replace("{traderId}", traderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.Note = questData
+            .Note?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.Description = questData
+            .Description.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.SuccessMessageText = questData
+            .SuccessMessageText?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.FailMessageText = questData
+            .FailMessageText?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.StartedMessageText = questData
+            .StartedMessageText?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.ChangeQuestMessageText = questData
+            .ChangeQuestMessageText?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.AcceptPlayerMessage = questData
+            .AcceptPlayerMessage?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.DeclinePlayerMessage = questData
+            .DeclinePlayerMessage?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        questData.CompletePlayerMessage = questData
+            .CompletePlayerMessage?.Replace("{traderId}", desiredTraderId)
+            .Replace("{templateId}", questData.TemplateId);
+
+        if (questData.QuestStatus is null)
+        {
+            // TODO: Localize me!
+            logger.Error($"No quest status found for type {type}");
+            return null;
+        }
+
+        questData.QuestStatus.Id = hashUtil.Generate();
+        questData.QuestStatus.Uid = sessionId; // Needs to match user id
+        questData.QuestStatus.QId = questData.Id; // Needs to match quest id
+
+        return questData;
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Models/Enums/RepeatableQuestType.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Enums/RepeatableQuestType.cs
@@ -1,0 +1,12 @@
+﻿using SPTarkov.Server.Core.Utils.Json.Converters;
+
+namespace SPTarkov.Server.Core.Models.Enums;
+
+[EftEnumConverter]
+public enum RepeatableQuestType
+{
+    Elimination,
+    Completion,
+    Exploration,
+    Pickup
+}


### PR DESCRIPTION
Repeatable quest generation code is a mess. It is near impossible to follow. This is a start of a cleanup to turn each type of operational task generation into its own component, again this will be done in pieces, as such the old `RepeatableQuestGenerator` has been marked `Obsolete` and shouldn't be added to going forward. It will be fully replaced by components and the choosing of quest type to be generated will happen inside of the controller, instead of the generator.

All changes tested with initial generation and replacements.

- Marked `RepeatableQuestGenerator` obsolete, its in the process of being removed in favor of components.
- Broke out `Completion` quest generation into its own component.
- Broke out quite a few code stubs into their own methods for readability.
- Fixed nearly all associated warnings with `Completion` generation code. (5901 Solution warnings remain)
- Added `GetClonedQuestTemplateForType()` in `RepeatableQuestHelper`
- Added more error handling to `Completion` generation code. Errors still need localized.
- Added new `RepeatableQuestType` enum to handle operational task types.