### PR TITLE
Handle ToLower neutrally across all locales (#412)

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Callbacks/BotCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/BotCallbacks.cs
@@ -30,7 +30,7 @@ public class BotCallbacks(BotController _botController, HttpResponseUtil _httpRe
     public ValueTask<string> GetBotDifficulty(string url, EmptyRequestData _, string sessionID)
     {
         var splitUrl = url.Split('/');
-        var type = splitUrl[^2].ToLower();
+        var type = splitUrl[^2].ToLowerInvariant();
         var difficulty = splitUrl[^1];
         if (difficulty == "core")
         {

--- a/Libraries/SPTarkov.Server.Core/Controllers/BotController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/BotController.cs
@@ -88,7 +88,7 @@ public class BotController(
         bool ignoreRaidSettings = false
     )
     {
-        var difficulty = diffLevel.ToLower();
+        var difficulty = diffLevel.ToLowerInvariant();
 
         var raidConfig = _profileActivityService
             .GetProfileActivityRaidData(sessionId)
@@ -107,7 +107,7 @@ public class BotController(
         // Check value chosen in pre-raid difficulty dropdown
         // If value is not 'asonline', change requested difficulty to be what was chosen in dropdown
         var botDifficultyDropDownValue =
-            raidConfig?.WavesSettings?.BotDifficulty?.ToString().ToLower() ?? "asonline";
+            raidConfig?.WavesSettings?.BotDifficulty?.ToString().ToLowerInvariant() ?? "asonline";
         if (botDifficultyDropDownValue != "asonline")
         {
             difficulty = _botDifficultyHelper.ConvertBotDifficultyDropdownToBotDifficulty(
@@ -138,8 +138,8 @@ public class BotController(
         {
             // If bot is usec/bear, swap to different name
             var botTypeLower = botType.IsPmc()
-                ? (botType.GetPmcSideByRole() ?? "usec").ToLower()
-                : botType.ToString().ToLower();
+                ? (botType.GetPmcSideByRole() ?? "usec").ToLowerInvariant()
+                : botType.ToString().ToLowerInvariant();
 
             // Get details from db
             if (!botTypesDb.TryGetValue(botTypeLower, out var botDetails))
@@ -165,7 +165,7 @@ public class BotController(
                 continue;
             }
 
-            var botNameKey = botType.ToString().ToLower();
+            var botNameKey = botType.ToString().ToLowerInvariant();
             foreach (var (difficultyName, _) in botDetails.BotDifficulty)
             {
                 // Bot doesn't exist in result, add
@@ -378,7 +378,7 @@ public class BotController(
     protected MinMax<int> GetPmcLevelRangeForMap(string? location)
     {
         return _pmcConfig.LocationSpecificPmcLevelOverride!.GetValueOrDefault(
-            location?.ToLower() ?? "",
+            location?.ToLowerInvariant() ?? "",
             null
         );
     }
@@ -430,7 +430,7 @@ public class BotController(
     /// <returns>bot cap for map</returns>
     public int GetBotCap(string location)
     {
-        if (!_botConfig.MaxBotCap.TryGetValue(location.ToLower(), out var maxCap))
+        if (!_botConfig.MaxBotCap.TryGetValue(location.ToLowerInvariant(), out var maxCap))
         {
             return _botConfig.MaxBotCap["default"];
         }
@@ -440,7 +440,7 @@ public class BotController(
             _logger.Warning(
                 _serverLocalisationService.GetText(
                     "bot-no_bot_cap_found_for_location",
-                    location.ToLower()
+                    location.ToLowerInvariant()
                 )
             );
         }

--- a/Libraries/SPTarkov.Server.Core/Controllers/InsuranceController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/InsuranceController.cs
@@ -872,7 +872,7 @@ public class InsuranceController(
     {
         var softInsertSlots = pmcData.Inventory.Items.Where(item =>
             item.ParentId == itemWithSoftInserts.Id
-            && _itemHelper.IsSoftInsertId(item.SlotId.ToLower())
+            && _itemHelper.IsSoftInsertId(item.SlotId.ToLowerInvariant())
         );
 
         foreach (var softInsertSlot in softInsertSlots)

--- a/Libraries/SPTarkov.Server.Core/Controllers/LauncherController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/LauncherController.cs
@@ -168,7 +168,7 @@ public class LauncherController(
         var timeStampStr = Convert.ToString(timeStamp, 16).PadLeft(8, '0');
         var counterStr = Convert.ToString(counter, 16).PadLeft(16, '0');
 
-        return timeStampStr.ToLower() + counterStr.ToLower();
+        return timeStampStr.ToLowerInvariant() + counterStr.ToLowerInvariant();
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Controllers/LauncherV2Controller.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/LauncherV2Controller.cs
@@ -196,7 +196,7 @@ public class LauncherV2Controller(
         var timeStampStr = Convert.ToString(timeStamp, 16).PadLeft(8, '0');
         var counterStr = Convert.ToString(counter, 16).PadLeft(16, '0');
 
-        return timeStampStr.ToLower() + counterStr.ToLower();
+        return timeStampStr.ToLowerInvariant() + counterStr.ToLowerInvariant();
     }
 
     protected string? GetSessionId(LoginRequestData info)

--- a/Libraries/SPTarkov.Server.Core/Controllers/ProfileController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/ProfileController.cs
@@ -171,7 +171,7 @@ public class ProfileController(
             var pmcData = _profileHelper.GetPmcProfile(sessionId);
 
             pmcData.Info.Nickname = request.Nickname;
-            pmcData.Info.LowerNickname = request.Nickname.ToLower();
+            pmcData.Info.LowerNickname = request.Nickname.ToLowerInvariant();
         }
 
         return output;
@@ -207,7 +207,7 @@ public class ProfileController(
         foreach (var profile in allProfiles)
         {
             var pmcProfile = profile?.CharacterData?.PmcData;
-            if (!pmcProfile?.Info?.LowerNickname?.Contains(request.Nickname.ToLower()) ?? false)
+            if (!pmcProfile?.Info?.LowerNickname?.Contains(request.Nickname.ToLowerInvariant()) ?? false)
             {
                 continue;
             }

--- a/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
@@ -137,7 +137,7 @@ public class RepeatableQuestController(
         }
 
         // Subtype name of quest - daily/weekly/scav
-        var repeatableTypeLower = repeatablesOfTypeInProfile.Name.ToLower();
+        var repeatableTypeLower = repeatablesOfTypeInProfile.Name.ToLowerInvariant();
 
         // Save for later standing loss calculation
         var replacedQuestTraderId = questToReplace.TraderId;
@@ -575,7 +575,7 @@ public class RepeatableQuestController(
                 repeatableConfig,
                 pmcData
             );
-            var repeatableTypeLower = repeatableConfig.Name.ToLower();
+            var repeatableTypeLower = repeatableConfig.Name.ToLowerInvariant();
 
             var canAccessRepeatables = CanProfileAccessRepeatableQuests(repeatableConfig, pmcData);
             if (!canAccessRepeatables)

--- a/Libraries/SPTarkov.Server.Core/Extensions/FullProfileExtensions.cs
+++ b/Libraries/SPTarkov.Server.Core/Extensions/FullProfileExtensions.cs
@@ -158,7 +158,7 @@ namespace SPTarkov.Server.Core.Extensions
             }
 
             // Dev profile additions
-            if (fullProfile.ProfileInfo.Edition.ToLower().Contains("developer"))
+            if (fullProfile.ProfileInfo.Edition.ToLowerInvariant().Contains("developer"))
             // CyberTark background
             {
                 fullProfile.CustomisationUnlocks.Add(
@@ -185,7 +185,7 @@ namespace SPTarkov.Server.Core.Extensions
 
             // Edge case - profile not created yet, fall back to what launcher has set
             var launcherEdition = fullProfile.ProfileInfo.Edition;
-            switch (launcherEdition.ToLower())
+            switch (launcherEdition.ToLowerInvariant())
             {
                 case "edge of darkness":
                     return GameEditions.EDGE_OF_DARKNESS;

--- a/Libraries/SPTarkov.Server.Core/Generators/BotEquipmentModGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotEquipmentModGenerator.cs
@@ -174,12 +174,12 @@ public class BotEquipmentModGenerator(
             // Slot can hold armor plates + we are filtering possible items by bot level, handle
             if (
                 settings.BotEquipmentConfig.FilterPlatesByLevel.GetValueOrDefault(false)
-                && _itemHelper.IsRemovablePlateSlot(modSlotName.ToLower())
+                && _itemHelper.IsRemovablePlateSlot(modSlotName.ToLowerInvariant())
             )
             {
                 var plateSlotFilteringOutcome = FilterPlateModsForSlotByLevel(
                     settings,
-                    modSlotName.ToLower(),
+                    modSlotName.ToLowerInvariant(),
                     compatibleModsPool.GetValueOrDefault(modSlotName),
                     parentTemplate
                 );
@@ -889,7 +889,7 @@ public class BotEquipmentModGenerator(
     /// <returns>true if it can hold a scope</returns>
     public bool ModSlotCanHoldScope(string modSlot, string modsParentId)
     {
-        return _scopeIds.Contains(modSlot.ToLower()) && modsParentId == BaseClasses.MOUNT;
+        return _scopeIds.Contains(modSlot.ToLowerInvariant()) && modsParentId == BaseClasses.MOUNT;
     }
 
     /// <summary>
@@ -932,7 +932,7 @@ public class BotEquipmentModGenerator(
     /// <returns>True if modSlot can have muzzle-related items</returns>
     public bool ModSlotCanHoldMuzzleDevices(string modSlot, string? modsParentId)
     {
-        return _muzzleIds.Contains(modSlot.ToLower());
+        return _muzzleIds.Contains(modSlot.ToLowerInvariant());
     }
 
     /// <summary>
@@ -1057,7 +1057,7 @@ public class BotEquipmentModGenerator(
     /// <returns>Slot item</returns>
     public Slot? GetModItemSlotFromDb(string modSlot, TemplateItem parentTemplate)
     {
-        var modSlotLower = modSlot.ToLower();
+        var modSlotLower = modSlot.ToLowerInvariant();
         switch (modSlotLower)
         {
             case "patron_in_weapon":
@@ -1100,7 +1100,7 @@ public class BotEquipmentModGenerator(
         }
 
         var spawnMod = _randomUtil.RollChance(
-            modSpawnChances.GetValueOrDefault(modSlotName.ToLower())
+            modSpawnChances.GetValueOrDefault(modSlotName.ToLowerInvariant())
         );
         if (
             !spawnMod
@@ -1556,8 +1556,8 @@ public class BotEquipmentModGenerator(
         var parentSlotCompatibleItems = request
             .ParentTemplate.Properties.Slots?.FirstOrDefault(slot =>
                 string.Equals(
-                    slot.Name.ToLower(),
-                    request.ModSlot.ToLower(),
+                    slot.Name.ToLowerInvariant(),
+                    request.ModSlot.ToLowerInvariant(),
                     StringComparison.Ordinal
                 )
             )

--- a/Libraries/SPTarkov.Server.Core/Generators/BotGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotGenerator.cs
@@ -188,7 +188,7 @@ public class BotGenerator(
         BotGenerationDetails botGenerationDetails
     )
     {
-        var botRoleLowercase = botGenerationDetails.Role.ToLower();
+        var botRoleLowercase = botGenerationDetails.Role.ToLowerInvariant();
         var botLevel = _botLevelGenerator.GenerateBotLevel(
             botJsonTemplate.BotExperience.Level,
             botGenerationDetails,
@@ -215,7 +215,7 @@ public class BotGenerator(
 
         // Only Pmcs should have a lower nickname
         bot.Info.LowerNickname = botGenerationDetails.IsPmc.GetValueOrDefault(false)
-            ? bot.Info.Nickname.ToLower()
+            ? bot.Info.Nickname.ToLowerInvariant()
             : string.Empty;
 
         // Only run when generating a 'fake' playerscav, not actual player scav
@@ -351,7 +351,7 @@ public class BotGenerator(
         string role
     )
     {
-        if (!experiences.TryGetValue(botDifficulty.ToLower(), out var result))
+        if (!experiences.TryGetValue(botDifficulty.ToLowerInvariant(), out var result))
         {
             if (_logger.IsLogEnabled(LogLevel.Debug))
             {
@@ -386,7 +386,7 @@ public class BotGenerator(
         string role
     )
     {
-        if (!standingsForKill.TryGetValue(botDifficulty.ToLower(), out var result))
+        if (!standingsForKill.TryGetValue(botDifficulty.ToLowerInvariant(), out var result))
         {
             _logger.Warning(
                 $"Unable to find standing for kill value for: {role} {botDifficulty}, falling back to `normal`"
@@ -411,7 +411,7 @@ public class BotGenerator(
         string role
     )
     {
-        if (!aggressorBonuses.TryGetValue(botDifficulty.ToLower(), out var result))
+        if (!aggressorBonuses.TryGetValue(botDifficulty.ToLowerInvariant(), out var result))
         {
             _logger.Warning(
                 $"Unable to find aggressor bonus for kill value for: {role} {botDifficulty}, falling back to `normal`"

--- a/Libraries/SPTarkov.Server.Core/Generators/BotLootGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotLootGenerator.cs
@@ -115,7 +115,7 @@ public class BotLootGenerator(
         var grenadeCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Grenades.Weights);
 
         // If bot has been flagged as not having loot, set below counts to 0
-        if (_botConfig.DisableLootOnBotTypes.Contains(botRole.ToLower()))
+        if (_botConfig.DisableLootOnBotTypes.Contains(botRole.ToLowerInvariant()))
         {
             backpackLootCount = 0;
             pocketLootCount = 0;
@@ -945,9 +945,9 @@ public class BotLootGenerator(
             return _botConfig.ItemSpawnLimits["pmc"];
         }
 
-        if (_botConfig.ItemSpawnLimits.ContainsKey(botRole.ToLower()))
+        if (_botConfig.ItemSpawnLimits.ContainsKey(botRole.ToLowerInvariant()))
         {
-            return _botConfig.ItemSpawnLimits[botRole.ToLower()];
+            return _botConfig.ItemSpawnLimits[botRole.ToLowerInvariant()];
         }
 
         _logger.Warning(

--- a/Libraries/SPTarkov.Server.Core/Generators/LocationLootGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/LocationLootGenerator.cs
@@ -58,7 +58,7 @@ public class LocationLootGenerator(
 
         // Pull location-specific spawn limits from db
         var itemsWithSpawnCountLimitsClone = _cloner.Clone(
-            _locationConfig.LootMaxSpawnLimits.GetValueOrDefault(locationId.ToLower())
+            _locationConfig.LootMaxSpawnLimits.GetValueOrDefault(locationId.ToLowerInvariant())
         );
 
         // Store items with spawn count limits inside so they can be accessed later inside static/dynamic loot spawn methods
@@ -68,13 +68,13 @@ public class LocationLootGenerator(
         }
 
         // Create containers with loot
-        result.AddRange(GenerateStaticContainers(locationId.ToLower(), staticAmmoDist));
+        result.AddRange(GenerateStaticContainers(locationId.ToLowerInvariant(), staticAmmoDist));
 
         // Add dynamic loot to output loot
         var dynamicSpawnPoints = GenerateDynamicLoot(
             _cloner.Clone(locationDetails.LooseLoot.Value),
             staticAmmoDist,
-            locationId.ToLower()
+            locationId.ToLowerInvariant()
         );
 
         // Merge dynamic spawns into result

--- a/Libraries/SPTarkov.Server.Core/Generators/PlayerScavGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/PlayerScavGenerator.cs
@@ -80,7 +80,7 @@ public class PlayerScavGenerator(
 
         var scavData = _botGenerator.GeneratePlayerScav(
             sessionID,
-            playerScavKarmaSettings.BotTypeForLoot.ToLower(),
+            playerScavKarmaSettings.BotTypeForLoot.ToLowerInvariant(),
             "easy",
             baseBotNode,
             pmcDataClone

--- a/Libraries/SPTarkov.Server.Core/Generators/PmcWaveGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/PmcWaveGenerator.cs
@@ -58,7 +58,7 @@ public class PmcWaveGenerator(
     /// <param name="location"> Location Object </param>
     public void ApplyWaveChangesToMap(LocationBase location)
     {
-        if (!_pmcConfig.CustomPmcWaves.TryGetValue(location.Id.ToLower(), out var pmcWavesToAdd))
+        if (!_pmcConfig.CustomPmcWaves.TryGetValue(location.Id.ToLowerInvariant(), out var pmcWavesToAdd))
         {
             return;
         }

--- a/Libraries/SPTarkov.Server.Core/Generators/RagfairOfferGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RagfairOfferGenerator.cs
@@ -495,7 +495,7 @@ public class RagfairOfferGenerator(
         }
 
         var plateSlots = presetWithChildren
-            .Where(item => itemHelper.GetRemovablePlateSlotIds().Contains(item.SlotId?.ToLower()))
+            .Where(item => itemHelper.GetRemovablePlateSlotIds().Contains(item.SlotId?.ToLowerInvariant()))
             .ToList();
         if (plateSlots.Count == 0)
         // Has no plate slots e.g. "front_plate", exit
@@ -507,7 +507,7 @@ public class RagfairOfferGenerator(
         foreach (var plateSlot in plateSlots)
         {
             var plateDetails = itemHelper.GetItem(plateSlot.Template).Value;
-            if (plateSettings.IgnoreSlots.Contains(plateSlot.SlotId.ToLower()))
+            if (plateSettings.IgnoreSlots.Contains(plateSlot.SlotId.ToLowerInvariant()))
             {
                 continue;
             }
@@ -631,7 +631,7 @@ public class RagfairOfferGenerator(
         }
 
         var offerItemPlatesToRemove = itemWithChildren.Where(item =>
-            armorConfig.PlateSlotIdToRemovePool.Contains(item.SlotId?.ToLower())
+            armorConfig.PlateSlotIdToRemovePool.Contains(item.SlotId?.ToLowerInvariant())
         );
 
         // Latest first, to ensure we don't move later items off by 1 each time we remove an item below it

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
@@ -211,7 +211,7 @@ public class ExplorationQuestGenerator(
     /// <returns>List of Exit objects</returns>
     protected List<Exit>? GetLocationExitsForSide(string locationKey, PlayerGroup playerGroup)
     {
-        var mapExtracts = databaseService.GetLocation(locationKey.ToLower())?.AllExtracts;
+        var mapExtracts = databaseService.GetLocation(locationKey.ToLowerInvariant())?.AllExtracts;
 
         return mapExtracts?.Where(exit => exit.Side == Enum.GetName(playerGroup)).ToList();
     }

--- a/Libraries/SPTarkov.Server.Core/Helpers/BotDifficultyHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/BotDifficultyHelper.cs
@@ -37,8 +37,8 @@ public class BotDifficultyHelper(
     )
     {
         var desiredType = _botHelper.IsBotPmc(type)
-            ? _botHelper.GetPmcSideByRole(type).ToLower()
-            : type.ToLower();
+            ? _botHelper.GetPmcSideByRole(type).ToLowerInvariant()
+            : type.ToLowerInvariant();
         if (!botDb.Types.ContainsKey(desiredType))
         {
             // No bot found, get fallback difficulty values
@@ -85,7 +85,7 @@ public class BotDifficultyHelper(
             StringComparison.OrdinalIgnoreCase
         )
             ? difficulty
-            : _pmcConfig.Difficulty.ToLower();
+            : _pmcConfig.Difficulty.ToLowerInvariant();
 
         difficultySetting = ConvertBotDifficultyDropdownToBotDifficulty(difficultySetting);
 
@@ -101,14 +101,14 @@ public class BotDifficultyHelper(
     /// <returns>bot difficulty</returns>
     public string ConvertBotDifficultyDropdownToBotDifficulty(string dropDownDifficulty)
     {
-        switch (dropDownDifficulty.ToLower())
+        switch (dropDownDifficulty.ToLowerInvariant())
         {
             case "medium":
                 return "normal";
             case "random":
                 return ChooseRandomDifficulty();
             default:
-                return dropDownDifficulty.ToLower();
+                return dropDownDifficulty.ToLowerInvariant();
         }
     }
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/BotGeneratorHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/BotGeneratorHelper.cs
@@ -37,7 +37,7 @@ public class BotGeneratorHelper(
         EquipmentSlots.ArmBand.ToString(),
     ];
 
-    private static readonly string[] _pmcTypes = [Sides.PmcBear.ToLower(), Sides.PmcUsec.ToLower()];
+    private static readonly string[] _pmcTypes = [Sides.PmcBear.ToLowerInvariant(), Sides.PmcUsec.ToLowerInvariant()];
 
     private readonly BotConfig _botConfig = _configServer.GetConfig<BotConfig>();
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/BotHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/BotHelper.cs
@@ -22,10 +22,10 @@ public class BotHelper(
 {
     private static readonly FrozenSet<string> _pmcTypeIds =
     [
-        Sides.Usec.ToLower(),
-        Sides.Bear.ToLower(),
-        Sides.PmcBear.ToLower(),
-        Sides.PmcUsec.ToLower(),
+        Sides.Usec.ToLowerInvariant(),
+        Sides.Bear.ToLowerInvariant(),
+        Sides.PmcBear.ToLowerInvariant(),
+        Sides.PmcUsec.ToLowerInvariant(),
     ];
 
     private readonly BotConfig _botConfig = _configServer.GetConfig<BotConfig>();
@@ -39,7 +39,7 @@ public class BotHelper(
     /// <returns>BotType object</returns>
     public BotType? GetBotTemplate(string role)
     {
-        if (!_databaseService.GetBots().Types.TryGetValue(role?.ToLower(), out var bot))
+        if (!_databaseService.GetBots().Types.TryGetValue(role?.ToLowerInvariant(), out var bot))
         {
             _logger.Error($"Unable to get bot of type: {role} from DB");
 
@@ -56,7 +56,7 @@ public class BotHelper(
     /// <returns>true if is pmc</returns>
     public bool IsBotPmc(string? botRole)
     {
-        return _pmcTypeIds.Contains(botRole?.ToLower());
+        return _pmcTypeIds.Contains(botRole?.ToLowerInvariant());
     }
 
     public bool IsBotBoss(string botRole)
@@ -135,10 +135,10 @@ public class BotHelper(
     {
         HashSet<string> listToCheck =
         [
-            _pmcConfig.UsecType.ToLower(),
-            _pmcConfig.BearType.ToLower(),
+            _pmcConfig.UsecType.ToLowerInvariant(),
+            _pmcConfig.BearType.ToLowerInvariant(),
         ];
-        return listToCheck.Contains(botRole.ToLower());
+        return listToCheck.Contains(botRole.ToLowerInvariant());
     }
 
     /// <summary>
@@ -227,7 +227,7 @@ public class BotHelper(
             )
             {
                 _logger.Error($"Unknown faction: {chosenFaction} Defaulting to: {Sides.Usec}");
-                chosenFaction = Sides.Usec.ToLower();
+                chosenFaction = Sides.Usec.ToLowerInvariant();
                 chosenFactionDetails = _databaseService.GetBots().Types[chosenFaction];
             }
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/GiveCommand/GiveSptCommand.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/GiveCommand/GiveSptCommand.cs
@@ -157,7 +157,7 @@ public class GiveSptCommand(
                     .Select(i =>
                         localizedGlobal
                             .GetValueOrDefault($"{i.Id} Name", i.Properties.Name)
-                            ?.ToLower()
+                            ?.ToLowerInvariant()
                     )
                     .Where(i => !string.IsNullOrEmpty(i));
 
@@ -210,7 +210,7 @@ public class GiveSptCommand(
                 .GetItems()
                 .Where(IsItemAllowed)
                 .FirstOrDefault(i =>
-                    (localizedGlobal[$"{i?.Id} Name"]?.ToLower() ?? i.Properties.Name) == item
+                    (localizedGlobal[$"{i?.Id} Name"]?.ToLowerInvariant() ?? i.Properties.Name) == item
                 )
                 .Id
             : item;

--- a/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/GiveCommand/StringSimilarity.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/Commando/SptCommands/GiveCommand/StringSimilarity.cs
@@ -14,8 +14,8 @@ public static class StringSimilarity
     {
         if (!caseSensitive)
         {
-            str1 = str1.ToLower();
-            str2 = str2.ToLower();
+            str1 = str1.ToLowerInvariant();
+            str2 = str2.ToLowerInvariant();
         }
 
         if (str1.Length < substringLength || str2.Length < substringLength)

--- a/Libraries/SPTarkov.Server.Core/Helpers/InventoryHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/InventoryHelper.cs
@@ -1303,7 +1303,7 @@ public class InventoryHelper(
         // Reset fast panel value if item was moved to a container other than pocket/rig (cant be used from fastpanel)
         HashSet<string> slots = ["pockets", "tacticalvest"];
         var wasMovedToFastPanelAccessibleContainer = slots.Contains(
-            itemParent?.SlotId?.ToLower() ?? ""
+            itemParent?.SlotId?.ToLowerInvariant() ?? ""
         );
         if (!wasMovedToFastPanelAccessibleContainer)
         {

--- a/Libraries/SPTarkov.Server.Core/Helpers/ItemHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ItemHelper.cs
@@ -359,7 +359,7 @@ public class ItemHelper(
         var itemTemplate = GetItem(itemTpl);
 
         return itemTemplate.Value.Properties.Slots.Any(slot =>
-            _removablePlateSlotIds.Contains(slot.Name.ToLower())
+            _removablePlateSlotIds.Contains(slot.Name.ToLowerInvariant())
         );
     }
 
@@ -390,7 +390,7 @@ public class ItemHelper(
         }
 
         // Check if item has slots that match soft insert name ids
-        if (itemDbDetails.Value.Properties.Slots.Any(slot => IsSoftInsertId(slot.Name.ToLower())))
+        if (itemDbDetails.Value.Properties.Slots.Any(slot => IsSoftInsertId(slot.Name.ToLowerInvariant())))
         {
             return true;
         }
@@ -1782,9 +1782,9 @@ public class ItemHelper(
             if (modSpawnChanceDict is not null && !(slot.Required ?? false))
             {
                 // only roll chance to not include mod if dict exists and has value for this mod type (e.g. front_plate)
-                if (modSpawnChanceDict.ContainsKey(slot.Name.ToLower()))
+                if (modSpawnChanceDict.ContainsKey(slot.Name.ToLowerInvariant()))
                 {
-                    if (!_randomUtil.GetChance100(modSpawnChanceDict[slot.Name.ToLower()]))
+                    if (!_randomUtil.GetChance100(modSpawnChanceDict[slot.Name.ToLowerInvariant()]))
                     {
                         continue;
                     }
@@ -1885,7 +1885,7 @@ public class ItemHelper(
     /// <returns>True if it is a slot that holds a removable plate</returns>
     public bool IsRemovablePlateSlot(string slotName)
     {
-        return GetRemovablePlateSlotIds().Contains(slotName.ToLower());
+        return GetRemovablePlateSlotIds().Contains(slotName.ToLowerInvariant());
     }
 
     // Get a list of slot names that hold removable plates

--- a/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
@@ -123,8 +123,8 @@ public class ProfileHelper(
             && !StringsMatch(p.ProfileInfo.ProfileId, sessionID)
             && // SessionIds dont match
             StringsMatch(
-                p.CharacterData.PmcData.Info.LowerNickname.ToLower(),
-                nicknameRequest.Nickname.ToLower()
+                p.CharacterData.PmcData.Info.LowerNickname.ToLowerInvariant(),
+                nicknameRequest.Nickname.ToLowerInvariant()
             )
         ); // Nicknames do
     }
@@ -564,7 +564,7 @@ public class ProfileHelper(
     public bool IsDeveloperAccount(string sessionID)
     {
         return GetFullProfile(sessionID)
-                ?.ProfileInfo?.Edition?.ToLower()
+                ?.ProfileInfo?.Edition?.ToLowerInvariant()
                 .StartsWith("spt developer") ?? false;
     }
 

--- a/Libraries/SPTarkov.Server.Core/Routers/ImageRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/ImageRouter.cs
@@ -28,7 +28,7 @@ public class ImageRouter
 
     public void AddRoute(string key, string valueToAdd)
     {
-        _imageRouterService.AddRoute(key.ToLower(), valueToAdd);
+        _imageRouterService.AddRoute(key.ToLowerInvariant(), valueToAdd);
     }
 
     public async Task SendImage(string sessionId, HttpRequest req, HttpResponse resp, object body)
@@ -37,7 +37,7 @@ public class ImageRouter
         var url = _fileUtil.StripExtension(req.Path, true);
 
         // Send image
-        var urlKeyLower = url.ToLower();
+        var urlKeyLower = url.ToLowerInvariant();
         if (_imageRouterService.ExistsByKey(urlKeyLower))
         {
             await _httpFileUtil.SendFile(resp, _imageRouterService.GetByKey(urlKeyLower));

--- a/Libraries/SPTarkov.Server.Core/Services/BotEquipmentFilterService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BotEquipmentFilterService.cs
@@ -51,7 +51,7 @@ public class BotEquipmentFilterService(
         );
 
         RandomisationDetails? randomisationDetails = null;
-        if (_botEquipmentConfig.TryGetValue(botRole.ToLower(), out var botEquipmentConfig))
+        if (_botEquipmentConfig.TryGetValue(botRole.ToLowerInvariant(), out var botEquipmentConfig))
         {
             randomisationDetails = botHelper.GetBotRandomizationDetails(
                 botLevel,

--- a/Libraries/SPTarkov.Server.Core/Services/BotGenerationCacheService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BotGenerationCacheService.cs
@@ -115,6 +115,6 @@ public class BotGenerationCacheService(
 
     public string CreateCacheKey(string? role, string? difficulty)
     {
-        return $"{role?.ToLower()}{difficulty?.ToLower()}";
+        return $"{role?.ToLowerInvariant()}{difficulty?.ToLowerInvariant()}";
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Services/BotNameService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BotNameService.cs
@@ -53,7 +53,7 @@ public class BotNameService(
         var showTypeInNickname =
             !botGenerationDetails.IsPlayerScav.GetValueOrDefault(false)
             && _botConfig.ShowTypeInNickname;
-        var roleShouldBeUnique = uniqueRoles?.Contains(botRole.ToLower());
+        var roleShouldBeUnique = uniqueRoles?.Contains(botRole.ToLowerInvariant());
 
         var attempts = 0;
         while (attempts <= 5)

--- a/Libraries/SPTarkov.Server.Core/Services/CreateProfileService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CreateProfileService.cs
@@ -55,7 +55,7 @@ public class CreateProfileService(
         pmcData.Savage = account.ProfileInfo.ScavengerId;
         pmcData.SessionId = sessionId;
         pmcData.Info.Nickname = request.Nickname;
-        pmcData.Info.LowerNickname = request.Nickname.ToLower();
+        pmcData.Info.LowerNickname = request.Nickname.ToLowerInvariant();
         pmcData.Info.RegistrationDate = (int)_timeUtil.GetTimeStamp();
         pmcData.Info.Voice = _databaseService.GetCustomization()[request.VoiceId].Name;
         pmcData.Stats = _profileHelper.GetDefaultCounters();

--- a/Libraries/SPTarkov.Server.Core/Services/DatabaseService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/DatabaseService.cs
@@ -123,7 +123,7 @@ public class DatabaseService(
     /// <returns> assets/database/locations/ </returns>
     public Location? GetLocation(string locationId)
     {
-        var desiredLocation = GetLocations()?.GetByJsonProp<Location>(locationId.ToLower());
+        var desiredLocation = GetLocations()?.GetByJsonProp<Location>(locationId.ToLowerInvariant());
         if (desiredLocation == null)
         {
             _logger.Error(

--- a/Libraries/SPTarkov.Server.Core/Services/FenceService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/FenceService.cs
@@ -1301,7 +1301,7 @@ public class FenceService(
             var modItemToAdjust = armorItemAndMods.FirstOrDefault(mod =>
                 string.Equals(
                     mod.SlotId,
-                    requiredSlot.Name.ToLower(),
+                    requiredSlot.Name.ToLowerInvariant(),
                     StringComparison.OrdinalIgnoreCase
                 )
             );

--- a/Libraries/SPTarkov.Server.Core/Services/LocaleService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/LocaleService.cs
@@ -78,7 +78,7 @@ public class LocaleService(
                 StringComparison.OrdinalIgnoreCase
             )
                 ? GetPlatformForClientLocale()
-                : _localeConfig.GameLocale.ToLower(); // Use custom locale value
+                : _localeConfig.GameLocale.ToLowerInvariant(); // Use custom locale value
         }
 
         return _chosenClientLocale;
@@ -99,7 +99,7 @@ public class LocaleService(
                 StringComparison.OrdinalIgnoreCase
             )
                 ? GetPlatformForServerLocale()
-                : _localeConfig.ServerLocale.ToLower(); // Use custom locale value
+                : _localeConfig.ServerLocale.ToLowerInvariant(); // Use custom locale value
         }
 
         return _chosenServerLocale;
@@ -136,7 +136,7 @@ public class LocaleService(
             return "en";
         }
 
-        var baseNameCode = platformLocale.TwoLetterISOLanguageName.ToLower();
+        var baseNameCode = platformLocale.TwoLetterISOLanguageName.ToLowerInvariant();
         if (_localeConfig.ServerSupportedLocales.Contains(baseNameCode))
         {
             // Found a matching locale
@@ -144,7 +144,7 @@ public class LocaleService(
         }
 
         // Check if base language (e.g. CN / EN / DE) exists
-        var languageCode = platformLocale.Name.ToLower();
+        var languageCode = platformLocale.Name.ToLowerInvariant();
         if (_localeConfig.ServerSupportedLocales.Contains(languageCode))
         {
             if (baseNameCode == "zh")
@@ -183,13 +183,13 @@ public class LocaleService(
         }
 
         var locales = _databaseServer.GetTables().Locales;
-        var baseNameCode = platformLocale.TwoLetterISOLanguageName.ToLower();
+        var baseNameCode = platformLocale.TwoLetterISOLanguageName.ToLowerInvariant();
         if (locales.Global.ContainsKey(baseNameCode))
         {
             return baseNameCode;
         }
 
-        var languageCode = platformLocale.Name.ToLower();
+        var languageCode = platformLocale.Name.ToLowerInvariant();
         if (locales.Global.ContainsKey(languageCode))
         {
             return languageCode;

--- a/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
@@ -446,8 +446,8 @@ public class LocationLifecycleService
         // ServerId has various info stored in it, delimited by a period
         var serverDetails = request.ServerId.Split(".");
 
-        var locationName = serverDetails[0].ToLower();
-        var isPmc = serverDetails[1].ToLower().Contains("pmc");
+        var locationName = serverDetails[0].ToLowerInvariant();
+        var isPmc = serverDetails[1].ToLowerInvariant().Contains("pmc");
         var isDead = IsPlayerDead(request.Results);
         var isTransfer = IsMapToMapTransfer(request.Results);
         var isSurvived = IsPlayerSurvived(request.Results);
@@ -554,7 +554,7 @@ public class LocationLifecycleService
             return false;
         }
 
-        if (extractName.ToLower().Contains("v-ex"))
+        if (extractName.ToLowerInvariant().Contains("v-ex"))
         {
             return true;
         }
@@ -1018,7 +1018,7 @@ public class LocationLifecycleService
         var roles = new List<string> { "pmcbear", "pmcusec" };
 
         var victims = postRaidProfile
-            .Stats.Eft.Victims.Where(victim => roles.Contains(victim.Role.ToLower()))
+            .Stats.Eft.Victims.Where(victim => roles.Contains(victim.Role.ToLowerInvariant()))
             .ToList();
         if (victims?.Count > 0)
         // Player killed PMCs, send some mail responses to them

--- a/Libraries/SPTarkov.Server.Core/Services/PmcChatResponseService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/PmcChatResponseService.cs
@@ -181,7 +181,7 @@ public class PmcChatResponseService(
 
         if (StripCapitalisation(isVictim))
         {
-            responseText = responseText.ToLower();
+            responseText = responseText.ToLowerInvariant();
         }
 
         if (AllCaps(isVictim))

--- a/Libraries/SPTarkov.Server.Core/Services/RaidTimeAdjustmentService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RaidTimeAdjustmentService.cs
@@ -148,7 +148,7 @@ public class RaidTimeAdjustmentService(
     public RaidChanges GetRaidAdjustments(string sessionId, GetRaidTimeRequest request)
     {
         var globals = _databaseService.GetGlobals();
-        var mapBase = _databaseService.GetLocation(request.Location.ToLower()).Base;
+        var mapBase = _databaseService.GetLocation(request.Location.ToLowerInvariant()).Base;
         var baseEscapeTimeMinutes = mapBase.EscapeTimeLimit;
 
         // Prep result object to return
@@ -248,7 +248,7 @@ public class RaidTimeAdjustmentService(
     /// <returns>ScavRaidTimeLocationSettings</returns>
     protected ScavRaidTimeLocationSettings GetMapSettings(string location)
     {
-        var mapSettings = _locationConfig.ScavRaidTimeSettings.Maps?[location.ToLower()];
+        var mapSettings = _locationConfig.ScavRaidTimeSettings.Maps?[location.ToLowerInvariant()];
         if (mapSettings is null)
         {
             _logger.Warning(

--- a/Libraries/SPTarkov.Server.Core/Services/SeasonalEventService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/SeasonalEventService.cs
@@ -387,8 +387,8 @@ public class SeasonalEventService(
         {
             var propInfo = props.FirstOrDefault(p =>
                 string.Equals(
-                    p.Name.ToLower(),
-                    lootContainerKey.ToLower(),
+                    p.Name.ToLowerInvariant(),
+                    lootContainerKey.ToLowerInvariant(),
                     StringComparison.OrdinalIgnoreCase
                 )
             );
@@ -871,7 +871,7 @@ public class SeasonalEventService(
 
     protected void AddEventWavesToMaps(string eventType)
     {
-        var wavesToAddByMap = _seasonalEventConfig.EventWaves[eventType.ToLower()];
+        var wavesToAddByMap = _seasonalEventConfig.EventWaves[eventType.ToLowerInvariant()];
 
         if (wavesToAddByMap is null)
         {
@@ -903,7 +903,7 @@ public class SeasonalEventService(
     {
         if (
             !_seasonalEventConfig.EventBossSpawns.TryGetValue(
-                eventType.ToLower(),
+                eventType.ToLowerInvariant(),
                 out var botsToAddPerMap
             )
         )
@@ -1018,7 +1018,7 @@ public class SeasonalEventService(
         // Iterate over bots with changes to apply
         foreach (var botKvP in botGearChanges)
         {
-            var botToUpdate = _databaseService.GetBots().Types[botKvP.Key.ToLower()];
+            var botToUpdate = _databaseService.GetBots().Types[botKvP.Key.ToLowerInvariant()];
             if (botToUpdate is null)
             {
                 _logger.Warning(
@@ -1068,7 +1068,7 @@ public class SeasonalEventService(
         // Iterate over bots with changes to apply
         foreach (var botKvpP in botLootChanges)
         {
-            var botToUpdate = _databaseService.GetBots().Types[botKvpP.Key.ToLower()];
+            var botToUpdate = _databaseService.GetBots().Types[botKvpP.Key.ToLowerInvariant()];
             if (botToUpdate is null)
             {
                 _logger.Warning(

--- a/Libraries/SPTarkov.Server.Core/Utils/ImporterUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/ImporterUtil.cs
@@ -65,7 +65,9 @@ public class ImporterUtil(ISptLogger<ImporterUtil> _logger, FileUtil _fileUtil, 
         {
             if (
                 _fileUtil.GetFileExtension(file) != "json"
-                || _filesToIgnore.Contains(_fileUtil.GetFileNameAndExtension(file).ToLower())
+                || _filesToIgnore.Contains(
+                    _fileUtil.GetFileNameAndExtension(file).ToLowerInvariant()
+                )
             )
             {
                 continue;
@@ -127,7 +129,7 @@ public class ImporterUtil(ISptLogger<ImporterUtil> _logger, FileUtil _fileUtil, 
 
             // Get the set method to update the object
             var setMethod = GetSetMethod(
-                _fileUtil.StripExtension(file).ToLower(),
+                _fileUtil.StripExtension(file).ToLowerInvariant(),
                 loadedType,
                 out var propertyType,
                 out var isDictionary
@@ -253,8 +255,8 @@ public class ImporterUtil(ISptLogger<ImporterUtil> _logger, FileUtil _fileUtil, 
             var matchedProperty = type.GetProperties()
                 .FirstOrDefault(prop =>
                     string.Equals(
-                        prop.Name.ToLower(),
-                        _fileUtil.StripExtension(propertyName).ToLower(),
+                        prop.Name.ToLowerInvariant(),
+                        _fileUtil.StripExtension(propertyName).ToLowerInvariant(),
                         StringComparison.Ordinal
                     )
                 );

--- a/Tools/ItemTplGenerator/ItemTplGenerator.cs
+++ b/Tools/ItemTplGenerator/ItemTplGenerator.cs
@@ -384,7 +384,7 @@ public class ItemTplGenerator(
         }
 
         // Add "DAMAGED" for damaged items
-        if (item.Name.ToLower().Contains("damaged"))
+        if (item.Name.ToLowerInvariant().Contains("damaged"))
         {
             suffix += "_DAMAGED";
         }


### PR DESCRIPTION
Fixes up #412, handle all `ToLower` with `ToLowerInvariant` to make sure regional changes aren't applied and breaking functionality 