### PR TITLE
PrestigeHelper: fix wrongly awarding prestige+1 awards

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
@@ -30,7 +30,7 @@ public class PrestigeHelper(
         var sessionId = newProfile.ProfileInfo.ProfileId;
         var prestigeLevels = databaseService.GetTemplates().Prestige.Elements;
         var indexOfPrestigeObtained = Math.Clamp(
-            (prestige.PrestigeLevel ?? 1),
+            (prestige.PrestigeLevel ?? 1) - 1,
             0,
             prestigeLevels.Count - 1
         ); // Levels are 1 to 4, Index is 0 to 3
@@ -39,7 +39,10 @@ public class PrestigeHelper(
 
         var skillProgressCopyAmount = (float)(
             1
-            - prestigeLevels[indexOfPrestigeObtained].TransferConfigs.SkillConfig.TransferMultiplier
+            - prestigeLevels[indexOfPrestigeObtained]
+                .TransferConfigs
+                .SkillConfig
+                .TransferMultiplier
         );
         var masteringProgressCopyAmount = (float)(
             1


### PR DESCRIPTION
I've accidentally bugged the code.
Again - index is 0 to 3, level is 1 to 4, so we clamp the resulting value in index values, but I forgor to actually subtract 1 from prestigeLevel.
Rest of logic works fine.

BUG Repro steps: just 'force' 1st prestige - rewards are as for 2nd prestige. Same goes for skill multiplier.