### PR TITLE
Bot generation MongoId updates

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/database/templates/repeatableQuests.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/database/templates/repeatableQuests.json
@@ -237,7 +237,7 @@
         },
         "Pickup": {
             "_id": "67d03016c971a7faef94af07",
-            "traderId": "{traderId}",
+            "traderId": "54cb57776803fa99248b456e",
             "location": "any",
             "image": "/files/quest/icon/62bd61b1b818ff064405b827.jpg",
             "type": "PickUp",

--- a/Libraries/SPTarkov.Server.Core/Extensions/TemplateItemExtensions.cs
+++ b/Libraries/SPTarkov.Server.Core/Extensions/TemplateItemExtensions.cs
@@ -44,7 +44,7 @@ namespace SPTarkov.Server.Core.Extensions
         /// </summary>
         /// <param name="weaponTemplate">Weapon to get default magazine for</param>
         /// <returns>Tpl of magazine</returns>
-        public static string? GetWeaponsDefaultMagazineTpl(this TemplateItem weaponTemplate)
+        public static MongoId? GetWeaponsDefaultMagazineTpl(this TemplateItem weaponTemplate)
         {
             return weaponTemplate.Properties.DefMagType;
         }

--- a/Libraries/SPTarkov.Server.Core/Generators/BotLevelGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotLevelGenerator.cs
@@ -11,9 +11,9 @@ namespace SPTarkov.Server.Core.Generators;
 
 [Injectable]
 public class BotLevelGenerator(
-    ISptLogger<BotLevelGenerator> _logger,
-    RandomUtil _randomUtil,
-    DatabaseService _databaseService
+    ISptLogger<BotLevelGenerator> logger,
+    RandomUtil randomUtil,
+    DatabaseService databaseService
 )
 {
     /// <summary>
@@ -34,7 +34,7 @@ public class BotLevelGenerator(
             return new RandomisedBotLevelResult { Exp = 0, Level = 1 };
         }
 
-        var expTable = _databaseService.GetGlobals().Configuration.Exp.Level.ExperienceTable;
+        var expTable = databaseService.GetGlobals().Configuration.Exp.Level.ExperienceTable;
         var botLevelRange = GetRelativePmcBotLevelRange(
             botGenerationDetails,
             levelDetails,
@@ -54,7 +54,7 @@ public class BotLevelGenerator(
         // Sprinkle in some random exp within the level, unless we are at max level.
         if (level < expTable.Length - 1)
         {
-            exp += _randomUtil.GetInt(0, expTable[level].Experience.Value - 1);
+            exp += randomUtil.GetInt(0, expTable[level].Experience.Value - 1);
         }
 
         return new RandomisedBotLevelResult { Level = level, Exp = exp };
@@ -62,7 +62,7 @@ public class BotLevelGenerator(
 
     public double ChooseBotLevel(double min, double max, int shift, double number)
     {
-        return _randomUtil.GetBiasedRandomNumber(min, max, shift, number);
+        return randomUtil.GetBiasedRandomNumber(min, max, shift, number);
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Generators/BotLootGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotLootGenerator.cs
@@ -16,23 +16,23 @@ namespace SPTarkov.Server.Core.Generators;
 
 [Injectable]
 public class BotLootGenerator(
-    ISptLogger<BotLootGenerator> _logger,
-    RandomUtil _randomUtil,
-    ItemHelper _itemHelper,
-    InventoryHelper _inventoryHelper,
-    HandbookHelper _handbookHelper,
-    BotGeneratorHelper _botGeneratorHelper,
-    BotWeaponGenerator _botWeaponGenerator,
-    WeightedRandomHelper _weightedRandomHelper,
-    BotHelper _botHelper,
-    BotLootCacheService _botLootCacheService,
-    ServerLocalisationService _serverLocalisationService,
-    ConfigServer _configServer,
-    ICloner _cloner
+    ISptLogger<BotLootGenerator> logger,
+    RandomUtil randomUtil,
+    ItemHelper itemHelper,
+    InventoryHelper inventoryHelper,
+    HandbookHelper handbookHelper,
+    BotGeneratorHelper botGeneratorHelper,
+    BotWeaponGenerator botWeaponGenerator,
+    WeightedRandomHelper weightedRandomHelper,
+    BotHelper botHelper,
+    BotLootCacheService botLootCacheService,
+    ServerLocalisationService serverLocalisationService,
+    ConfigServer configServer,
+    ICloner cloner
 )
 {
-    protected readonly BotConfig _botConfig = _configServer.GetConfig<BotConfig>();
-    protected readonly PmcConfig _pmcConfig = _configServer.GetConfig<PmcConfig>();
+    protected readonly BotConfig _botConfig = configServer.GetConfig<BotConfig>();
+    protected readonly PmcConfig _pmcConfig = configServer.GetConfig<PmcConfig>();
 
     /// <summary>
     /// </summary>
@@ -43,7 +43,7 @@ public class BotLootGenerator(
         var limits = GetItemSpawnLimitsForBotType(botRole);
 
         // Clone limits and set all values to 0 to use as a running total
-        var limitsForBotDict = _cloner.Clone(limits);
+        var limitsForBotDict = cloner.Clone(limits);
         // Init current count of items we want to limit
         foreach (var limit in limitsForBotDict)
         {
@@ -67,7 +67,7 @@ public class BotLootGenerator(
     /// <param name="botInventory">Inventory to add loot to</param>
     /// <param name="botLevel">Level of bot</param>
     public void GenerateLoot(
-        string sessionId,
+        MongoId sessionId,
         BotType botJsonTemplate,
         bool isPmc,
         string botRole,
@@ -92,27 +92,27 @@ public class BotLootGenerator(
             || itemCounts.Grenades.Weights is null
         )
         {
-            _logger.Warning(
-                _serverLocalisationService.GetText("bot-unable_to_generate_bot_loot", botRole)
+            logger.Warning(
+                serverLocalisationService.GetText("bot-unable_to_generate_bot_loot", botRole)
             );
             return;
         }
 
-        var backpackLootCount = _weightedRandomHelper.GetWeightedValue(
+        var backpackLootCount = weightedRandomHelper.GetWeightedValue(
             itemCounts.BackpackLoot.Weights
         );
-        var pocketLootCount = _weightedRandomHelper.GetWeightedValue(itemCounts.PocketLoot.Weights);
-        var vestLootCount = _weightedRandomHelper.GetWeightedValue(itemCounts.VestLoot.Weights);
-        var specialLootItemCount = _weightedRandomHelper.GetWeightedValue(
+        var pocketLootCount = weightedRandomHelper.GetWeightedValue(itemCounts.PocketLoot.Weights);
+        var vestLootCount = weightedRandomHelper.GetWeightedValue(itemCounts.VestLoot.Weights);
+        var specialLootItemCount = weightedRandomHelper.GetWeightedValue(
             itemCounts.SpecialItems.Weights
         );
-        var healingItemCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Healing.Weights);
-        var drugItemCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Drugs.Weights);
-        var foodItemCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Food.Weights);
-        var drinkItemCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Drink.Weights);
-        var currencyItemCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Currency.Weights);
-        var stimItemCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Stims.Weights);
-        var grenadeCount = _weightedRandomHelper.GetWeightedValue(itemCounts.Grenades.Weights);
+        var healingItemCount = weightedRandomHelper.GetWeightedValue(itemCounts.Healing.Weights);
+        var drugItemCount = weightedRandomHelper.GetWeightedValue(itemCounts.Drugs.Weights);
+        var foodItemCount = weightedRandomHelper.GetWeightedValue(itemCounts.Food.Weights);
+        var drinkItemCount = weightedRandomHelper.GetWeightedValue(itemCounts.Drink.Weights);
+        var currencyItemCount = weightedRandomHelper.GetWeightedValue(itemCounts.Currency.Weights);
+        var stimItemCount = weightedRandomHelper.GetWeightedValue(itemCounts.Stims.Weights);
+        var grenadeCount = weightedRandomHelper.GetWeightedValue(itemCounts.Grenades.Weights);
 
         // If bot has been flagged as not having loot, set below counts to 0
         if (_botConfig.DisableLootOnBotTypes.Contains(botRole.ToLowerInvariant()))
@@ -139,7 +139,7 @@ public class BotLootGenerator(
 
         // Special items
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.Special,
@@ -155,7 +155,7 @@ public class BotLootGenerator(
 
         // Healing items / Meds
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.HealingItems,
@@ -173,7 +173,7 @@ public class BotLootGenerator(
 
         // Drugs
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.DrugItems,
@@ -191,7 +191,7 @@ public class BotLootGenerator(
 
         // Food
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.FoodItems,
@@ -209,7 +209,7 @@ public class BotLootGenerator(
 
         // Drink
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.DrinkItems,
@@ -227,7 +227,7 @@ public class BotLootGenerator(
 
         // Currency
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.CurrencyItems,
@@ -245,7 +245,7 @@ public class BotLootGenerator(
 
         // Stims
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.StimItems,
@@ -263,7 +263,7 @@ public class BotLootGenerator(
 
         // Grenades
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.GrenadeItems,
@@ -285,7 +285,7 @@ public class BotLootGenerator(
         if (containersBotHasAvailable.Contains(EquipmentSlots.Backpack))
         {
             // Add randomly generated weapon to PMC backpacks
-            if (isPmc && _randomUtil.GetChance100(_pmcConfig.LooseWeaponInBackpackChancePercent))
+            if (isPmc && randomUtil.GetChance100(_pmcConfig.LooseWeaponInBackpackChancePercent))
             {
                 AddLooseWeaponsToInventorySlot(
                     sessionId,
@@ -302,7 +302,7 @@ public class BotLootGenerator(
 
             var backpackLootRoubleTotal = GetBackpackRoubleTotalByLevel(botLevel, isPmc);
             AddLootFromPool(
-                _botLootCacheService.GetLootFromCache(
+                botLootCacheService.GetLootFromCache(
                     botRole,
                     isPmc,
                     LootCacheType.Backpack,
@@ -325,7 +325,7 @@ public class BotLootGenerator(
         // Vest
         {
             AddLootFromPool(
-                _botLootCacheService.GetLootFromCache(
+                botLootCacheService.GetLootFromCache(
                     botRole,
                     isPmc,
                     LootCacheType.Vest,
@@ -345,7 +345,7 @@ public class BotLootGenerator(
 
         // Pockets
         AddLootFromPool(
-            _botLootCacheService.GetLootFromCache(
+            botLootCacheService.GetLootFromCache(
                 botRole,
                 isPmc,
                 LootCacheType.Pocket,
@@ -368,7 +368,7 @@ public class BotLootGenerator(
         if (!isPmc || (isPmc && _pmcConfig.AddSecureContainerLootFromBotConfig))
         {
             AddLootFromPool(
-                _botLootCacheService.GetLootFromCache(
+                botLootCacheService.GetLootFromCache(
                     botRole,
                     isPmc,
                     LootCacheType.Secure,
@@ -458,7 +458,7 @@ public class BotLootGenerator(
     {
         // surv12
         AddLootFromPool(
-            new Dictionary<MongoId, double> { { "5d02797c86f774203f38e30a", 1 } },
+            new Dictionary<MongoId, double> { { ItemTpl.MEDICAL_SURV12_FIELD_SURGICAL_KIT, 1 } },
             [EquipmentSlots.SecuredContainer],
             1,
             botInventory,
@@ -470,7 +470,10 @@ public class BotLootGenerator(
 
         // AFAK
         AddLootFromPool(
-            new Dictionary<MongoId, double> { { "60098ad7c2240c0fe85c570a", 1 } },
+            new Dictionary<MongoId, double>
+            {
+                { ItemTpl.MEDKIT_AFAK_TACTICAL_INDIVIDUAL_FIRST_AID_KIT, 1 },
+            },
             [EquipmentSlots.SecuredContainer],
             10,
             botInventory,
@@ -524,12 +527,12 @@ public class BotLootGenerator(
                 return;
             }
 
-            var weightedItemTpl = _weightedRandomHelper.GetWeightedValue(pool);
-            var (key, itemToAddTemplate) = _itemHelper.GetItem(weightedItemTpl);
+            var weightedItemTpl = weightedRandomHelper.GetWeightedValue(pool);
+            var (key, itemToAddTemplate) = itemHelper.GetItem(weightedItemTpl);
 
             if (!key)
             {
-                _logger.Warning(
+                logger.Warning(
                     $"Unable to process item tpl: {weightedItemTpl} for slots: {equipmentSlots} on bot: {botRole}"
                 );
 
@@ -555,7 +558,7 @@ public class BotLootGenerator(
                 {
                     Id = newRootItemId,
                     Template = itemToAddTemplate?.Id ?? string.Empty,
-                    Upd = _botGeneratorHelper.GenerateExtraPropertiesForItem(
+                    Upd = botGeneratorHelper.GenerateExtraPropertiesForItem(
                         itemToAddTemplate,
                         botRole
                     ),
@@ -565,7 +568,7 @@ public class BotLootGenerator(
             // Is Simple-Wallet / WZ wallet
             if (_botConfig.WalletLoot.WalletTplPool.Contains(weightedItemTpl))
             {
-                var addCurrencyToWallet = _randomUtil.GetChance100(
+                var addCurrencyToWallet = randomUtil.GetChance100(
                     _botConfig.WalletLoot.ChancePercent
                 );
                 if (addCurrencyToWallet)
@@ -574,11 +577,11 @@ public class BotLootGenerator(
                     var itemsToAdd = CreateWalletLoot(newRootItemId);
 
                     // Get the container grid for the wallet
-                    var containerGrid = _inventoryHelper.GetContainerSlotMap(weightedItemTpl);
+                    var containerGrid = inventoryHelper.GetContainerSlotMap(weightedItemTpl);
 
                     // Check if all the chosen currency items fit into wallet
-                    var canAddToContainer = _inventoryHelper.CanPlaceItemsInContainer(
-                        _cloner.Clone(containerGrid), // MUST clone grid before passing in as function modifies grid
+                    var canAddToContainer = inventoryHelper.CanPlaceItemsInContainer(
+                        cloner.Clone(containerGrid), // MUST clone grid before passing in as function modifies grid
                         itemsToAdd
                     );
                     if (canAddToContainer)
@@ -586,7 +589,7 @@ public class BotLootGenerator(
                         // Add each currency to wallet
                         foreach (var itemToAdd in itemsToAdd)
                         {
-                            _inventoryHelper.PlaceItemInContainer(
+                            inventoryHelper.PlaceItemInContainer(
                                 containerGrid,
                                 itemToAdd,
                                 itemWithChildrenToAdd[0].Id,
@@ -603,7 +606,7 @@ public class BotLootGenerator(
             AddRequiredChildItemsToParent(itemToAddTemplate, itemWithChildrenToAdd, isPmc, botRole);
 
             // Attempt to add item to container(s)
-            var itemAddedResult = _botGeneratorHelper.AddItemWithChildrenToEquipmentSlot(
+            var itemAddedResult = botGeneratorHelper.AddItemWithChildrenToEquipmentSlot(
                 equipmentSlots,
                 newRootItemId,
                 itemToAddTemplate.Id,
@@ -618,9 +621,9 @@ public class BotLootGenerator(
                 if (itemAddedResult == ItemAddedResult.NO_CONTAINERS)
                 {
                     // Bot has no container to put item in, exit
-                    if (_logger.IsLogEnabled(LogLevel.Debug))
+                    if (logger.IsLogEnabled(LogLevel.Debug))
                     {
-                        _logger.Debug(
+                        logger.Debug(
                             $"Unable to add: {totalItemCount} items to bot as it lacks a container to include them"
                         );
                     }
@@ -631,9 +634,9 @@ public class BotLootGenerator(
                 fitItemIntoContainerAttempts++;
                 if (fitItemIntoContainerAttempts >= 4)
                 {
-                    if (_logger.IsLogEnabled(LogLevel.Debug))
+                    if (logger.IsLogEnabled(LogLevel.Debug))
                     {
-                        _logger.Debug(
+                        logger.Debug(
                             $"Failed placing item: {itemToAddTemplate.Id} - {itemToAddTemplate.Name}: {i} of: {totalItemCount} items into: {botRole} "
                                 + $"containers: {string.Join(",", equipmentSlots)}. Tried: {fitItemIntoContainerAttempts} "
                                 + $"times, reason: {itemAddedResult}, skipping"
@@ -653,7 +656,7 @@ public class BotLootGenerator(
             // Stop adding items to bots pool if rolling total is over total limit
             if (totalValueLimitRub > 0)
             {
-                currentTotalRub += _handbookHelper.GetTemplatePrice(itemToAddTemplate.Id);
+                currentTotalRub += handbookHelper.GetTemplatePrice(itemToAddTemplate.Id);
                 if (currentTotalRub > totalValueLimitRub)
                 {
                     break;
@@ -672,14 +675,14 @@ public class BotLootGenerator(
         List<List<Item>> result = [];
 
         // Choose how many stacks of currency will be added to wallet
-        var itemCount = _randomUtil.GetInt(
+        var itemCount = randomUtil.GetInt(
             _botConfig.WalletLoot.ItemCount.Min,
             _botConfig.WalletLoot.ItemCount.Max
         );
         for (var index = 0; index < itemCount; index++)
         {
             // Choose the size of the currency stack - default is 5k, 10k, 15k, 20k, 25k
-            var chosenStackCount = _weightedRandomHelper.GetWeightedValue(
+            var chosenStackCount = weightedRandomHelper.GetWeightedValue(
                 _botConfig.WalletLoot.StackSizeWeight
             );
             List<Item> items =
@@ -687,7 +690,7 @@ public class BotLootGenerator(
                 new()
                 {
                     Id = new MongoId(),
-                    Template = _weightedRandomHelper.GetWeightedValue(
+                    Template = weightedRandomHelper.GetWeightedValue(
                         _botConfig.WalletLoot.CurrencyWeight
                     ),
                     ParentId = walletId,
@@ -715,24 +718,24 @@ public class BotLootGenerator(
     )
     {
         // Fill ammo box
-        if (_itemHelper.IsOfBaseclass(itemToAddTemplate.Id, BaseClasses.AMMO_BOX))
+        if (itemHelper.IsOfBaseclass(itemToAddTemplate.Id, BaseClasses.AMMO_BOX))
         {
-            _itemHelper.AddCartridgesToAmmoBox(itemToAddChildrenTo, itemToAddTemplate);
+            itemHelper.AddCartridgesToAmmoBox(itemToAddChildrenTo, itemToAddTemplate);
         }
         // Make money a stack
-        else if (_itemHelper.IsOfBaseclass(itemToAddTemplate.Id, BaseClasses.MONEY))
+        else if (itemHelper.IsOfBaseclass(itemToAddTemplate.Id, BaseClasses.MONEY))
         {
             RandomiseMoneyStackSize(botRole, itemToAddTemplate, itemToAddChildrenTo[0]);
         }
         // Make ammo a stack
-        else if (_itemHelper.IsOfBaseclass(itemToAddTemplate.Id, BaseClasses.AMMO))
+        else if (itemHelper.IsOfBaseclass(itemToAddTemplate.Id, BaseClasses.AMMO))
         {
             RandomiseAmmoStackSize(isPmc, itemToAddTemplate, itemToAddChildrenTo[0]);
         }
         // Must add soft inserts/plates
-        else if (_itemHelper.ItemRequiresSoftInserts(itemToAddTemplate.Id))
+        else if (itemHelper.ItemRequiresSoftInserts(itemToAddTemplate.Id))
         {
-            _itemHelper.AddChildSlotItems(itemToAddChildrenTo, itemToAddTemplate);
+            itemHelper.AddChildSlotItems(itemToAddChildrenTo, itemToAddTemplate);
         }
     }
 
@@ -749,7 +752,7 @@ public class BotLootGenerator(
     /// <param name="botLevel"></param>
     /// <param name="containersIdFull"></param>
     public void AddLooseWeaponsToInventorySlot(
-        string sessionId,
+        MongoId sessionId,
         BotBaseInventory botInventory,
         EquipmentSlots equipmentSlot,
         BotTypeInventory? templateInventory,
@@ -760,7 +763,7 @@ public class BotLootGenerator(
         HashSet<string>? containersIdFull
     )
     {
-        var chosenWeaponType = _randomUtil.GetArrayValue<string>(
+        var chosenWeaponType = randomUtil.GetArrayValue<string>(
             [
                 EquipmentSlots.FirstPrimaryWeapon.ToString(),
                 EquipmentSlots.FirstPrimaryWeapon.ToString(),
@@ -768,7 +771,7 @@ public class BotLootGenerator(
                 EquipmentSlots.Holster.ToString(),
             ]
         );
-        var randomisedWeaponCount = _randomUtil.GetInt(
+        var randomisedWeaponCount = randomUtil.GetInt(
             _pmcConfig.LooseWeaponInBackpackLootMinMax.Min,
             _pmcConfig.LooseWeaponInBackpackLootMinMax.Max
         );
@@ -780,7 +783,7 @@ public class BotLootGenerator(
 
         for (var i = 0; i < randomisedWeaponCount; i++)
         {
-            var generatedWeapon = _botWeaponGenerator.GenerateRandomWeapon(
+            var generatedWeapon = botWeaponGenerator.GenerateRandomWeapon(
                 sessionId,
                 chosenWeaponType,
                 templateInventory,
@@ -794,13 +797,13 @@ public class BotLootGenerator(
             var weaponRootItem = generatedWeapon.Weapon?.FirstOrDefault();
             if (weaponRootItem is null)
             {
-                _logger.Error(
+                logger.Error(
                     $"Generated loose weapon: {chosenWeaponType} for: {botRole} level: {botLevel} was null, skipping"
                 );
 
                 continue;
             }
-            var result = _botGeneratorHelper.AddItemWithChildrenToEquipmentSlot(
+            var result = botGeneratorHelper.AddItemWithChildrenToEquipmentSlot(
                 [equipmentSlot],
                 weaponRootItem.Id,
                 weaponRootItem.Template,
@@ -811,9 +814,9 @@ public class BotLootGenerator(
 
             if (result != ItemAddedResult.SUCCESS)
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
+                if (logger.IsLogEnabled(LogLevel.Debug))
                 {
-                    _logger.Debug(
+                    logger.Debug(
                         $"Failed to add additional weapon: {weaponRootItem.Id} to bot backpack, reason: {result.ToString()}"
                     );
                 }
@@ -855,26 +858,26 @@ public class BotLootGenerator(
         }
 
         // Use tryAdd to see if it exists, and automatically add 1
-        if (!itemSpawnLimits.CurrentLimits.TryAdd(idToCheckFor, 1))
-        // if it does exist, come in here and increment
-        // Increment item count with this bot type
+        if (!itemSpawnLimits.CurrentLimits.TryAdd(idToCheckFor.Value, 1))
+        // if it does exist, come in here and increment item count with this bot type
         {
-            itemSpawnLimits.CurrentLimits[idToCheckFor]++;
+            itemSpawnLimits.CurrentLimits[idToCheckFor.Value]++;
         }
 
         // Check if over limit
-        var currentLimitCount = itemSpawnLimits.CurrentLimits[idToCheckFor];
+        var currentLimitCount = itemSpawnLimits.CurrentLimits[idToCheckFor.Value];
         if (
-            itemSpawnLimits.CurrentLimits[idToCheckFor] > itemSpawnLimits.GlobalLimits[idToCheckFor]
+            itemSpawnLimits.CurrentLimits[idToCheckFor.Value]
+            > itemSpawnLimits.GlobalLimits[idToCheckFor.Value]
         )
         {
             // Prevent edge-case of small loot pools + code trying to add limited item over and over infinitely
             if (currentLimitCount > currentLimitCount * 10)
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
+                if (logger.IsLogEnabled(LogLevel.Debug))
                 {
-                    _logger.Debug(
-                        _serverLocalisationService.GetText(
+                    logger.Debug(
+                        serverLocalisationService.GetText(
                             "bot-item_spawn_limit_reached_skipping_item",
                             new
                             {
@@ -911,10 +914,10 @@ public class BotLootGenerator(
 
         var currencyWeight = currencyWeights[moneyItem.Template];
 
-        _itemHelper.AddUpdObjectToItem(moneyItem);
+        itemHelper.AddUpdObjectToItem(moneyItem);
 
         moneyItem.Upd.StackObjectsCount = int.Parse(
-            _weightedRandomHelper.GetWeightedValue(currencyWeight)
+            weightedRandomHelper.GetWeightedValue(currencyWeight)
         );
     }
 
@@ -926,8 +929,8 @@ public class BotLootGenerator(
     /// <param name="ammoItem">Ammo item to randomise</param>
     public void RandomiseAmmoStackSize(bool isPmc, TemplateItem itemTemplate, Item ammoItem)
     {
-        var randomSize = _itemHelper.GetRandomisedAmmoStackSize(itemTemplate);
-        _itemHelper.AddUpdObjectToItem(ammoItem);
+        var randomSize = itemHelper.GetRandomisedAmmoStackSize(itemTemplate);
+        itemHelper.AddUpdObjectToItem(ammoItem);
 
         ammoItem.Upd.StackObjectsCount = randomSize;
     }
@@ -938,9 +941,9 @@ public class BotLootGenerator(
     /// </summary>
     /// <param name="botRole">what role does the bot have</param>
     /// <returns>Dictionary of tplIds and limit</returns>
-    public Dictionary<string, double> GetItemSpawnLimitsForBotType(string botRole)
+    public Dictionary<MongoId, double> GetItemSpawnLimitsForBotType(string botRole)
     {
-        if (_botHelper.IsBotPmc(botRole))
+        if (botHelper.IsBotPmc(botRole))
         {
             return _botConfig.ItemSpawnLimits["pmc"];
         }
@@ -950,14 +953,14 @@ public class BotLootGenerator(
             return _botConfig.ItemSpawnLimits[botRole.ToLowerInvariant()];
         }
 
-        _logger.Warning(
-            _serverLocalisationService.GetText(
+        logger.Warning(
+            serverLocalisationService.GetText(
                 "bot-unable_to_find_spawn_limits_fallback_to_defaults",
                 botRole
             )
         );
 
-        return new Dictionary<string, double>();
+        return [];
     }
 
     /// <summary>
@@ -966,9 +969,9 @@ public class BotLootGenerator(
     /// <param name="itemTemplate">item we want to look for in spawn limits</param>
     /// <param name="spawnLimits">Limits to check for item</param>
     /// <returns>id as string, otherwise undefined</returns>
-    public string? GetMatchingIdFromSpawnLimits(
+    public MongoId? GetMatchingIdFromSpawnLimits(
         TemplateItem itemTemplate,
-        Dictionary<string, double> spawnLimits
+        Dictionary<MongoId, double> spawnLimits
     )
     {
         if (spawnLimits.ContainsKey(itemTemplate.Id))

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/CompletionQuestGenerator.cs
@@ -40,7 +40,7 @@ public class CompletionQuestGenerator(
     /// </param>
     /// <returns>quest type format for "Completion" (see assets/database/templates/repeatableQuests.json)</returns>
     public RepeatableQuest? Generate(
-        string sessionId,
+        MongoId sessionId,
         int pmcLevel,
         MongoId traderId,
         QuestTypePool questTypePool,
@@ -289,7 +289,7 @@ public class CompletionQuestGenerator(
     /// <param name="itemSelection">Filtered item selection</param>
     /// <param name="roublesBudget">Budget in roubles</param>
     /// <returns>Chosen item template Ids</returns>
-    protected List<string> GenerateAvailableForFinish(
+    protected List<MongoId> GenerateAvailableForFinish(
         RepeatableQuest quest,
         Completion completionConfig,
         RepeatableQuestConfig repeatableConfig,
@@ -299,7 +299,7 @@ public class CompletionQuestGenerator(
     {
         // Store the indexes of items we are asking player to supply
         var distinctItemsToRetrieveCount = randomUtil.GetInt(1, completionConfig.UniqueItemCount);
-        var chosenRequirementItemsTpls = new List<string>();
+        var chosenRequirementItemsTpls = new List<MongoId>();
         var usedItemIndexes = new HashSet<int>();
 
         for (var i = 0; i < distinctItemsToRetrieveCount; i++)

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/EliminationQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/EliminationQuestGenerator.cs
@@ -71,7 +71,7 @@ public class EliminationQuestGenerator(
     /// </param>
     /// <returns>Object of quest type format for "Elimination" (see assets/database/templates/repeatableQuests.json)</returns>
     public RepeatableQuest? Generate(
-        string sessionId,
+        MongoId sessionId,
         int pmcLevel,
         MongoId traderId,
         QuestTypePool questTypePool,

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
@@ -44,7 +44,7 @@ public class ExplorationQuestGenerator(
     /// </param>
     /// <returns>object of quest type format for "Exploration" (see assets/database/templates/repeatableQuests.json)</returns>
     public RepeatableQuest? Generate(
-        string sessionId,
+        MongoId sessionId,
         int pmcLevel,
         MongoId traderId,
         QuestTypePool questTypePool,

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/IRepeatableQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/IRepeatableQuestGenerator.cs
@@ -8,7 +8,7 @@ namespace SPTarkov.Server.Core.Generators.RepeatableQuestGeneration;
 public interface IRepeatableQuestGenerator
 {
     public RepeatableQuest? Generate(
-        string sessionId,
+        MongoId sessionId,
         int pmcLevel,
         MongoId traderId,
         QuestTypePool questTypePool,

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/PickupQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/PickupQuestGenerator.cs
@@ -24,9 +24,9 @@ public class PickupQuestGenerator(
     HashUtil hashUtil
 ) : IRepeatableQuestGenerator
 {
-    // TODO: This isn't really implemented well at all, what even is this.
+    // TODO: This isn't really implemented, not in the current pool.
     public RepeatableQuest? Generate(
-        string sessionId,
+        MongoId sessionId,
         int pmcLevel,
         MongoId traderId,
         QuestTypePool questTypePool,

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/RepeatableQuestRewardGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/RepeatableQuestRewardGenerator.cs
@@ -64,7 +64,7 @@ public class RepeatableQuestRewardGenerator(
         MongoId traderId,
         RepeatableQuestConfig repeatableConfig,
         BaseQuestConfig eliminationConfig,
-        List<string>? rewardTplBlacklist = null
+        List<MongoId>? rewardTplBlacklist = null
     )
     {
         // Get vars to configure rewards with

--- a/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/BarrelInventoryMagGen.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/BarrelInventoryMagGen.cs
@@ -6,9 +6,9 @@ using SPTarkov.Server.Core.Utils;
 namespace SPTarkov.Server.Core.Generators.WeaponGen.Implementations;
 
 [Injectable]
-public class BarrelInvetoryMagGen(
-    RandomUtil _randomUtil,
-    BotWeaponGeneratorHelper _botWeaponGeneratorHelper
+public class BarrelInventoryMagGen(
+    RandomUtil randomUtil,
+    BotWeaponGeneratorHelper botWeaponGeneratorHelper
 ) : InventoryMagGen, IInventoryMagGen
 {
     public int GetPriority()
@@ -28,17 +28,17 @@ public class BarrelInvetoryMagGen(
         if (inventoryMagGen.GetAmmoTemplate().Properties.StackMaxRandom == 1)
         // Doesn't stack
         {
-            randomisedAmmoStackSize = _randomUtil.GetInt(3, 6);
+            randomisedAmmoStackSize = randomUtil.GetInt(3, 6);
         }
         else
         {
-            randomisedAmmoStackSize = _randomUtil.GetInt(
+            randomisedAmmoStackSize = randomUtil.GetInt(
                 inventoryMagGen.GetAmmoTemplate().Properties.StackMinRandom.Value,
                 inventoryMagGen.GetAmmoTemplate().Properties.StackMaxRandom.Value
             );
         }
 
-        _botWeaponGeneratorHelper.AddAmmoIntoEquipmentSlots(
+        botWeaponGeneratorHelper.AddAmmoIntoEquipmentSlots(
             inventoryMagGen.GetAmmoTemplate().Id,
             (int)randomisedAmmoStackSize,
             inventoryMagGen.GetPmcInventory(),

--- a/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/InternalMagazineInventoryMagGen.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/InternalMagazineInventoryMagGen.cs
@@ -5,7 +5,7 @@ using SPTarkov.Server.Core.Models.Enums;
 namespace SPTarkov.Server.Core.Generators.WeaponGen.Implementations;
 
 [Injectable]
-public class InternalMagazineInventoryMagGen(BotWeaponGeneratorHelper _botWeaponGeneratorHelper)
+public class InternalMagazineInventoryMagGen(BotWeaponGeneratorHelper botWeaponGeneratorHelper)
     : InventoryMagGen,
         IInventoryMagGen
 {
@@ -22,11 +22,11 @@ public class InternalMagazineInventoryMagGen(BotWeaponGeneratorHelper _botWeapon
 
     public void Process(InventoryMagGen inventoryMagGen)
     {
-        var bulletCount = _botWeaponGeneratorHelper.GetRandomizedBulletCount(
+        var bulletCount = botWeaponGeneratorHelper.GetRandomizedBulletCount(
             inventoryMagGen.GetMagCount(),
             inventoryMagGen.GetMagazineTemplate()
         );
-        _botWeaponGeneratorHelper.AddAmmoIntoEquipmentSlots(
+        botWeaponGeneratorHelper.AddAmmoIntoEquipmentSlots(
             inventoryMagGen.GetAmmoTemplate().Id,
             (int)bulletCount,
             inventoryMagGen.GetPmcInventory(),

--- a/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/UbglExternalMagGen.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/UbglExternalMagGen.cs
@@ -5,7 +5,7 @@ using SPTarkov.Server.Core.Models.Enums;
 namespace SPTarkov.Server.Core.Generators.WeaponGen.Implementations;
 
 [Injectable]
-public class UbglExternalMagGen(BotWeaponGeneratorHelper _botWeaponGeneratorHelper)
+public class UbglExternalMagGen(BotWeaponGeneratorHelper botWeaponGeneratorHelper)
     : InventoryMagGen,
         IInventoryMagGen
 {
@@ -21,11 +21,11 @@ public class UbglExternalMagGen(BotWeaponGeneratorHelper _botWeaponGeneratorHelp
 
     public void Process(InventoryMagGen inventoryMagGen)
     {
-        var bulletCount = _botWeaponGeneratorHelper.GetRandomizedBulletCount(
+        var bulletCount = botWeaponGeneratorHelper.GetRandomizedBulletCount(
             inventoryMagGen.GetMagCount(),
             inventoryMagGen.GetMagazineTemplate()
         );
-        _botWeaponGeneratorHelper.AddAmmoIntoEquipmentSlots(
+        botWeaponGeneratorHelper.AddAmmoIntoEquipmentSlots(
             inventoryMagGen.GetAmmoTemplate().Id,
             (int)bulletCount,
             inventoryMagGen.GetPmcInventory(),

--- a/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/InventoryMagGen.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/InventoryMagGen.cs
@@ -6,11 +6,11 @@ namespace SPTarkov.Server.Core.Generators.WeaponGen;
 [Injectable]
 public class InventoryMagGen()
 {
-    private readonly TemplateItem _ammoTemplate;
-    private readonly TemplateItem _magazineTemplate;
-    private readonly GenerationData _magCounts;
-    private readonly BotBaseInventory _pmcInventory;
-    private readonly TemplateItem _weaponTemplate;
+    private readonly TemplateItem? _ammoTemplate;
+    private readonly TemplateItem? _magazineTemplate;
+    private readonly GenerationData? _magCounts;
+    private readonly BotBaseInventory? _pmcInventory;
+    private readonly TemplateItem? _weaponTemplate;
 
     public InventoryMagGen(
         GenerationData magCounts,
@@ -30,26 +30,26 @@ public class InventoryMagGen()
 
     public GenerationData GetMagCount()
     {
-        return _magCounts;
+        return _magCounts!;
     }
 
     public TemplateItem GetMagazineTemplate()
     {
-        return _magazineTemplate;
+        return _magazineTemplate!;
     }
 
     public TemplateItem GetWeaponTemplate()
     {
-        return _weaponTemplate;
+        return _weaponTemplate!;
     }
 
     public TemplateItem GetAmmoTemplate()
     {
-        return _ammoTemplate;
+        return _ammoTemplate!;
     }
 
     public BotBaseInventory GetPmcInventory()
     {
-        return _pmcInventory;
+        return _pmcInventory!;
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/GlobalTablesUsings.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/GlobalTablesUsings.cs
@@ -3,7 +3,7 @@ global using GlobalAmmo = System.Collections.Generic.Dictionary<
     System.Collections.Generic.Dictionary<string, double>
 >;
 global using GlobalMods = System.Collections.Generic.Dictionary<
-    string,
+    SPTarkov.Server.Core.Models.Common.MongoId,
     System.Collections.Generic.Dictionary<
         string,
         System.Collections.Generic.HashSet<SPTarkov.Server.Core.Models.Common.MongoId>

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/TemplateItem.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/TemplateItem.cs
@@ -786,7 +786,7 @@ public record Props
     public bool? IsBoltCatch { get; set; }
 
     [JsonPropertyName("defMagType")]
-    public string? DefMagType { get; set; }
+    public MongoId? DefMagType { get; set; }
 
     [JsonPropertyName("defAmmo")]
     public string? DefAmmo { get; set; }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Bots/ItemSpawnLimitSettings.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Bots/ItemSpawnLimitSettings.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using SPTarkov.Server.Core.Models.Common;
 
 namespace SPTarkov.Server.Core.Models.Spt.Bots;
 
@@ -8,8 +9,8 @@ public record ItemSpawnLimitSettings
     public Dictionary<string, object>? ExtensionData { get; set; }
 
     [JsonPropertyName("currentLimits")]
-    public Dictionary<string, double>? CurrentLimits { get; set; }
+    public Dictionary<MongoId, double>? CurrentLimits { get; set; }
 
     [JsonPropertyName("globalLimits")]
-    public Dictionary<string, double>? GlobalLimits { get; set; }
+    public Dictionary<MongoId, double>? GlobalLimits { get; set; }
 }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/BotConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/BotConfig.cs
@@ -51,7 +51,7 @@ public record BotConfig : BaseConfig
     ///     key: itemTpl: value: max item count>
     /// </summary>
     [JsonPropertyName("itemSpawnLimits")]
-    public required Dictionary<string, Dictionary<string, double>> ItemSpawnLimits { get; set; }
+    public required Dictionary<string, Dictionary<MongoId, double>> ItemSpawnLimits { get; set; }
 
     /// <summary>
     ///     Blacklist/whitelist items on a bot


### PR DESCRIPTION
- Changes a ton of bot gen to use MongoIds
- Changes sessionIds to MongoIds in bot gen where applicable
- Use generated `ItemTpl` class in places where we had hard coded strings in bot gen
- Remove underscore from injections in bot gen
- Fix TraderId bug introduced in last PR. It was bad data in repeatable quest templates.


Full tested factory run, bots generated fine. Will do rest of generators in a separate PR