### PR TITLE
Repeatable quest generation (Part 2)

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
@@ -395,7 +395,7 @@
                     "maxExtractsWithSpecificExit": 2,
                     "possibleSkillRewards": ["Endurance", "Strength", "Vitality"],
                     "specificExits": {
-                        "probability": 0.2,
+                        "chance": 20,
                         "passageRequirementWhitelist": [
                             "None",
                             "TransferItem",
@@ -1194,7 +1194,7 @@
                     "maxExtractsWithSpecificExit": 4,
                     "possibleSkillRewards": ["Endurance", "Strength", "Vitality"],
                     "specificExits": {
-                        "probability": 0.1,
+                        "chance": 10,
                         "passageRequirementWhitelist": [
                             "None",
                             "TransferItem",
@@ -1947,7 +1947,7 @@
                     "maxExtracts": 3,
                     "maxExtractsWithSpecificExit": 1,
                     "specificExits": {
-                        "probability": 0.2,
+                        "chance": 20,
                         "passageRequirementWhitelist": ["None", "WorldEvent", "Train", "Reference", "Empty"]
                     }
                 },

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
@@ -3,6 +3,7 @@ using SPTarkov.Server.Core.Helpers;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Enums;
 using SPTarkov.Server.Core.Models.Spt.Config;
+using SPTarkov.Server.Core.Models.Spt.Repeatable;
 using SPTarkov.Server.Core.Models.Utils;
 using SPTarkov.Server.Core.Servers;
 using SPTarkov.Server.Core.Services;
@@ -19,13 +20,16 @@ public class CompletionQuestGenerator(
     DatabaseService databaseService,
     SeasonalEventService seasonalEventService,
     LocalisationService localisationService,
+    ConfigServer configServer,
     RandomUtil randomUtil,
     MathUtil mathUtil,
     HashUtil hashUtil,
     ItemHelper itemHelper
-)
+) : IRepeatableQuestGenerator
 {
     protected const int MaxRandomNumberAttempts = 6;
+
+    protected QuestConfig QuestConfig = configServer.GetConfig<QuestConfig>();
 
     /// <summary>
     ///     Generates a valid Completion quest
@@ -42,6 +46,7 @@ public class CompletionQuestGenerator(
         string sessionId,
         int pmcLevel,
         string traderId,
+        QuestTypePool questTypePool,
         RepeatableQuestConfig repeatableConfig
     )
     {

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
@@ -1,0 +1,319 @@
+﻿using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.Helpers;
+using SPTarkov.Server.Core.Models.Eft.Common;
+using SPTarkov.Server.Core.Models.Eft.Common.Tables;
+using SPTarkov.Server.Core.Models.Enums;
+using SPTarkov.Server.Core.Models.Spt.Config;
+using SPTarkov.Server.Core.Models.Spt.Repeatable;
+using SPTarkov.Server.Core.Models.Utils;
+using SPTarkov.Server.Core.Servers;
+using SPTarkov.Server.Core.Services;
+using SPTarkov.Server.Core.Utils;
+using SPTarkov.Server.Core.Utils.Json;
+
+namespace SPTarkov.Server.Core.Generators.RepeatableQuestGeneration;
+
+[Injectable]
+public class ExplorationQuestGenerator(
+    ISptLogger<ExplorationQuestGenerator> logger,
+    RepeatableQuestHelper repeatableQuestHelper,
+    RepeatableQuestRewardGenerator repeatableQuestRewardGenerator,
+    DatabaseService databaseService,
+    LocalisationService localisationService,
+    ConfigServer configServer,
+    RandomUtil randomUtil,
+    MathUtil mathUtil,
+    HashUtil hashUtil
+    ) : IRepeatableQuestGenerator
+{
+    protected record LocationInfo(
+        ELocationName LocationName,
+        List<string> LocationTarget,
+        bool RequiresSpecificExtract,
+        int NumOfExtractsRequired
+        );
+
+    protected QuestConfig QuestConfig = configServer.GetConfig<QuestConfig>();
+
+    /// <summary>
+    ///     Generates a valid Exploration quest
+    /// </summary>
+    /// <param name="sessionId">session id for the quest</param>
+    /// <param name="pmcLevel">player's level for reward generation</param>
+    /// <param name="traderId">trader from which the quest will be provided</param>
+    /// <param name="questTypePool">Pools for quests (used to avoid redundant quests)</param>
+    /// <param name="repeatableConfig">
+    ///     The configuration for the repeatably kind (daily, weekly) as configured in QuestConfig
+    ///     for the requested quest
+    /// </param>
+    /// <returns>object of quest type format for "Exploration" (see assets/database/templates/repeatableQuests.json)</returns>
+    public RepeatableQuest? Generate(
+        string sessionId,
+        int pmcLevel,
+        string traderId,
+        QuestTypePool questTypePool,
+        RepeatableQuestConfig repeatableConfig
+    )
+    {
+        var explorationConfig = repeatableConfig.QuestConfig.Exploration;
+
+        // Try and get a location to generate for
+        if (!TryGetLocationInfo(repeatableConfig, explorationConfig, questTypePool, out var locationInfo)
+            || locationInfo is null)
+        {
+            // TODO - Localize me
+            logger.Warning("Generating exploration repeatable quest failed, no remaining locations available");
+            return null;
+        }
+
+        // Generate the quest template
+        var quest = repeatableQuestHelper.GenerateRepeatableTemplate(
+            RepeatableQuestType.Exploration,
+            traderId,
+            repeatableConfig.Side,
+            sessionId
+        );
+
+        if (quest is null)
+        {
+            // TODO - Localize me
+            logger.Error("Generating quest failed, no quest template available");
+            return null;
+        }
+
+        // Generate the available for finish exit condition
+        if (!TryGenerateAvailableForFinish(quest, locationInfo))
+        {
+            // TODO - Localize me
+            logger.Error($"Generating AvailableForFinish failed for location {locationInfo.LocationName}");
+            return null;
+        }
+
+        // If we require a specific extract requirement, generate it
+        if (locationInfo.RequiresSpecificExtract
+            && !TryGenerateSpecificExtractRequirement(quest, repeatableConfig, locationInfo))
+        {
+            // TODO - Localize me
+            logger.Error($"Generating SpecificExtractRequirement failed for location {locationInfo.LocationName}");
+            return null;
+        }
+
+        // Difficulty for exploration goes from 1 extract to maxExtracts
+        // Difficulty for reward goes from 0.2...1 -> map
+        var difficulty = mathUtil.MapToRange(
+            locationInfo.NumOfExtractsRequired,
+            1,
+            explorationConfig.MaximumExtracts,
+            0.2,
+            1
+        );
+        quest.Rewards = repeatableQuestRewardGenerator.GenerateReward(
+            pmcLevel,
+            difficulty,
+            traderId,
+            repeatableConfig,
+            explorationConfig
+        );
+
+        return quest;
+    }
+
+    /// <summary>
+    ///     Draws a location from the exploration location pool
+    /// </summary>
+    /// <param name="repeatableConfig"></param>
+    /// <param name="explorationConfig"></param>
+    /// <param name="pool">Pool to draw from</param>
+    /// <param name="locationInfo">Location chosen</param>
+    /// <returns>True if location selected, false if no locations remain</returns>
+    protected bool TryGetLocationInfo(
+        RepeatableQuestConfig repeatableConfig,
+        Exploration explorationConfig,
+        QuestTypePool pool,
+        out LocationInfo? locationInfo)
+    {
+        if (pool.Pool?.Exploration?.Locations?.Count is null or 0)
+        {
+            // there are no more locations left for exploration; delete it as a possible quest type
+            pool.Types = pool.Types?.Where(t => t != "Exploration").ToList();
+            locationInfo = null;
+            return false;
+        }
+
+        // If location drawn is factory, it's possible to either get factory4_day and factory4_night use index 0,
+        // as the key is factory4_day
+        var locationKey = randomUtil.DrawRandomFromDict(pool.Pool.Exploration.Locations)[
+            0
+        ];
+
+        // Make the location info object
+        var locationTarget = pool.Pool!.Exploration!.Locations![locationKey];
+
+        var requiresSpecificExtract =
+            randomUtil.GetChance100(repeatableConfig.QuestConfig.Exploration.SpecificExits.Chance);
+
+        var numExtracts = GetNumberOfExits(explorationConfig, requiresSpecificExtract);
+
+        locationInfo = new LocationInfo(locationKey,  locationTarget.ToList(), requiresSpecificExtract, numExtracts);
+
+        // Remove the location from the available pool
+        pool.Pool.Exploration.Locations.Remove(locationKey);
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Get the number of times the player needs to exit
+    /// </summary>
+    /// <param name="config">Exploration config</param>
+    /// <param name="requiresSpecificExtract">Is this a specific extract</param>
+    /// <returns>Number of exit requirements</returns>
+    protected int GetNumberOfExits(Exploration config, bool requiresSpecificExtract)
+    {
+        // Different max extract count when specific extract needed
+        var exitTimesMax = requiresSpecificExtract
+            ? config.MaximumExtractsWithSpecificExit
+            : config.MaximumExtracts + 1;
+
+        return randomUtil.RandInt(1, exitTimesMax);
+    }
+
+    /// <summary>
+    ///     Filter a maps exits to just those for the desired side
+    /// </summary>
+    /// <param name="locationKey">Map id (e.g. factory4_day)</param>
+    /// <param name="playerGroup">Pmc/Scav</param>
+    /// <returns>List of Exit objects</returns>
+    protected List<Exit>? GetLocationExitsForSide(string locationKey, PlayerGroup playerGroup)
+    {
+        var mapExtracts = databaseService.GetLocation(locationKey.ToLower())?.AllExtracts;
+
+        return mapExtracts?.Where(exit => exit.Side == Enum.GetName(playerGroup)).ToList();
+    }
+
+    /// <summary>
+    ///     Generate the initial available for finish condition
+    /// </summary>
+    /// <param name="quest">quest to add the condition to</param>
+    /// <param name="locationInfo">LocationInfo object with the generated data</param>
+    /// <returns>True if generated, false if not</returns>
+    protected bool TryGenerateAvailableForFinish(RepeatableQuest quest, LocationInfo locationInfo)
+    {
+        // This should never be hit, this is here to shut the compiler up.
+        if (quest.Conditions.AvailableForFinish?[0].Counter is null)
+        {
+            logger.Error("Counter is null, something has gone terribly wrong");
+            return false;
+        }
+
+        // Lookup the location
+        var location = repeatableQuestHelper.GetQuestLocationByMapId(locationInfo.LocationName.ToString());
+
+        if (location is null)
+        {
+            // TODO - Localize me
+            logger.Error($"Unable to get locationId for {locationInfo.LocationName}");
+            return false;
+        }
+
+        var exitStatusCondition = new QuestConditionCounterCondition
+        {
+            Id = hashUtil.Generate(),
+            DynamicLocale = true,
+            Status = ["Survived"],
+            ConditionType = "ExitStatus",
+        };
+
+        var locationCondition = new QuestConditionCounterCondition
+        {
+            Id = hashUtil.Generate(),
+            DynamicLocale = true,
+            Target = new ListOrT<string>(locationInfo.LocationTarget, null),
+            ConditionType = "Location",
+        };
+
+        quest.Conditions.AvailableForFinish![0].Counter!.Id = hashUtil.Generate();
+        quest.Conditions.AvailableForFinish![0].Counter!.Conditions =
+        [
+            exitStatusCondition,
+            locationCondition,
+        ];
+        quest.Conditions.AvailableForFinish[0].Value = locationInfo.NumOfExtractsRequired;
+        quest.Conditions.AvailableForFinish[0].Id = hashUtil.Generate();
+
+
+
+        quest.Location = location;
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Adds a specific extract requirement to the quest
+    /// </summary>
+    /// <param name="quest">quest to add it to</param>
+    /// <param name="repeatableConfig">repeatable config</param>
+    /// <param name="locationInfo">LocationInfo object with the generated data</param>
+    /// <returns>True if generated, false if not</returns>
+    protected bool TryGenerateSpecificExtractRequirement(RepeatableQuest quest, RepeatableQuestConfig repeatableConfig, LocationInfo locationInfo)
+    {
+        // Fetch extracts for the requested side
+        var mapExits = GetLocationExitsForSide(locationInfo.LocationName.ToString(), repeatableConfig.Side);
+
+        if (mapExits is null)
+        {
+            // TODO: Localize me
+            logger.Error($"Unable to get location list for location {locationInfo.LocationName}");
+            return false;
+        }
+
+        // Only get exits that have a greater than 0% chance to spawn
+        var exitPool = mapExits.Where(exit => exit.Chance > 0).ToList();
+
+        // Exclude exits with a requirement to leave (e.g. car extracts)
+        var possibleExits = exitPool
+            .Where(exit =>
+                exit.PassageRequirement is not null
+                || repeatableConfig.QuestConfig.Exploration.SpecificExits.PassageRequirementWhitelist.Contains(
+                    "PassageRequirement"
+                )
+            )
+            .ToList();
+
+        if (possibleExits.Count == 0)
+        {
+            // TODO - Localize me!
+            logger.Error(
+                $"Unable to choose specific exit on map: {locationInfo.LocationName}, Possible exit pool was empty"
+            );
+
+            return false;
+        }
+
+        // Choose one of the exits we filtered above
+        var chosenExit = randomUtil.DrawRandomFromList(possibleExits)[0];
+
+        // Create a quest condition to leave raid via chosen exit
+        var exitCondition = GenerateQuestConditionCounter(chosenExit);
+        quest.Conditions.AvailableForFinish![0].Counter!.Conditions!.Add(exitCondition);
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Exploration repeatable quests can specify a required extraction point.
+    ///     This method creates the according object which will be appended to the conditions list
+    /// </summary>
+    /// <param name="exit">The exit name to generate the condition for</param>
+    /// <returns>Exit condition</returns>
+    protected QuestConditionCounterCondition GenerateQuestConditionCounter(Exit exit)
+    {
+        return new QuestConditionCounterCondition
+        {
+            Id = hashUtil.Generate(),
+            DynamicLocale = true,
+            ExitName = exit.Name,
+            ConditionType = "ExitName",
+        };
+    }
+}

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/IRepeatableQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/IRepeatableQuestGenerator.cs
@@ -1,0 +1,16 @@
+﻿using SPTarkov.Server.Core.Models.Eft.Common.Tables;
+using SPTarkov.Server.Core.Models.Spt.Config;
+using SPTarkov.Server.Core.Models.Spt.Repeatable;
+
+namespace SPTarkov.Server.Core.Generators.RepeatableQuestGeneration;
+
+public interface IRepeatableQuestGenerator
+{
+    public RepeatableQuest? Generate(
+        string sessionId,
+        int pmcLevel,
+        string traderId,
+        QuestTypePool questTypePool,
+        RepeatableQuestConfig repeatableConfig
+        );
+}

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/PickupQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/PickupQuestGenerator.cs
@@ -1,0 +1,87 @@
+﻿using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.Helpers;
+using SPTarkov.Server.Core.Models.Eft.Common.Tables;
+using SPTarkov.Server.Core.Models.Enums;
+using SPTarkov.Server.Core.Models.Spt.Config;
+using SPTarkov.Server.Core.Models.Spt.Repeatable;
+using SPTarkov.Server.Core.Models.Utils;
+using SPTarkov.Server.Core.Services;
+using SPTarkov.Server.Core.Utils;
+using SPTarkov.Server.Core.Utils.Json;
+
+namespace SPTarkov.Server.Core.Generators.RepeatableQuestGeneration;
+
+[Injectable]
+public class PickupQuestGenerator(
+    ISptLogger<PickupQuestGenerator> logger,
+    RepeatableQuestHelper repeatableQuestHelper,
+    RepeatableQuestRewardGenerator repeatableQuestRewardGenerator,
+    DatabaseService databaseService,
+    LocalisationService localisationService,
+    RandomUtil randomUtil,
+    MathUtil mathUtil,
+    HashUtil hashUtil
+) : IRepeatableQuestGenerator
+{
+
+    // TODO: This isn't really implemented well at all, what even is this.
+    public RepeatableQuest? Generate(
+        string sessionId,
+        int pmcLevel,
+        string traderId,
+        QuestTypePool questTypePool,
+        RepeatableQuestConfig repeatableConfig)
+    {
+        var pickupConfig = repeatableConfig.QuestConfig.Pickup;
+
+        var quest = repeatableQuestHelper.GenerateRepeatableTemplate(
+            RepeatableQuestType.Pickup,
+            traderId,
+            repeatableConfig.Side,
+            sessionId
+        );
+
+        var itemTypeToFetchWithCount = randomUtil.GetArrayValue(
+            pickupConfig.ItemTypeToFetchWithMaxCount
+        );
+
+        var itemCountToFetch = randomUtil.RandInt(
+            itemTypeToFetchWithCount.MinimumPickupCount.Value,
+            itemTypeToFetchWithCount.MaximumPickupCount + 1
+        );
+        // Choose location - doesn't seem to work for anything other than 'any'
+        // var locationKey: string = this.randomUtil.drawRandomFromDict(questTypePool.pool.Pickup.locations)[0];
+        // var locationTarget = questTypePool.pool.Pickup.locations[locationKey];
+
+        var findCondition = quest.Conditions.AvailableForFinish.FirstOrDefault(x =>
+            x.ConditionType == "FindItem"
+        );
+        findCondition.Target = new ListOrT<string>([itemTypeToFetchWithCount.ItemType], null);
+        findCondition.Value = itemCountToFetch;
+
+        var counterCreatorCondition = quest.Conditions.AvailableForFinish.FirstOrDefault(x =>
+            x.ConditionType == "CounterCreator"
+        );
+        // var locationCondition = counterCreatorCondition._props.counter.conditions.find(x => x._parent === "Location");
+        // (locationCondition._props as ILocationConditionProps).target = [...locationTarget];
+
+        var equipmentCondition = counterCreatorCondition.Counter.Conditions.FirstOrDefault(x =>
+            x.ConditionType == "Equipment"
+        );
+        equipmentCondition.EquipmentInclusive =
+        [
+            [itemTypeToFetchWithCount.ItemType],
+        ];
+
+        // Add rewards
+        quest.Rewards = repeatableQuestRewardGenerator.GenerateReward(
+            pmcLevel,
+            1,
+            traderId,
+            repeatableConfig,
+            pickupConfig
+        );
+
+        return quest;
+    }
+}

--- a/Libraries/SPTarkov.Server.Core/Helpers/RepeatableQuestHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RepeatableQuestHelper.cs
@@ -19,7 +19,7 @@ public class RepeatableQuestHelper(
     ConfigServer configServer
 )
 {
-    protected QuestConfig _questConfig = configServer.GetConfig<QuestConfig>();
+    protected QuestConfig QuestConfig = configServer.GetConfig<QuestConfig>();
 
     /// <summary>
     ///     Get the relevant elimination config based on the current players PMC level
@@ -45,7 +45,7 @@ public class RepeatableQuestHelper(
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     public Dictionary<string, string> GetRepeatableQuestTemplatesByGroup(PlayerGroup playerGroup)
     {
-        var templates = _questConfig.RepeatableQuestTemplates;
+        var templates = QuestConfig.RepeatableQuestTemplates;
 
         return playerGroup switch
         {
@@ -195,5 +195,22 @@ public class RepeatableQuestHelper(
         questData.QuestStatus.QId = questData.Id; // Needs to match quest id
 
         return questData;
+    }
+
+    /// <summary>
+    ///     Convert a raw location string into a location code can read (e.g. factory4_day into 55f2d3fd4bdc2d5f408b4567)
+    /// </summary>
+    /// <param name="locationKey">e.g. factory4_day</param>
+    /// <returns>guid</returns>
+    public string? GetQuestLocationByMapId(string locationKey)
+    {
+        if (!QuestConfig.LocationIdMap.TryGetValue(locationKey, out var locationId))
+        {
+            // TODO - localize me!
+            logger.Error($"No location in LocationIdMap found for key {locationKey}");
+            return null;
+        }
+
+        return locationId;
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/QuestConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/QuestConfig.cs
@@ -406,8 +406,8 @@ public record SpecificExits
     /// <summary>
     ///     Chance that an operational task is generated with a specific extract
     /// </summary>
-    [JsonPropertyName("probability")]
-    public required double Probability { get; set; }
+    [JsonPropertyName("chance")]
+    public required double Chance { get; set; }
 
     /// <summary>
     ///     Whitelist of specific extract types

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Repeatable/QuestTypePool.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Repeatable/QuestTypePool.cs
@@ -9,10 +9,10 @@ public record QuestTypePool
     public Dictionary<string, object> ExtensionData { get; set; }
 
     [JsonPropertyName("types")]
-    public List<string>? Types { get; set; }
+    public required List<string> Types { get; set; }
 
     [JsonPropertyName("pool")]
-    public QuestPool? Pool { get; set; }
+    public required QuestPool Pool { get; set; }
 }
 
 public record QuestPool
@@ -21,13 +21,13 @@ public record QuestPool
     public Dictionary<string, object> ExtensionData { get; set; }
 
     [JsonPropertyName("Exploration")]
-    public ExplorationPool? Exploration { get; set; }
+    public required ExplorationPool Exploration { get; set; }
 
     [JsonPropertyName("Elimination")]
-    public EliminationPool? Elimination { get; set; }
+    public required EliminationPool Elimination { get; set; }
 
     [JsonPropertyName("Pickup")]
-    public ExplorationPool? Pickup { get; set; }
+    public required ExplorationPool Pickup { get; set; }
 }
 
 public record ExplorationPool


### PR DESCRIPTION
Continuation of part 1. This should be the last massive diff, everything is now in its proper place.

All changes tested with initial generation and replacements.

- Breaks apart remaining code into components
- `Exploration` generation code is the only code that has had changes, rest has only been moved for now.
- Improves error handling of `Exploration` generation code
- Broke out `Exploration` code into methods for readability and error handling
- Add new `GetQuestLocationByMapId()` method in the helper class
- Add new `IRepeatableQuestGenerator` interface that should be implemented by any repeatable quest generators. Provides a way to know what data is needed to generate a repeatable quest.
- Improve null-ability of `QuestTypePool`
- Rename `Probabilty` property to `Chance` and adjusted to use `GetChance100()`