### PR TITLE
added a random chance infected to be present

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/seasonalevents.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/seasonalevents.json
@@ -9691,14 +9691,14 @@
             "Sandbox": 5,
             "factory4": 5,
             "laboratory": 100,
-			"Woods": 5,
-			"bigmap": 5,
-			"Shoreline": 5,
-			"Interchange": 5,
-			"RezervBase": 5,
-			"laboratory": 5,
-			"Lighthouse": 5,
-			"TarkovStreets": 5
+            "Woods": 5,
+            "bigmap": 5,
+            "Shoreline": 5,
+            "Interchange": 5,
+            "RezervBase": 5,
+            "laboratory": 5,
+            "Lighthouse": 5,
+            "TarkovStreets": 5
           }
         }
       },


### PR DESCRIPTION
Right now data for whether or not infected in present in map come from dumps from BSG.

Added a chance percent where the bottom is the configured value and the top is 100. This will result in a random chance that infected will be present / not present in the map.

See discussion in https://github.com/sp-tarkov/server-csharp/issues/382