### PR TITLE
Get rid of all logger.IsLogEnabled() calls by moving these checks to a base class

### DIFF
--- a/Benchmarks/Mock/MockLogger.cs
+++ b/Benchmarks/Mock/MockLogger.cs
@@ -4,49 +4,49 @@ using SPTarkov.Server.Core.Models.Utils;
 
 namespace Benchmarks.Mock;
 
-public class MockLogger<T> : ISptLogger<T>
+public class MockLogger<T> : SptLoggerBase<T>
 {
-    public void LogWithColor(
+    public override void LogWithColorInternal(
         string data,
         LogTextColor? textColor = null,
         LogBackgroundColor? backgroundColor = null,
         Exception? ex = null
     )
     {
-        throw new NotImplementedException();
+        Console.WriteLine(data);
     }
 
-    public void Success(string data, Exception? ex = null)
+    protected override void SuccessInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Error(string data, Exception? ex = null)
+    protected override void ErrorInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Warning(string data, Exception? ex = null)
+    protected override void WarningInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Info(string data, Exception? ex = null)
+    protected override void InfoInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Debug(string data, Exception? ex = null)
+    protected override void DebugInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Critical(string data, Exception? ex = null)
+    protected override void CriticalInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Log(
+    protected override void LogInternal(
         LogLevel level,
         string data,
         LogTextColor? textColor = null,
@@ -62,24 +62,14 @@ public class MockLogger<T> : ISptLogger<T>
         throw new NotImplementedException();
     }
 
-    public bool IsLogEnabled(LogLevel level)
+    protected override bool IsLogEnabled(LogLevel level)
     {
         return false;
     }
 
-    public void DumpAndStop()
+    public override void DumpAndStop()
     {
         throw new NotImplementedException();
-    }
-
-    public void LogWithColor(
-        string data,
-        Exception? ex = null,
-        LogTextColor? textColor = null,
-        LogBackgroundColor? backgroundColor = null
-    )
-    {
-        Console.WriteLine(data);
     }
 
     public void WriteToLogFile(object body)

--- a/Libraries/SPTarkov.Server.Core/Callbacks/BtrDeliveryCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/BtrDeliveryCallbacks.cs
@@ -78,12 +78,9 @@ public class BtrDeliveryCallbacks(
         var deliveryList = saveServer.GetProfile(sessionId).BtrDeliveryList;
         if (deliveryList != null && deliveryList!.Count > 0)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Found {deliveryList.Count} BTR delivery package(s) in profile {sessionId}"
-                );
-            }
+            logger.Debug(
+                $"Found {deliveryList.Count} BTR delivery package(s) in profile {sessionId}"
+            );
             return deliveryList
                 .Where(toBeDelivered => currentTime >= toBeDelivered.ScheduledTime)
                 .ToList();
@@ -99,12 +96,9 @@ public class BtrDeliveryCallbacks(
     /// <param name="sessionId">session ID that should receive the processed items</param>
     protected void ProcessDeliveryItems(List<BtrDelivery> packagesToBeDelivered, MongoId sessionId)
     {
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Processing {packagesToBeDelivered.Count} BTR delivery package(s), which include a total of: {packagesToBeDelivered.Select(items => items.Items).Count()} items, in profile: {sessionId}"
-            );
-        }
+        logger.Debug(
+            $"Processing {packagesToBeDelivered.Count} BTR delivery package(s), which include a total of: {packagesToBeDelivered.Select(items => items.Items).Count()} items, in profile: {sessionId}"
+        );
 
         // Iterate over each of the insurance packages.
         foreach (var package in packagesToBeDelivered)

--- a/Libraries/SPTarkov.Server.Core/Controllers/BotController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/BotController.cs
@@ -145,12 +145,9 @@ public class BotController(
             {
                 // No bot of this type found, copy details from assault
                 result[botTypeLower] = result[Roles.Assault];
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        $"Unable to find bot: {botTypeLower} in db, copying: '{Roles.Assault}'"
-                    );
-                }
+                _logger.Debug(
+                    $"Unable to find bot: {botTypeLower} in db, copying: '{Roles.Assault}'"
+                );
 
                 continue;
             }
@@ -245,12 +242,7 @@ public class BotController(
 
         stopwatch.Stop();
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug(
-                $"Took {stopwatch.ElapsedMilliseconds}ms to GenerateMultipleBotsAndCache()"
-            );
-        }
+        _logger.Debug($"Took {stopwatch.ElapsedMilliseconds}ms to GenerateMultipleBotsAndCache()");
 
         return generatedBotList;
     }
@@ -285,12 +277,9 @@ public class BotController(
 
         var role = botGenerationDetails.EventRole ?? botGenerationDetails.Role;
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug(
-                $"Generating wave of: {botGenerationDetails.BotCountToGenerate} bots of type: {role} {botGenerationDetails.BotDifficulty}"
-            );
-        }
+        _logger.Debug(
+            $"Generating wave of: {botGenerationDetails.BotCountToGenerate} bots of type: {role} {botGenerationDetails.BotDifficulty}"
+        );
 
         var maxThreads = botGenerationDetails.BotCountToGenerate;
 
@@ -338,13 +327,10 @@ public class BotController(
             }
         );
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug(
-                $"Generated: {botGenerationDetails.BotCountToGenerate} {botGenerationDetails.Role}"
-                    + $"({botGenerationDetails.EventRole ?? botGenerationDetails.Role ?? ""}) {botGenerationDetails.BotDifficulty} bots"
-            );
-        }
+        _logger.Debug(
+            $"Generated: {botGenerationDetails.BotCountToGenerate} {botGenerationDetails.Role}"
+                + $"({botGenerationDetails.EventRole ?? botGenerationDetails.Role ?? ""}) {botGenerationDetails.BotDifficulty} bots"
+        );
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Controllers/GameController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/GameController.cs
@@ -91,12 +91,7 @@ public class GameController(
             profileFixerService.CheckForAndFixDialogueAttachments(fullProfile);
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Started game with session {sessionId} {fullProfile.ProfileInfo?.Username}"
-            );
-        }
+        logger.Debug($"Started game with session {sessionId} {fullProfile.ProfileInfo?.Username}");
 
         var pmcProfile = fullProfile.CharacterData.PmcData;
 
@@ -551,15 +546,12 @@ public class GameController(
     /// <param name="fullProfile"></param>
     protected void LogProfileDetails(SptProfile fullProfile)
     {
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Profile made with: {fullProfile.SptData?.Version}");
-            logger.Debug(
-                $"Server version: {ProgramStatics.SPT_VERSION() ?? _coreConfig.SptVersion} {ProgramStatics.COMMIT()}"
-            );
-            logger.Debug($"Debug enabled: {ProgramStatics.DEBUG()}");
-            logger.Debug($"Mods enabled: {ProgramStatics.MODS()}");
-        }
+        logger.Debug($"Profile made with: {fullProfile.SptData?.Version}");
+        logger.Debug(
+            $"Server version: {ProgramStatics.SPT_VERSION() ?? _coreConfig.SptVersion} {ProgramStatics.COMMIT()}"
+        );
+        logger.Debug($"Debug enabled: {ProgramStatics.DEBUG()}");
+        logger.Debug($"Mods enabled: {ProgramStatics.MODS()}");
     }
 
     public void Load()

--- a/Libraries/SPTarkov.Server.Core/Controllers/InsuranceController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/InsuranceController.cs
@@ -88,12 +88,9 @@ public class InsuranceController(
         var profileInsuranceDetails = saveServer.GetProfile(sessionId).InsuranceList;
         if (profileInsuranceDetails.Count > 0)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Found {profileInsuranceDetails.Count} insurance packages in profile {sessionId}"
-                );
-            }
+            logger.Debug(
+                $"Found {profileInsuranceDetails.Count} insurance packages in profile {sessionId}"
+            );
         }
 
         return profileInsuranceDetails
@@ -108,12 +105,9 @@ public class InsuranceController(
     /// <param name="sessionId">session ID that should receive the processed items</param>
     protected void ProcessInsuredItems(List<Insurance> insuranceDetails, MongoId sessionId)
     {
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Processing {insuranceDetails.Count} insurance packages, which includes a total of: {CountAllInsuranceItems(insuranceDetails)} items, in profile: {sessionId}"
-            );
-        }
+        logger.Debug(
+            $"Processing {insuranceDetails.Count} insurance packages, which includes a total of: {CountAllInsuranceItems(insuranceDetails)} items, in profile: {sessionId}"
+        );
 
         // Iterate over each of the insurance packages.
         foreach (var insured in insuranceDetails)
@@ -171,12 +165,9 @@ public class InsuranceController(
             )
             .ToList();
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Removed processed insurance package. Remaining packages: {profile.InsuranceList.Count}"
-            );
-        }
+        logger.Debug(
+            $"Removed processed insurance package. Remaining packages: {profile.InsuranceList.Count}"
+        );
     }
 
     /// <summary>
@@ -218,12 +209,9 @@ public class InsuranceController(
         }
 
         // Log the number of items marked for deletion, if any
-        if (logger.IsLogEnabled(LogLevel.Debug))
+        if (toDelete.Any())
         {
-            if (toDelete.Any())
-            {
-                logger.Debug($"Marked {toDelete.Count} items for deletion from insurance.");
-            }
+            logger.Debug($"Marked {toDelete.Count} items for deletion from insurance.");
         }
 
         return toDelete;
@@ -456,10 +444,7 @@ public class InsuranceController(
             // Log the parent item's name.
             itemsMap.TryGetValue(key, out var parentItem);
             var parentName = itemHelper.GetItemName(parentItem.Template);
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Processing attachments of parent {parentName}");
-            }
+            logger.Debug($"Processing attachments of parent {parentName}");
 
             // Process the attachments for this individual parent item.
             ProcessAttachmentByParent(attachments, insuredTraderId.Value, toDelete);
@@ -511,10 +496,7 @@ public class InsuranceController(
 
         LogAttachmentsBeingRemoved(attachmentIdsToRemove, attachments, weightedAttachmentByPrice);
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Number of attachments to be deleted: {attachmentIdsToRemove.Count}");
-        }
+        logger.Debug($"Number of attachments to be deleted: {attachmentIdsToRemove.Count}");
     }
 
     /// <summary>
@@ -532,13 +514,10 @@ public class InsuranceController(
         var index = 1;
         foreach (var attachmentId in attachmentIdsToRemove)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Attachment {index} Id: {attachmentId} Tpl: {attachments.FirstOrDefault(x => x.Id == attachmentId)?.Template} - "
-                        + $"Price: {attachmentPrices[attachmentId]}"
-                );
-            }
+            logger.Debug(
+                $"Attachment {index} Id: {attachmentId} Tpl: {attachments.FirstOrDefault(x => x.Id == attachmentId)?.Template} - "
+                    + $"Price: {attachmentPrices[attachmentId]}"
+            );
 
             index++;
         }
@@ -755,12 +734,9 @@ public class InsuranceController(
             ? $"{itemHelper.GetItemName(insuredItem.Template)}"
             : "";
         var status = roll ? "Delete" : "Keep";
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Rolling {itemName} with {trader} - Return {traderReturnChance}% - Roll: {returnChance} - Status: {status}"
-            );
-        }
+        logger.Debug(
+            $"Rolling {itemName} with {trader} - Return {traderReturnChance}% - Roll: {returnChance} - Status: {status}"
+        );
 
         return roll;
     }
@@ -862,10 +838,7 @@ public class InsuranceController(
 
         foreach (var softInsertSlot in softInsertSlots)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"SoftInsertSlots: {softInsertSlot.SlotId}");
-            }
+            logger.Debug($"SoftInsertSlots: {softInsertSlot.SlotId}");
 
             pmcData.InsuredItems.Add(
                 new InsuredItem { TId = request.TransactionId, ItemId = softInsertSlot.Id }
@@ -898,12 +871,7 @@ public class InsuranceController(
                 // Ensure inventory has item in it
                 if (!inventoryItemsHash.TryGetValue(itemId, out var inventoryItem))
                 {
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Item with id: {itemId} missing from player inventory, skipping"
-                        );
-                    }
+                    logger.Debug($"Item with id: {itemId} missing from player inventory, skipping");
 
                     continue;
                 }

--- a/Libraries/SPTarkov.Server.Core/Controllers/LocationController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/LocationController.cs
@@ -35,10 +35,7 @@ public class LocationController(
             var mapBase = location.Base;
             if (mapBase == null)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug($"Map: {locationId} has no base json file, skipping generation");
-                }
+                logger.Debug($"Map: {locationId} has no base json file, skipping generation");
 
                 continue;
             }

--- a/Libraries/SPTarkov.Server.Core/Controllers/RagfairController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/RagfairController.cs
@@ -288,10 +288,7 @@ public class RagfairController(
         else
         {
             logger.Error(localisationService.GetText("ragfair-unable_to_get_categories"));
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(jsonUtil.Serialize(searchRequest));
-            }
+            logger.Debug(jsonUtil.Serialize(searchRequest));
 
             return [];
         }
@@ -952,12 +949,9 @@ public class RagfairController(
                 offerRequest.SellInOnePiece.GetValueOrDefault(false)
             );
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Offer tax to charge: {tax}, pulled from client: {storedClientTaxValue.Count is not null}"
-            );
-        }
+        logger.Debug(
+            $"Offer tax to charge: {tax}, pulled from client: {storedClientTaxValue.Count is not null}"
+        );
 
         // cleanup of cache now we've used the tax value from it
         ragfairTaxService.ClearStoredOfferTaxById(offerRequest.Items.First());

--- a/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
@@ -197,12 +197,9 @@ public class RepeatableQuestController(
         newRepeatableQuest.Side = Enum.GetName(repeatableConfig.Side);
         repeatablesOfTypeInProfile.ActiveQuests.Add(newRepeatableQuest);
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Removing: {repeatableConfig.Name} quest: {questToReplace.Id} from trader: {questToReplace.TraderId} as its been replaced"
-            );
-        }
+        logger.Debug(
+            $"Removing: {repeatableConfig.Name} quest: {questToReplace.Id} from trader: {questToReplace.TraderId} as its been replaced"
+        );
 
         // Remove the replaced quest from profile
         RemoveQuestFromProfile(fullProfile, questToReplace.Id);
@@ -281,10 +278,7 @@ public class RepeatableQuestController(
                 continue;
             }
 
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Accepted repeatable quest: {questId} from: {repeatableQuest.Name}");
-            }
+            logger.Debug($"Accepted repeatable quest: {questId} from: {repeatableQuest.Name}");
 
             matchingQuest.SptRepatableGroupName = repeatableQuest.Name;
 
@@ -453,10 +447,7 @@ public class RepeatableQuestController(
             return null;
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Generating operation task type: {questType} for {traderId}");
-        }
+        logger.Debug($"Generating operation task type: {questType} for {traderId}");
 
         return questType switch
         {
@@ -595,10 +586,7 @@ public class RepeatableQuestController(
             {
                 returnData.Add(generatedRepeatables);
 
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug($"[Quest Check] {repeatableTypeLower} quests are still valid.");
-                }
+                logger.Debug($"[Quest Check] {repeatableTypeLower} quests are still valid.");
 
                 continue;
             }
@@ -608,10 +596,7 @@ public class RepeatableQuestController(
             // Set endtime to be now + new duration
             generatedRepeatables.EndTime = currentTime + repeatableConfig.ResetTime;
             generatedRepeatables.InactiveQuests = [];
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Generating new {repeatableTypeLower}");
-            }
+            logger.Debug($"Generating new {repeatableTypeLower}");
 
             // Put old quests to inactive (this is required since only then the client makes them fail due to non-completion)
             // Also need to push them to the "inactiveQuests" list since we need to remove them from offraidData.profile.Quests
@@ -772,10 +757,7 @@ public class RepeatableQuestController(
         // Scav and daily quests not unlocked yet
         if (repeatableConfig.Side == PlayerGroup.Scav && !PlayerHasDailyScavQuestsUnlocked(pmcData))
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug("Daily scav quests still locked, Intel center not built");
-            }
+            logger.Debug("Daily scav quests still locked, Intel center not built");
 
             return false;
         }
@@ -836,12 +818,9 @@ public class RepeatableQuestController(
             if (questStatusInProfile.Status == QuestStatusEnum.AvailableForFinish)
             {
                 questsToKeep.Add(activeQuest);
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug( // TODO: this shouldn't happen, doesn't on live
-                        $"Keeping repeatable quest: {activeQuest.Id} in activeQuests since it is available to hand in"
-                    );
-                }
+                logger.Debug( // TODO: this shouldn't happen, doesn't on live
+                    $"Keeping repeatable quest: {activeQuest.Id} in activeQuests since it is available to hand in"
+                );
 
                 continue;
             }

--- a/Libraries/SPTarkov.Server.Core/Controllers/TradeController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/TradeController.cs
@@ -163,10 +163,7 @@ public class TradeController(
         {
             var errorMessage =
                 $"Unable to buy item: {fleaOffer.Items[0].Template} from trader: {fleaOffer.User.Id} as loyalty level too low, skipping";
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(errorMessage);
-            }
+            logger.Debug(errorMessage);
 
             httpResponseUtil.AppendErrorToOutput(
                 output,
@@ -320,10 +317,7 @@ public class TradeController(
     /// <param name="trader">Trader to sell items to</param>
     protected void MailMoneyToPlayer(MongoId sessionId, int roublesToSend, MongoId trader)
     {
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Selling scav items to fence for {roublesToSend} roubles");
-        }
+        logger.Debug($"Selling scav items to fence for {roublesToSend} roubles");
 
         // Create single currency item with all currency on it
         var rootCurrencyReward = new Item

--- a/Libraries/SPTarkov.Server.Core/Generators/BotEquipmentModGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotEquipmentModGenerator.cs
@@ -198,12 +198,9 @@ public class BotEquipmentModGenerator(
                 switch (plateSlotFilteringOutcome.Result)
                 {
                     case Result.UNKNOWN_FAILURE or Result.NO_DEFAULT_FILTER:
-                        if (logger.IsLogEnabled(LogLevel.Debug))
-                        {
-                            logger.Debug(
-                                $"Plate slot: {modSlotName} selection for armor: {parentTemplate.Id} failed: {plateSlotFilteringOutcome.Result}, skipping"
-                            );
-                        }
+                        logger.Debug(
+                            $"Plate slot: {modSlotName} selection for armor: {parentTemplate.Id} failed: {plateSlotFilteringOutcome.Result}, skipping"
+                        );
 
                         continue;
                     case Result.LACKS_PLATE_WEIGHTS:
@@ -411,12 +408,9 @@ public class BotEquipmentModGenerator(
             // No valid plate class found in 3 tries, attempt default plates
             if (findCompatiblePlateAttempts >= maxAttempts)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Plate filter too restrictive for armor: {armorItem.Name} {armorItem.Id}, unable to find plates of level: {chosenArmorPlateLevelString}, using items default plate"
-                    );
-                }
+                logger.Debug(
+                    $"Plate filter too restrictive for armor: {armorItem.Name} {armorItem.Id}, unable to find plates of level: {chosenArmorPlateLevelString}, using items default plate"
+                );
 
                 var defaultPlate = armorItem.GetDefaultPlateTpl(modSlot);
                 if (defaultPlate is not null)
@@ -1128,12 +1122,9 @@ public class BotEquipmentModGenerator(
         if ((modPool is null || !modPool.Any()) && !(parentSlot?.Required ?? false))
         {
             // Nothing in mod pool + item not required
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Mod pool for optional slot: {request.ModSlot} on item: {request.ParentTemplate.Name} was empty, skipping mod"
-                );
-            }
+            logger.Debug(
+                $"Mod pool for optional slot: {request.ModSlot} on item: {request.ParentTemplate.Name} was empty, skipping mod"
+            );
 
             return null;
         }
@@ -1212,12 +1203,9 @@ public class BotEquipmentModGenerator(
             && !parentSlot.Required.GetValueOrDefault(false)
         )
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Unable to find compatible mod of type: {parentSlot.Name}, in slot: {request.ModSlot} reason: {chosenModResult.Reason}"
-                );
-            }
+            logger.Debug(
+                $"Unable to find compatible mod of type: {parentSlot.Name}, in slot: {request.ModSlot} reason: {chosenModResult.Reason}"
+            );
         }
 
         // Get random mod to attach from items db for required slots if none found above
@@ -1509,12 +1497,9 @@ public class BotEquipmentModGenerator(
         {
             if (request.ItemModPool[request.ModSlot]?.Count > 1)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"{request.BotData.Role} No default: {request.ModSlot} mod found for: {weaponTemplate.Name}, using existing pool"
-                    );
-                }
+                logger.Debug(
+                    $"{request.BotData.Role} No default: {request.ModSlot} mod found for: {weaponTemplate.Name}, using existing pool"
+                );
             }
 
             // Couldn't find default in globals, use existing mod pool data
@@ -1556,23 +1541,17 @@ public class BotEquipmentModGenerator(
             }
 
             // Above chosen mod had conflicts with existing weapon mods
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"{request.BotData.Role} Chosen default: {request.ModSlot} mod found for: {weaponTemplate.Name} weapon conflicts with item on weapon, cannot use default"
-                );
-            }
+            logger.Debug(
+                $"{request.BotData.Role} Chosen default: {request.ModSlot} mod found for: {weaponTemplate.Name} weapon conflicts with item on weapon, cannot use default"
+            );
 
             var existingModPool = request.ItemModPool[request.ModSlot];
             if (existingModPool.Count == 1)
             {
                 // The only item in pool isn't compatible
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"{request.BotData.Role} {request.ModSlot} Mod pool for: {weaponTemplate.Name} weapon has only incompatible items, using parent list instead"
-                    );
-                }
+                logger.Debug(
+                    $"{request.BotData.Role} {request.ModSlot} Mod pool for: {weaponTemplate.Name} weapon has only incompatible items, using parent list instead"
+                );
 
                 // Last ditch, use full pool of items minus conflicts
                 var newListOfModsForSlot = parentSlotCompatibleItems.Where(tpl =>
@@ -1758,10 +1737,7 @@ public class BotEquipmentModGenerator(
                     new { modId = modBeingAddedDbTemplate.Value?.Id ?? "UNKNOWN", modSlot }
                 )
             );
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Item -> {parentTemplate?.Id}; Slot -> {modSlot}");
-            }
+            logger.Debug($"Item -> {parentTemplate?.Id}; Slot -> {modSlot}");
 
             return false;
         }
@@ -2058,12 +2034,9 @@ public class BotEquipmentModGenerator(
             )
         )
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Unable to find whitelist for weapon type: {weaponDetails.Value.Parent} {weaponDetails.Value.Name}, skipping sight filtering"
-                );
-            }
+            logger.Debug(
+                $"Unable to find whitelist for weapon type: {weaponDetails.Value.Parent} {weaponDetails.Value.Name}, skipping sight filtering"
+            );
 
             return scopes;
         }
@@ -2115,12 +2088,9 @@ public class BotEquipmentModGenerator(
         // No mods added to return list after filtering has occurred, send back the original mod list
         if (filteredScopesAndMods.Count == 0)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Scope whitelist too restrictive for: {weapon.Template} {weaponDetails.Value.Name}, skipping filter"
-                );
-            }
+            logger.Debug(
+                $"Scope whitelist too restrictive for: {weapon.Template} {weaponDetails.Value.Name}, skipping filter"
+            );
 
             return scopes;
         }

--- a/Libraries/SPTarkov.Server.Core/Generators/BotGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotGenerator.cs
@@ -342,12 +342,9 @@ public class BotGenerator(
     {
         if (!experiences.TryGetValue(botDifficulty.ToLowerInvariant(), out var result))
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Unable to find experience: {botDifficulty} for {role} bot, falling back to `normal`"
-                );
-            }
+            logger.Debug(
+                $"Unable to find experience: {botDifficulty} for {role} bot, falling back to `normal`"
+            );
 
             return randomUtil.GetInt(experiences["normal"].Min, experiences["normal"].Max);
         }

--- a/Libraries/SPTarkov.Server.Core/Generators/BotInventoryGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotInventoryGenerator.cs
@@ -436,12 +436,9 @@ public class BotInventoryGenerator(
 
         if (!tacVestsWithArmor.Any())
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Unable to filter to only armored rigs as bot: {botRole} has none in pool"
-                );
-            }
+            logger.Debug(
+                $"Unable to filter to only armored rigs as bot: {botRole} has none in pool"
+            );
 
             return;
         }
@@ -467,12 +464,9 @@ public class BotInventoryGenerator(
 
         if (!allowEmptyResult && !tacVestsWithoutArmor.Any())
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Unable to filter to only unarmored rigs as bot: {botRole} has none in pool"
-                );
-            }
+            logger.Debug(
+                $"Unable to filter to only unarmored rigs as bot: {botRole} has none in pool"
+            );
 
             return;
         }
@@ -535,10 +529,7 @@ public class BotInventoryGenerator(
                             chosenItemTpl
                         )
                     );
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug($"EquipmentSlot-> {settings.RootEquipmentSlot}");
-                    }
+                    logger.Debug($"EquipmentSlot-> {settings.RootEquipmentSlot}");
 
                     // Remove picked item
                     settings.RootEquipmentPool.Remove(chosenItemTpl);

--- a/Libraries/SPTarkov.Server.Core/Generators/BotLootGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotLootGenerator.cs
@@ -618,12 +618,9 @@ public class BotLootGenerator(
                 if (itemAddedResult == ItemAddedResult.NO_CONTAINERS)
                 {
                     // Bot has no container to put item in, exit
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Unable to add: {totalItemCount} items to bot as it lacks a container to include them"
-                        );
-                    }
+                    logger.Debug(
+                        $"Unable to add: {totalItemCount} items to bot as it lacks a container to include them"
+                    );
 
                     break;
                 }
@@ -631,14 +628,11 @@ public class BotLootGenerator(
                 fitItemIntoContainerAttempts++;
                 if (fitItemIntoContainerAttempts >= 4)
                 {
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Failed placing item: {itemToAddTemplate.Id} - {itemToAddTemplate.Name}: {i} of: {totalItemCount} items into: {botRole} "
-                                + $"containers: {string.Join(",", equipmentSlots)}. Tried: {fitItemIntoContainerAttempts} "
-                                + $"times, reason: {itemAddedResult}, skipping"
-                        );
-                    }
+                    logger.Debug(
+                        $"Failed placing item: {itemToAddTemplate.Id} - {itemToAddTemplate.Name}: {i} of: {totalItemCount} items into: {botRole} "
+                            + $"containers: {string.Join(",", equipmentSlots)}. Tried: {fitItemIntoContainerAttempts} "
+                            + $"times, reason: {itemAddedResult}, skipping"
+                    );
 
                     break;
                 }
@@ -811,12 +805,9 @@ public class BotLootGenerator(
 
             if (result != ItemAddedResult.SUCCESS)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Failed to add additional weapon: {weaponRootItem.Id} to bot backpack, reason: {result.ToString()}"
-                    );
-                }
+                logger.Debug(
+                    $"Failed to add additional weapon: {weaponRootItem.Id} to bot backpack, reason: {result.ToString()}"
+                );
             }
         }
     }
@@ -871,20 +862,17 @@ public class BotLootGenerator(
             // Prevent edge-case of small loot pools + code trying to add limited item over and over infinitely
             if (currentLimitCount > currentLimitCount * 10)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        serverLocalisationService.GetText(
-                            "bot-item_spawn_limit_reached_skipping_item",
-                            new
-                            {
-                                botRole,
-                                itemName = itemTemplate.Name,
-                                attempts = currentLimitCount,
-                            }
-                        )
-                    );
-                }
+                logger.Debug(
+                    serverLocalisationService.GetText(
+                        "bot-item_spawn_limit_reached_skipping_item",
+                        new
+                        {
+                            botRole,
+                            itemName = itemTemplate.Name,
+                            attempts = currentLimitCount,
+                        }
+                    )
+                );
 
                 return false;
             }

--- a/Libraries/SPTarkov.Server.Core/Generators/BotWeaponGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/BotWeaponGenerator.cs
@@ -647,12 +647,9 @@ public class BotWeaponGenerator(
 
             var defaultMagTplId = weaponTemplate.GetWeaponsDefaultMagazineTpl();
 
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"[{botRole}] Unable to find magazine for weapon: {weaponTemplate.Id} {weaponTemplate.Name}, using mag template default: {defaultMagTplId}."
-                );
-            }
+            logger.Debug(
+                $"[{botRole}] Unable to find magazine for weapon: {weaponTemplate.Id} {weaponTemplate.Name}, using mag template default: {defaultMagTplId}."
+            );
 
             return defaultMagTplId;
         }
@@ -677,20 +674,17 @@ public class BotWeaponGenerator(
             || cartridgePoolForWeapon?.Count == 0
         )
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    serverLocalisationService.GetText(
-                        "bot-no_caliber_data_for_weapon_falling_back_to_default",
-                        new
-                        {
-                            weaponId = weaponTemplate.Id,
-                            weaponName = weaponTemplate.Name,
-                            defaultAmmo = weaponTemplate.Properties.DefAmmo,
-                        }
-                    )
-                );
-            }
+            logger.Debug(
+                serverLocalisationService.GetText(
+                    "bot-no_caliber_data_for_weapon_falling_back_to_default",
+                    new
+                    {
+                        weaponId = weaponTemplate.Id,
+                        weaponName = weaponTemplate.Name,
+                        defaultAmmo = weaponTemplate.Properties.DefAmmo,
+                    }
+                )
+            );
 
             // Immediately returns, default ammo is guaranteed to be compatible
             // it is not guaranteed to even have a default ammo

--- a/Libraries/SPTarkov.Server.Core/Generators/LocationLootGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/LocationLootGenerator.cs
@@ -191,20 +191,14 @@ public class LocationLootGenerator(
             staticLootItemCount += containerWithLoot.Template.Items.Count;
         }
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug($"Added {guaranteedContainers.Count} guaranteed containers");
-        }
+        _logger.Debug($"Added {guaranteedContainers.Count} guaranteed containers");
 
         // Randomisation is turned off for location / globally
         if (!LocationRandomisationEnabled(locationId))
         {
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug(
-                    $"Container randomisation disabled, Adding: {staticRandomisableContainersOnMap.Count} containers to: {locationId}"
-                );
-            }
+            _logger.Debug(
+                $"Container randomisation disabled, Adding: {staticRandomisableContainersOnMap.Count} containers to: {locationId}"
+            );
 
             foreach (var container in staticRandomisableContainersOnMap)
             {
@@ -253,12 +247,9 @@ public class LocationLootGenerator(
 
             if (data.ContainerIdsWithProbability.Count == 0)
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        $"Group: {key} has no containers with < 100 % spawn chance to choose from, skipping"
-                    );
-                }
+                _logger.Debug(
+                    $"Group: {key} has no containers with < 100 % spawn chance to choose from, skipping"
+                );
 
                 continue;
             }
@@ -299,12 +290,9 @@ public class LocationLootGenerator(
                 );
                 if (containerObject is null)
                 {
-                    if (_logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        _logger.Debug(
-                            $"Container: {chosenContainerId} not found in staticRandomisableContainersOnMap, this is bad"
-                        );
-                    }
+                    _logger.Debug(
+                        $"Container: {chosenContainerId} not found in staticRandomisableContainersOnMap, this is bad"
+                    );
 
                     continue;
                 }
@@ -398,12 +386,9 @@ public class LocationLootGenerator(
         var containerIds = containerData.ContainerIdsWithProbability.Keys.ToList();
         if (containerData.ChosenCount > containerIds.Count)
         {
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug(
-                    $"Group: {groupId} wants: {containerData.ChosenCount} containers but pool only has: {containerIds.Count}, add what's available"
-                );
-            }
+            _logger.Debug(
+                $"Group: {groupId} wants: {containerData.ChosenCount} containers but pool only has: {containerIds.Count}, add what's available"
+            );
 
             return containerIds;
         }
@@ -492,12 +477,9 @@ public class LocationLootGenerator(
 
             if (container.Probability >= 1)
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        $"Container {container.Template.Id} with group: {groupData.GroupId} had 100 % chance to spawn was picked as random container, skipping"
-                    );
-                }
+                _logger.Debug(
+                    $"Container {container.Template.Id} with group: {groupData.GroupId} had 100 % chance to spawn was picked as random container, skipping"
+                );
 
                 continue;
             }
@@ -823,10 +805,7 @@ public class LocationLootGenerator(
             // Point is blacklisted, skip
             if (blacklistedSpawnPoints?.Contains(spawnPoint.Template.Id) ?? false)
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug($"Ignoring loose loot location: {spawnPoint.Template.Id}");
-                }
+                _logger.Debug($"Ignoring loose loot location: {spawnPoint.Template.Id}");
 
                 continue;
             }
@@ -879,20 +858,17 @@ public class LocationLootGenerator(
         var tooManySpawnPointsRequested = desiredSpawnPointCount - chosenSpawnPoints.Count > 0;
         if (tooManySpawnPointsRequested)
         {
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug(
-                    _serverLocalisationService.GetText(
-                        "location-spawn_point_count_requested_vs_found",
-                        new
-                        {
-                            requested = desiredSpawnPointCount + guaranteedLoosePoints.Count,
-                            found = chosenSpawnPoints.Count,
-                            mapName = locationName,
-                        }
-                    )
-                );
-            }
+            _logger.Debug(
+                _serverLocalisationService.GetText(
+                    "location-spawn_point_count_requested_vs_found",
+                    new
+                    {
+                        requested = desiredSpawnPointCount + guaranteedLoosePoints.Count,
+                        found = chosenSpawnPoints.Count,
+                        mapName = locationName,
+                    }
+                )
+            );
         }
 
         // Iterate over spawnPoints
@@ -931,15 +907,12 @@ public class LocationLootGenerator(
             // Spawn point has no items after filtering, skip
             if (spawnPoint.Template.Items is null || spawnPoint.Template.Items.Count == 0)
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        _serverLocalisationService.GetText(
-                            "location-spawnpoint_missing_items",
-                            spawnPoint.Template.Id
-                        )
-                    );
-                }
+                _logger.Debug(
+                    _serverLocalisationService.GetText(
+                        "location-spawnpoint_missing_items",
+                        spawnPoint.Template.Id
+                    )
+                );
 
                 continue;
             }
@@ -1084,12 +1057,9 @@ public class LocationLootGenerator(
             }
             else
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        $"Attempted to add a forced loot location with Id: {locationTemplateToAdd.Id} to map {locationName} that already has that id in use, skipping"
-                    );
-                }
+                _logger.Debug(
+                    $"Attempted to add a forced loot location with Id: {locationTemplateToAdd.Id} to map {locationName} that already has that id in use, skipping"
+                );
             }
         }
 
@@ -1359,10 +1329,7 @@ public class LocationLootGenerator(
         else
         {
             // RSP30 (62178be9d0050232da3485d9/624c0b3340357b5f566e8766/6217726288ed9f0845317459) doesn't have any default presets and kills this code below as it has no children to re-parent
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug($"createStaticLootItem() No preset found for weapon: {chosenTpl}");
-            }
+            _logger.Debug($"createStaticLootItem() No preset found for weapon: {chosenTpl}");
         }
 
         var rootItem = items.FirstOrDefault();

--- a/Libraries/SPTarkov.Server.Core/Generators/LootGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/LootGenerator.cs
@@ -445,15 +445,12 @@ public class LootGenerator(
         // No `_encyclopedia` property, not possible to reliably get root item tpl
         if (chosenPreset?.Encyclopedia is null)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Warning(
-                    serverLocalisationService.GetText(
-                        "loot-chosen_preset_missing_encyclopedia_value",
-                        chosenPreset?.Id
-                    )
-                );
-            }
+            logger.Warning(
+                serverLocalisationService.GetText(
+                    "loot-chosen_preset_missing_encyclopedia_value",
+                    chosenPreset?.Id
+                )
+            );
 
             return false;
         }
@@ -462,12 +459,7 @@ public class LootGenerator(
         var itemDbDetails = itemHelper.GetItem(chosenPreset.Encyclopedia.Value);
         if (!itemDbDetails.Key)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"$Unable to find preset with tpl: {chosenPreset.Encyclopedia}, skipping"
-                );
-            }
+            logger.Debug($"$Unable to find preset with tpl: {chosenPreset.Encyclopedia}, skipping");
 
             return false;
         }
@@ -629,10 +621,7 @@ public class LootGenerator(
                 );
                 if (!ammoBoxesMatchingCaliber.Any())
                 {
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug($"No ammo box with caliber {weaponCaliber} found, skipping");
-                    }
+                    logger.Debug($"No ammo box with caliber {weaponCaliber} found, skipping");
 
                     continue;
                 }
@@ -664,10 +653,7 @@ public class LootGenerator(
 
             if (!rewardItemPool.Any())
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug($"No items with base type of {rewardKey} found, skipping");
-                }
+                logger.Debug($"No items with base type of {rewardKey} found, skipping");
 
                 continue;
             }
@@ -719,12 +705,9 @@ public class LootGenerator(
             );
             if (relatedItems is null || !relatedItems.Any())
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"No items found to fulfil reward type: {rewardKey} for weapon: {chosenWeaponPreset.Name}, skipping type"
-                    );
-                }
+                logger.Debug(
+                    $"No items found to fulfil reward type: {rewardKey} for weapon: {chosenWeaponPreset.Name}, skipping type"
+                );
 
                 continue;
             }

--- a/Libraries/SPTarkov.Server.Core/Generators/PlayerScavGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/PlayerScavGenerator.cs
@@ -67,10 +67,7 @@ public class PlayerScavGenerator(
             );
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Generated player scav load out with karma level: {scavKarmaLevel}");
-        }
+        logger.Debug($"Generated player scav load out with karma level: {scavKarmaLevel}");
 
         // Edit baseBotNode values
         var baseBotNode = ConstructBotBaseTemplate(playerScavKarmaSettings.BotTypeForLoot);
@@ -191,10 +188,7 @@ public class PlayerScavGenerator(
 
             if (result != ItemAddedResult.SUCCESS)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug($"Unable to add keycard to bot. Reason: {result.ToString()}");
-                }
+                logger.Debug($"Unable to add keycard to bot. Reason: {result.ToString()}");
             }
         }
     }

--- a/Libraries/SPTarkov.Server.Core/Generators/RagfairOfferGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RagfairOfferGenerator.cs
@@ -402,7 +402,7 @@ public class RagfairOfferGenerator(
             ? expiredOffers ?? []
             : ragfairAssortGenerator.GetAssortItems();
         stopwatch.Stop();
-        if (logger.IsLogEnabled(LogLevel.Debug) && stopwatch.ElapsedMilliseconds > 0)
+        if (stopwatch.ElapsedMilliseconds > 0)
         {
             logger.Debug(
                 $"Took {stopwatch.ElapsedMilliseconds}ms to GetRagfairAssorts - {assortItemsToProcess.Count} items"
@@ -427,10 +427,7 @@ public class RagfairOfferGenerator(
 
         Task.WaitAll(tasks.ToArray());
         stopwatch.Stop();
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Took {stopwatch.ElapsedMilliseconds}ms to CreateOffersFromAssort");
-        }
+        logger.Debug($"Took {stopwatch.ElapsedMilliseconds}ms to CreateOffersFromAssort");
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/RepeatableQuestRewardGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/RepeatableQuestRewardGenerator.cs
@@ -161,12 +161,9 @@ public class RepeatableQuestRewardGenerator(
             }
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Generating: {repeatableConfig.Name} quest for: {traderId.ToString()} with budget: {itemRewardBudget} totalling: {rewardParams.RewardNumItems} items"
-            );
-        }
+        logger.Debug(
+            $"Generating: {repeatableConfig.Name} quest for: {traderId.ToString()} with budget: {itemRewardBudget} totalling: {rewardParams.RewardNumItems} items"
+        );
 
         if (inBudgetRewardItemPool.Count > 0)
         {
@@ -204,12 +201,9 @@ public class RepeatableQuestRewardGenerator(
             rewards.Success.Add(reward);
             rewardIndex++;
 
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Adding: {rewardParams.RewardReputation} {traderId.ToString()} trader reputation reward"
-                );
-            }
+            logger.Debug(
+                $"Adding: {rewardParams.RewardReputation} {traderId.ToString()} trader reputation reward"
+            );
         }
 
         // Chance of adding skill reward
@@ -229,12 +223,7 @@ public class RepeatableQuestRewardGenerator(
             };
             rewards.Success.Add(reward);
 
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Adding {rewardParams.SkillPointReward} skill points to {targetSkill}"
-                );
-            }
+            logger.Debug($"Adding {rewardParams.SkillPointReward} skill points to {targetSkill}");
         }
 
         return rewards;
@@ -424,12 +413,9 @@ public class RepeatableQuestRewardGenerator(
 
             var itemCost = presetHelper.GetDefaultPresetOrItemPrice(chosenItemFromPool.Id);
             var calculatedItemRewardBudget = itemRewardBudget - rewardItemStackCount * itemCost;
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Added item: {chosenItemFromPool.Id} with price: {rewardItemStackCount * itemCost}"
-                );
-            }
+            logger.Debug(
+                $"Added item: {chosenItemFromPool.Id} with price: {rewardItemStackCount * itemCost}"
+            );
 
             // If we still have budget narrow down possible items
             if (calculatedItemRewardBudget > 0)
@@ -443,12 +429,9 @@ public class RepeatableQuestRewardGenerator(
 
                 if (!exhaustibleItemPool.HasValues())
                 {
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Reward pool empty with: {calculatedItemRewardBudget} roubles of budget remaining"
-                        );
-                    }
+                    logger.Debug(
+                        $"Reward pool empty with: {calculatedItemRewardBudget} roubles of budget remaining"
+                    );
                 }
             }
 

--- a/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/ExternalInventoryMagGen.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/WeaponGen/Implementations/ExternalInventoryMagGen.cs
@@ -75,12 +75,9 @@ public class ExternalInventoryMagGen(
                 // Prevent infinite loop by only allowing 5 attempts at fitting a magazine into inventory
                 if (fitAttempts > 5)
                 {
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Failed {fitAttempts} times to add magazine {magazineTpl} to bot inventory, stopping"
-                        );
-                    }
+                    logger.Debug(
+                        $"Failed {fitAttempts} times to add magazine {magazineTpl} to bot inventory, stopping"
+                    );
 
                     break;
                 }
@@ -141,12 +138,9 @@ public class ExternalInventoryMagGen(
                             break;
                         }
 
-                        if (logger.IsLogEnabled(LogLevel.Debug))
-                        {
-                            logger.Debug(
-                                $"Unable to add additional magazine into bot inventory: vest/pockets for weapon: {weapon.Name}, attempted: {fitAttempts} times. Reason: {fitsIntoInventory}"
-                            );
-                        }
+                        logger.Debug(
+                            $"Unable to add additional magazine into bot inventory: vest/pockets for weapon: {weapon.Name}, attempted: {fitAttempts} times. Reason: {fitsIntoInventory}"
+                        );
 
                         break;
                     }

--- a/Libraries/SPTarkov.Server.Core/Helpers/BotGeneratorHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/BotGeneratorHelper.cs
@@ -566,12 +566,9 @@ public class BotGeneratorHelper(
                 if (missingContainerCount == equipmentSlots.Count)
                 {
                     // Bot doesn't have any containers we want to add item to
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Unable to add item: {itemWithChildren.FirstOrDefault()?.Template} to bot as it lacks the following containers: {string.Join(",", equipmentSlots)}"
-                        );
-                    }
+                    logger.Debug(
+                        $"Unable to add item: {itemWithChildren.FirstOrDefault()?.Template} to bot as it lacks the following containers: {string.Join(",", equipmentSlots)}"
+                    );
 
                     return ItemAddedResult.NO_CONTAINERS;
                 }

--- a/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
@@ -231,10 +231,7 @@ public class HideoutHelper(
 
         // Add bonus to player bonuses array in profile
         // EnergyRegeneration, HealthRegeneration, RagfairCommission, ScavCooldownTimer, SkillGroupLevelingBoost, ExperienceRate, QuestMoneyReward etc
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Adding bonus: {bonus.Type} to profile, value: {bonus.Value}");
-        }
+        logger.Debug($"Adding bonus: {bonus.Type} to profile, value: {bonus.Value}");
 
         profileData.Bonuses.Add(bonus);
     }
@@ -676,12 +673,9 @@ public class HideoutHelper(
                     isFuelItemFoundInRaid
                 );
 
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Profile: {pmcData.Id} Generator has: {fuelRemaining} fuel left in slot {i + 1}"
-                    );
-                }
+                logger.Debug(
+                    $"Profile: {pmcData.Id} Generator has: {fuelRemaining} fuel left in slot {i + 1}"
+                );
 
                 hasFuelRemaining = true;
 
@@ -692,10 +686,7 @@ public class HideoutHelper(
 
             // Ran out of fuel items to deduct fuel from
             fuelUsedSinceLastTick = Math.Abs(fuelRemaining ?? 0);
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Profile: {pmcData.Id} Generator ran out of fuel");
-            }
+            logger.Debug($"Profile: {pmcData.Id} Generator ran out of fuel");
         }
 
         // Out of fuel, flag generator as offline
@@ -904,10 +895,7 @@ public class HideoutHelper(
                     pointsConsumed,
                     isWaterFilterFoundInRaid
                 );
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug($"Water filter has: {resourceValue} units left in slot {i + 1}");
-                }
+                logger.Debug($"Water filter has: {resourceValue} units left in slot {i + 1}");
 
                 break; // Break here to avoid iterating other filters now we're done
             }
@@ -1079,10 +1067,7 @@ public class HideoutHelper(
                             UnitsConsumed = pointsConsumed,
                         },
                     };
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug($"Air filter: {resourceValue} filter left on slot {i + 1}");
-                    }
+                    logger.Debug($"Air filter: {resourceValue} filter left on slot {i + 1}");
 
                     break; // Break here to avoid updating all filters
                 }
@@ -1576,10 +1561,7 @@ public class HideoutHelper(
             bonusIdsToRemove.Add(bonus.Id);
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Removing: {bonusIdsToRemove.Count} bonuses from profile");
-        }
+        logger.Debug($"Removing: {bonusIdsToRemove.Count} bonuses from profile");
 
         // Remove the wall bonuses from profile by id
         pmcData.Bonuses = pmcData

--- a/Libraries/SPTarkov.Server.Core/Helpers/InventoryHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/InventoryHelper.cs
@@ -159,12 +159,9 @@ public class InventoryHelper(
         output.ProfileChanges[sessionId].Items.NewItems.AddRange(itemWithModsToAddClone);
         pmcData.Inventory.Items.AddRange(itemWithModsToAddClone);
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Added: {itemWithModsToAddClone[0].Upd?.StackObjectsCount ?? 1} item: {itemWithModsToAddClone[0].Template} with: {itemWithModsToAddClone.Count - 1} mods to inventory"
-            );
-        }
+        logger.Debug(
+            $"Added: {itemWithModsToAddClone[0].Upd?.StackObjectsCount ?? 1} item: {itemWithModsToAddClone[0].Template} with: {itemWithModsToAddClone.Count - 1} mods to inventory"
+        );
     }
 
     /// <summary>
@@ -495,15 +492,12 @@ public class InventoryHelper(
         var itemAndChildrenToRemove = profile.Inventory.Items.FindAndReturnChildrenAsItems(itemId);
         if (!itemAndChildrenToRemove.Any())
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    serverLocalisationService.GetText(
-                        "inventory-unable_to_remove_item_id_not_found",
-                        new { ChildId = itemId, ProfileId = profile.Id }
-                    )
-                );
-            }
+            logger.Debug(
+                serverLocalisationService.GetText(
+                    "inventory-unable_to_remove_item_id_not_found",
+                    new { ChildId = itemId, ProfileId = profile.Id }
+                )
+            );
 
             return;
         }
@@ -1201,12 +1195,9 @@ public class InventoryHelper(
             return false;
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"{moveRequest.Action} item: {moveRequest.Item} from slotid: {matchingInventoryItem.SlotId} to container: {moveRequest.To.Container}"
-            );
-        }
+        logger.Debug(
+            $"{moveRequest.Action} item: {moveRequest.Item} from slotid: {matchingInventoryItem.SlotId} to container: {moveRequest.To.Container}"
+        );
 
         // Don't move shells from camora to cartridges (happens when loading shells into mts-255 revolver shotgun)
         if (

--- a/Libraries/SPTarkov.Server.Core/Helpers/ItemHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ItemHelper.cs
@@ -1481,12 +1481,9 @@ public class ItemHelper(
         );
         if (cartridgeTpl is null)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Unable to fill item: {magazine.FirstOrDefault().Id} {magTemplate.Name} with cartridges, none found."
-                );
-            }
+            logger.Debug(
+                $"Unable to fill item: {magazine.FirstOrDefault().Id} {magTemplate.Name} with cartridges, none found."
+            );
 
             return;
         }
@@ -1762,12 +1759,9 @@ public class ItemHelper(
             var itemPool = slot.Props.Filters.FirstOrDefault().Filter ?? [];
             if (itemPool.Count == 0)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Unable to choose a mod for slot: {slot.Name} on item: {itemToAddTemplate.Id} {itemToAddTemplate.Name}, parents' 'Filter' array is empty, skipping"
-                    );
-                }
+                logger.Debug(
+                    $"Unable to choose a mod for slot: {slot.Name} on item: {itemToAddTemplate.Id} {itemToAddTemplate.Name}, parents' 'Filter' array is empty, skipping"
+                );
 
                 continue;
             }
@@ -1775,12 +1769,9 @@ public class ItemHelper(
             var chosenTpl = GetCompatibleTplFromArray(itemPool, incompatibleModTpls);
             if (chosenTpl is null)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Unable to choose a mod for slot: {slot.Name} on item: {itemToAddTemplate.Id} {itemToAddTemplate.Name}, no compatible tpl found in pool of {itemPool.Count}, skipping"
-                    );
-                }
+                logger.Debug(
+                    $"Unable to choose a mod for slot: {slot.Name} on item: {itemToAddTemplate.Id} {itemToAddTemplate.Name}, no compatible tpl found in pool of {itemPool.Count}, skipping"
+                );
 
                 continue;
             }
@@ -1931,10 +1922,7 @@ public class ItemHelper(
 
         if (warningMessageWhenMissing is not null)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(warningMessageWhenMissing);
-            }
+            logger.Debug(warningMessageWhenMissing);
         }
 
         return true;

--- a/Libraries/SPTarkov.Server.Core/Helpers/NotificationSendHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/NotificationSendHelper.cs
@@ -29,30 +29,19 @@ public class NotificationSendHelper(
     /// <param name="notificationMessage"></param>
     public void SendMessage(MongoId sessionID, WsNotificationEvent notificationMessage)
     {
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Send message for {sessionID} started, message: {jsonUtil.Serialize(notificationMessage)}"
-            );
-        }
+        logger.Debug(
+            $"Send message for {sessionID} started, message: {jsonUtil.Serialize(notificationMessage)}"
+        );
         if (sptWebSocketConnectionHandler.IsWebSocketConnected(sessionID))
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Send message for {sessionID} websocket available, message being sent"
-                );
-            }
+            logger.Debug($"Send message for {sessionID} websocket available, message being sent");
             sptWebSocketConnectionHandler.SendMessage(sessionID, notificationMessage);
         }
         else
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Send message for {sessionID} websocket not available, queueing into profile"
-                );
-            }
+            logger.Debug(
+                $"Send message for {sessionID} websocket not available, queueing into profile"
+            );
             notificationService.Add(sessionID, notificationMessage);
         }
     }

--- a/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
@@ -431,10 +431,7 @@ public class ProfileHelper(
         var profile = GetFullProfile(playerId);
         if (profile == null)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Unable to gift {giftId}, Profile: {playerId} does not exist");
-            }
+            logger.Debug($"Unable to gift {giftId}, Profile: {playerId} does not exist");
 
             return false;
         }

--- a/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/QuestHelper.cs
@@ -148,19 +148,13 @@ public class QuestHelper(
         {
             // Calculate how much progress to add, limiting it to the current level max progress
             var currentLevelRemainingProgress = (currentLevel + 1) * 10 - startingLevelProgress;
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"currentLevelRemainingProgress: {currentLevelRemainingProgress}");
-            }
+            logger.Debug($"currentLevelRemainingProgress: {currentLevelRemainingProgress}");
 
             var progressToAdd = Math.Min(remainingProgress, currentLevelRemainingProgress ?? 0);
             var adjustedProgressToAdd = 10 / (currentLevel + 1) * progressToAdd;
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Progress To Add: {progressToAdd}  Adjusted for level: {adjustedProgressToAdd}"
-                );
-            }
+            logger.Debug(
+                $"Progress To Add: {progressToAdd}  Adjusted for level: {adjustedProgressToAdd}"
+            );
 
             // Add the progress amount adjusted by level
             adjustedSkillProgress += (int)adjustedProgressToAdd;
@@ -719,10 +713,7 @@ public class QuestHelper(
             }
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"GetSellToTraderQuests found: {result.Count} quests");
-        }
+        logger.Debug($"GetSellToTraderQuests found: {result.Count} quests");
 
         return result;
     }
@@ -1021,12 +1012,9 @@ public class QuestHelper(
             var questInDb = allQuests.FirstOrDefault(x => x.Id == questId);
             if (questInDb is null)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Unable to find quest: {questId} in db, cannot get 'FindItem' condition, skipping"
-                    );
-                }
+                logger.Debug(
+                    $"Unable to find quest: {questId} in db, cannot get 'FindItem' condition, skipping"
+                );
 
                 continue;
             }
@@ -1292,12 +1280,9 @@ public class QuestHelper(
             // Player can use trader mods then remove them, leaving quests behind
             if (!profile.TradersInfo.ContainsKey(quest.TraderId))
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Unable to show quest: {quest.QuestName} as its for a trader: {quest.TraderId} that no longer exists."
-                    );
-                }
+                logger.Debug(
+                    $"Unable to show quest: {quest.QuestName} as its for a trader: {quest.TraderId} that no longer exists."
+                );
 
                 continue;
             }

--- a/Libraries/SPTarkov.Server.Core/Helpers/RagfairSellHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RagfairSellHelper.cs
@@ -96,12 +96,9 @@ public class RagfairSellHelper(
             );
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Rolling to sell: {itemSellCount} item(s) - (chance: {effectiveSellChance}%)"
-            );
-        }
+        logger.Debug(
+            $"Rolling to sell: {itemSellCount} item(s) - (chance: {effectiveSellChance}%)"
+        );
 
         // No point rolling for a sale on a 0% chance item, exit early
         if (effectiveSellChance == 0)
@@ -138,19 +135,13 @@ public class RagfairSellHelper(
                 sellTimestamp += (long)newSellTime;
                 result.Add(new SellResult { SellTime = sellTimestamp, Amount = boughtAmount });
 
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Offer will sell at: {timeUtil.GetDateTimeFromTimeStamp(sellTimestamp).ToLocalTime().ToString(CultureInfo.InvariantCulture)}, bought: {boughtAmount}"
-                    );
-                }
+                logger.Debug(
+                    $"Offer will sell at: {timeUtil.GetDateTimeFromTimeStamp(sellTimestamp).ToLocalTime().ToString(CultureInfo.InvariantCulture)}, bought: {boughtAmount}"
+                );
             }
             else
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug($"Offer rolled not to sell, item count: {boughtAmount}");
-                }
+                logger.Debug($"Offer rolled not to sell, item count: {boughtAmount}");
             }
 
             remainingCount -= boughtAmount;

--- a/Libraries/SPTarkov.Server.Core/Helpers/RepairHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RepairHelper.cs
@@ -42,12 +42,9 @@ public class RepairHelper(
         bool applyMaxDurabilityDegradation = true
     )
     {
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Adding {amountToRepair} to {itemToRepairDetails.Name} using kit: {useRepairKit}"
-            );
-        }
+        logger.Debug(
+            $"Adding {amountToRepair} to {itemToRepairDetails.Name} using kit: {useRepairKit}"
+        );
 
         var itemMaxDurability = cloner.Clone(itemToRepair.Upd.Repairable.MaxDurability);
         var itemCurrentDurability = cloner.Clone(itemToRepair.Upd.Repairable.Durability);

--- a/Libraries/SPTarkov.Server.Core/Helpers/TradeHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/TradeHelper.cs
@@ -139,12 +139,9 @@ public class TradeHelper(
                 var rootItemIndex = fenceItems.FindIndex(item => item.Id == buyRequestData.ItemId);
                 if (rootItemIndex == -1)
                 {
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Tried to buy item {buyRequestData.ItemId} from fence that no longer exists"
-                        );
-                    }
+                    logger.Debug(
+                        $"Tried to buy item {buyRequestData.ItemId} from fence that no longer exists"
+                    );
 
                     var message = serverLocalisationService.GetText(
                         "ragfair-offer_no_longer_exists"
@@ -336,12 +333,9 @@ public class TradeHelper(
                 return;
             }
 
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Selling: id: {matchingItemInInventory.Id} tpl: {matchingItemInInventory.Template}"
-                );
-            }
+            logger.Debug(
+                $"Selling: id: {matchingItemInInventory.Id} tpl: {matchingItemInInventory.Template}"
+            );
 
             if (sellRequest.TransactionId == Traders.FENCE)
             {

--- a/Libraries/SPTarkov.Server.Core/Helpers/TraderAssortHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/TraderAssortHelper.cs
@@ -81,24 +81,18 @@ public class TraderAssortHelper(
             var assortToAdjust = traderClone.Assort.Items.FirstOrDefault(x => x.Id == assortId.Key);
             if (assortToAdjust is null)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Cannot find trader: {traderClone.Base.Nickname} assort: {assortId} to adjust BuyRestrictionCurrent value, skipping"
-                    );
-                }
+                logger.Debug(
+                    $"Cannot find trader: {traderClone.Base.Nickname} assort: {assortId} to adjust BuyRestrictionCurrent value, skipping"
+                );
 
                 continue;
             }
 
             if (assortToAdjust.Upd is null)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Unable to adjust assort: {assortToAdjust.Id} item: {assortToAdjust.Template} BuyRestrictionCurrent value, assort has a null upd object"
-                    );
-                }
+                logger.Debug(
+                    $"Unable to adjust assort: {assortToAdjust.Id} item: {assortToAdjust.Template} BuyRestrictionCurrent value, assort has a null upd object"
+                );
 
                 continue;
             }

--- a/Libraries/SPTarkov.Server.Core/Helpers/TraderHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/TraderHelper.cs
@@ -120,10 +120,7 @@ public class TraderHelper(
         var traderAssorts = GetTraderAssortsByTraderId(traderId);
         if (traderAssorts is null)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"No assorts on trader: {traderId} found");
-            }
+            logger.Debug($"No assorts on trader: {traderId} found");
 
             return null;
         }
@@ -132,10 +129,7 @@ public class TraderHelper(
         var purchasedAssort = traderAssorts.Items.FirstOrDefault(item => item.Id == assortId);
         if (purchasedAssort is null)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"No assort {assortId} on trader: {traderId} found");
-            }
+            logger.Debug($"No assort {assortId} on trader: {traderId} found");
 
             return null;
         }

--- a/Libraries/SPTarkov.Server.Core/Models/Utils/ISptLogger.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Utils/ISptLogger.cs
@@ -24,6 +24,5 @@ public interface ISptLogger<T>
         LogBackgroundColor? backgroundColor = null,
         Exception? ex = null
     );
-    bool IsLogEnabled(LogLevel level);
     void DumpAndStop();
 }

--- a/Libraries/SPTarkov.Server.Core/Models/Utils/SptLoggerBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Utils/SptLoggerBase.cs
@@ -1,0 +1,118 @@
+using SPTarkov.Server.Core.Models.Logging;
+using LogLevel = SPTarkov.Server.Core.Models.Spt.Logging.LogLevel;
+
+namespace SPTarkov.Server.Core.Models.Utils;
+
+public abstract class SptLoggerBase<T> : ISptLogger<T>
+{
+    public abstract void LogWithColorInternal(
+        string data,
+        LogTextColor? textColor = null,
+        LogBackgroundColor? backgroundColor = null,
+        Exception? ex = null
+    );
+
+    public void LogWithColor(
+        string data,
+        LogTextColor? textColor = null,
+        LogBackgroundColor? backgroundColor = null,
+        Exception? ex = null
+    )
+    {
+        LogWithColorInternal(data, textColor, backgroundColor, ex);
+    }
+
+    protected abstract void SuccessInternal(string data, Exception? ex = null);
+
+    public void Success(string data, Exception? ex = null)
+    {
+        SuccessInternal(data, ex);
+    }
+
+    protected abstract void ErrorInternal(string data, Exception? ex = null);
+
+    public void Error(string data, Exception? ex = null)
+    {
+        if (!IsLogEnabled(LogLevel.Error))
+        {
+            return;
+        }
+
+        ErrorInternal(data, ex);
+    }
+
+    protected abstract void WarningInternal(string data, Exception? ex = null);
+
+    public void Warning(string data, Exception? ex = null)
+    {
+        if (!IsLogEnabled(LogLevel.Warn))
+        {
+            return;
+        }
+
+        WarningInternal(data, ex);
+    }
+
+    protected abstract void InfoInternal(string data, Exception? ex = null);
+
+    public void Info(string data, Exception? ex = null)
+    {
+        if (!IsLogEnabled(LogLevel.Info))
+        {
+            return;
+        }
+
+        InfoInternal(data, ex);
+    }
+
+    protected abstract void DebugInternal(string data, Exception? ex = null);
+
+    public void Debug(string data, Exception? ex = null)
+    {
+        if (!IsLogEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        DebugInternal(data, ex);
+    }
+
+    protected abstract void CriticalInternal(string data, Exception? ex = null);
+
+    public void Critical(string data, Exception? ex = null)
+    {
+        if (!IsLogEnabled(LogLevel.Fatal))
+        {
+            return;
+        }
+
+        CriticalInternal(data, ex);
+    }
+
+    protected abstract void LogInternal(
+        LogLevel level,
+        string data,
+        LogTextColor? textColor = null,
+        LogBackgroundColor? backgroundColor = null,
+        Exception? ex = null
+    );
+
+    public void Log(
+        LogLevel level,
+        string data,
+        LogTextColor? textColor = null,
+        LogBackgroundColor? backgroundColor = null,
+        Exception? ex = null
+    )
+    {
+        if (!IsLogEnabled(level))
+        {
+            return;
+        }
+        LogInternal(level, data, textColor, backgroundColor, ex);
+    }
+
+    protected abstract bool IsLogEnabled(LogLevel level);
+
+    public abstract void DumpAndStop();
+}

--- a/Libraries/SPTarkov.Server.Core/Routers/ItemEventRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/ItemEventRouter.cs
@@ -50,10 +50,7 @@ public class ItemEventRouter(
                 continue;
             }
 
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"event: {body.Action}");
-            }
+            logger.Debug($"event: {body.Action}");
 
             await eventRouter.HandleItemEvent(body.Action, pmcData, body, sessionID, output);
 

--- a/Libraries/SPTarkov.Server.Core/Servers/ConfigServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/ConfigServer.cs
@@ -62,10 +62,7 @@ public class ConfigServer
 
     public void Initialize()
     {
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug("Importing configs...");
-        }
+        _logger.Debug("Importing configs...");
 
         // Get all filepaths
         const string filepath = "./SPT_Data/configs/";

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -97,10 +97,7 @@ public class SptHttpListener(
 
                 if (!requestIsCompressed)
                 {
-                    if (_logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        _logger.Debug(body);
-                    }
+                    _logger.Debug(body);
                 }
 
                 var response = await GetResponse(sessionId, req, body);
@@ -142,10 +139,7 @@ public class SptHttpListener(
         {
             // Send only raw response without transformation
             await SendJson(resp, output, sessionID);
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug($"Response: {output}");
-            }
+            _logger.Debug($"Response: {output}");
 
             LogRequest(req, output);
             return;

--- a/Libraries/SPTarkov.Server.Core/Servers/SaveServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/SaveServer.cs
@@ -77,12 +77,7 @@ public class SaveServer(
         }
 
         stopwatch.Stop();
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"{files.Count()} Profiles took: {stopwatch.ElapsedMilliseconds}ms to load."
-            );
-        }
+        logger.Debug($"{files.Count()} Profiles took: {stopwatch.ElapsedMilliseconds}ms to load.");
     }
 
     /// <summary>
@@ -97,10 +92,7 @@ public class SaveServer(
             totalTime += await SaveProfileAsync(sessionID.Key);
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Saved {profiles.Count} profiles, took: {totalTime}ms");
-        }
+        logger.Debug($"Saved {profiles.Count} profiles, took: {totalTime}ms");
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
@@ -43,30 +43,21 @@ public class WebSocketServer(
 
         var webSocketIdContext = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug(
-                $"[WS] Notifying handlers of new websocket connection opening with reference {webSocketIdContext}"
-            );
-        }
+        _logger.Debug(
+            $"[WS] Notifying handlers of new websocket connection opening with reference {webSocketIdContext}"
+        );
 
         foreach (var wsh in socketHandlers)
         {
             if (webSocket.State == WebSocketState.Open)
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug($"WebSocketHandler \"{wsh.GetSocketId()}\" connected");
-                }
+                _logger.Debug($"WebSocketHandler \"{wsh.GetSocketId()}\" connected");
             }
 
             await wsh.OnConnection(webSocket, context, webSocketIdContext);
         }
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug($"[WS] Starting read loop for websocket reference {webSocketIdContext}");
-        }
+        _logger.Debug($"[WS] Starting read loop for websocket reference {webSocketIdContext}");
 
         var thread = Task.Factory.StartNew(
             async () =>
@@ -126,12 +117,9 @@ public class WebSocketServer(
 
                     if (result.EndOfMessage)
                     {
-                        if (_logger.IsLogEnabled(LogLevel.Debug))
-                        {
-                            _logger.Debug(
-                                $"[WS] Read loop for websocket reference {webSocketIdContext} received new message. Notifying socket handlers."
-                            );
-                        }
+                        _logger.Debug(
+                            $"[WS] Read loop for websocket reference {webSocketIdContext} received new message. Notifying socket handlers."
+                        );
 
                         var message = messageBuffer.ToArray();
 
@@ -157,7 +145,7 @@ public class WebSocketServer(
         var counter = 0;
         while (webSocket.State == WebSocketState.Open)
         {
-            if (counter == 30 && _logger.IsLogEnabled(LogLevel.Debug))
+            if (counter == 30)
             {
                 _logger.Debug(
                     $"[WS] Websocket keep alive for reference {webSocketIdContext}. Thread state {thread.Status}. Websocket state {webSocket.State}"
@@ -173,31 +161,20 @@ public class WebSocketServer(
             Thread.Sleep(1000);
         }
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug(
-                $"[WS] State for websocket reference {webSocketIdContext} is now {webSocket.State}, closing"
-            );
-        }
+        _logger.Debug(
+            $"[WS] State for websocket reference {webSocketIdContext} is now {webSocket.State}, closing"
+        );
 
         // Disconnect has been received, cancel the token and send OnClose to the relevant WebSockets.
         foreach (var wsh in socketHandlers)
         {
             await cts.CancelAsync();
 
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug(
-                    $"[WS] OnClose for websocket reference {webSocketIdContext} requested"
-                );
-            }
+            _logger.Debug($"[WS] OnClose for websocket reference {webSocketIdContext} requested");
 
             await wsh.OnClose(webSocket, context, webSocketIdContext);
         }
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug($"[WS] Websocket reference {webSocketIdContext} fully closed.");
-        }
+        _logger.Debug($"[WS] Websocket reference {webSocketIdContext} fully closed.");
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Servers/Ws/SptWebSocketConnectionHandler.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Ws/SptWebSocketConnectionHandler.cs
@@ -40,12 +40,9 @@ public class SptWebSocketConnectionHandler(
         var sessionID = splitUrl.Last();
         var playerProfile = _profileHelper.GetFullProfile(sessionID);
         var playerInfoText = $"{playerProfile.ProfileInfo.Username} ({sessionID})";
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug(
-                $"[WS] Websocket connect for player {playerInfoText} started with context {sessionIdContext}"
-            );
-        }
+        _logger.Debug(
+            $"[WS] Websocket connect for player {playerInfoText} started with context {sessionIdContext}"
+        );
 
         lock (_socketsLock)
         {
@@ -53,15 +50,12 @@ public class SptWebSocketConnectionHandler(
             {
                 if (sessionSockets.Any())
                 {
-                    if (_logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        _logger.Debug(
-                            _serverLocalisationService.GetText(
-                                "websocket-player_reconnect",
-                                new { sessionId = playerInfoText, contextId = sessionIdContext }
-                            )
-                        );
-                    }
+                    _logger.Debug(
+                        _serverLocalisationService.GetText(
+                            "websocket-player_reconnect",
+                            new { sessionId = playerInfoText, contextId = sessionIdContext }
+                        )
+                    );
                 }
             }
             else
@@ -71,15 +65,12 @@ public class SptWebSocketConnectionHandler(
             }
 
             sessionSockets.Add(sessionIdContext, ws);
-            if (_logger.IsLogEnabled(LogLevel.Info))
-            {
-                _logger.Info(
-                    _serverLocalisationService.GetText(
-                        "websocket-player_connected",
-                        new { sessionId = playerInfoText, contextId = sessionIdContext }
-                    )
-                );
-            }
+            _logger.Info(
+                _serverLocalisationService.GetText(
+                    "websocket-player_connected",
+                    new { sessionId = playerInfoText, contextId = sessionIdContext }
+                )
+            );
 
             return Task.CompletedTask;
         }
@@ -94,12 +85,9 @@ public class SptWebSocketConnectionHandler(
     {
         var splitUrl = context.Request.Path.Value.Split("/");
         var sessionID = splitUrl.Last();
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug(
-                $"[WS] Message for session {sessionID} received. Notifying message handlers."
-            );
-        }
+        _logger.Debug(
+            $"[WS] Message for session {sessionID} received. Notifying message handlers."
+        );
 
         foreach (var sptWebSocketMessageHandler in _messageHandlers)
         {
@@ -114,26 +102,17 @@ public class SptWebSocketConnectionHandler(
 
         lock (_socketsLock)
         {
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug(
-                    $"Attempting to close websocket session {sessionID} with context {sessionIdContext}"
-                );
-            }
+            _logger.Debug(
+                $"Attempting to close websocket session {sessionID} with context {sessionIdContext}"
+            );
 
             if (_sockets.TryGetValue(sessionID, out var sessionSockets) && sessionSockets.Any())
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        $"Websockets for session {sessionID} entry matched, attempting to find context {sessionIdContext}"
-                    );
-                }
+                _logger.Debug(
+                    $"Websockets for session {sessionID} entry matched, attempting to find context {sessionIdContext}"
+                );
 
-                if (
-                    !sessionSockets.TryGetValue(sessionIdContext, out _)
-                    && _logger.IsLogEnabled(LogLevel.Info)
-                )
+                if (!sessionSockets.TryGetValue(sessionIdContext, out _))
                 {
                     _logger.Info(
                         $"[ws] The websocket session {sessionID} with reference: {sessionIdContext} has already been removed or reconnected"
@@ -142,24 +121,18 @@ public class SptWebSocketConnectionHandler(
                 else
                 {
                     sessionSockets.Remove(sessionIdContext);
-                    if (_logger.IsLogEnabled(LogLevel.Info))
-                    {
-                        var playerProfile = _profileHelper.GetFullProfile(sessionID);
-                        var playerInfoText = $"{playerProfile.ProfileInfo.Username} ({sessionID})";
-                        _logger.Info(
-                            $"[ws] player: {playerInfoText} {sessionIdContext} has disconnected"
-                        );
-                    }
+                    var playerProfile = _profileHelper.GetFullProfile(sessionID);
+                    var playerInfoText = $"{playerProfile.ProfileInfo.Username} ({sessionID})";
+                    _logger.Info(
+                        $"[ws] player: {playerInfoText} {sessionIdContext} has disconnected"
+                    );
                 }
             }
             else
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        $"Websocket for session {sessionID} with context {sessionIdContext} does not exist on the socket map, nothing was removed"
-                    );
-                }
+                _logger.Debug(
+                    $"Websocket for session {sessionID} with context {sessionIdContext} does not exist on the socket map, nothing was removed"
+                );
             }
         }
     }
@@ -183,12 +156,9 @@ public class SptWebSocketConnectionHandler(
             {
                 var webSockets = GetSessionWebSocket(sessionID);
 
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        $"Send message for {sessionID} matched {webSockets.Count()} websockets. Messages being sent"
-                    );
-                }
+                _logger.Debug(
+                    $"Send message for {sessionID} matched {webSockets.Count()} websockets. Messages being sent"
+                );
 
                 foreach (var webSocket in webSockets)
                 {
@@ -198,34 +168,22 @@ public class SptWebSocketConnectionHandler(
                         true,
                         CancellationToken.None
                     );
-                    if (_logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        _logger.Debug($"Send message for {sessionID} on websocket async started");
-                    }
+                    _logger.Debug($"Send message for {sessionID} on websocket async started");
 
                     sendTask.Wait();
-                    if (_logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        _logger.Debug($"Send message for {sessionID} on websocket async finished");
-                    }
+                    _logger.Debug($"Send message for {sessionID} on websocket async finished");
                 }
 
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(_serverLocalisationService.GetText("websocket-message_sent"));
-                }
+                _logger.Debug(_serverLocalisationService.GetText("websocket-message_sent"));
             }
             else
             {
-                if (_logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    _logger.Debug(
-                        _serverLocalisationService.GetText(
-                            "websocket-not_ready_message_not_sent",
-                            sessionID
-                        )
-                    );
-                }
+                _logger.Debug(
+                    _serverLocalisationService.GetText(
+                        "websocket-not_ready_message_not_sent",
+                        sessionID
+                    )
+                );
             }
         }
         catch (Exception err)

--- a/Libraries/SPTarkov.Server.Core/Services/AirdropService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/AirdropService.cs
@@ -61,10 +61,7 @@ public class AirdropService(
     public GetAirdropLootResponse GenerateAirdropLoot(SptAirdropTypeEnum? forcedAirdropType = null)
     {
         var airdropType = forcedAirdropType ?? ChooseAirdropType();
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug($"Chose: {airdropType} for airdrop loot");
-        }
+        _logger.Debug($"Chose: {airdropType} for airdrop loot");
 
         // Common/weapon/etc
         var airdropConfig = GetAirdropLootConfigByType(airdropType);

--- a/Libraries/SPTarkov.Server.Core/Services/BackupService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BackupService.cs
@@ -105,10 +105,7 @@ public class BackupService
 
         if (currentProfilePaths.Count == 0)
         {
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug("No profiles to backup");
-            }
+            _logger.Debug("No profiles to backup");
 
             return;
         }
@@ -139,10 +136,7 @@ public class BackupService
                 _jsonUtil.Serialize(_activeServerMods)
             );
 
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug($"Profile backup created in: {targetDir}");
-            }
+            _logger.Debug($"Profile backup created in: {targetDir}");
         }
         catch (Exception ex)
         {
@@ -164,10 +158,7 @@ public class BackupService
             return true;
         }
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
-        {
-            _logger.Debug("Profile backups disabled");
-        }
+        _logger.Debug("Profile backups disabled");
 
         return false;
     }
@@ -302,10 +293,7 @@ public class BackupService
         {
             _fileUtil.DeleteDirectory(Path.Combine(pathToDelete), true);
 
-            if (_logger.IsLogEnabled(LogLevel.Debug))
-            {
-                _logger.Debug($"Deleted old backup: {pathToDelete}");
-            }
+            _logger.Debug($"Deleted old backup: {pathToDelete}");
         }
     }
 

--- a/Libraries/SPTarkov.Server.Core/Services/BotEquipmentFilterService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BotEquipmentFilterService.cs
@@ -430,12 +430,9 @@ public class BotEquipmentFilterService(
                     {
                         if (showEditWarnings)
                         {
-                            if (logger.IsLogEnabled(LogLevel.Debug))
-                            {
-                                logger.Debug(
-                                    $"Tried to edit a non - existent item for slot: {poolAdjustmentKvP} {itemToEditKvP}"
-                                );
-                            }
+                            logger.Debug(
+                                $"Tried to edit a non - existent item for slot: {poolAdjustmentKvP} {itemToEditKvP}"
+                            );
                         }
                     }
                 }
@@ -491,12 +488,9 @@ public class BotEquipmentFilterService(
                     {
                         if (showEditWarnings)
                         {
-                            if (logger.IsLogEnabled(LogLevel.Debug))
-                            {
-                                logger.Debug(
-                                    $"Tried to edit a non - existent item for slot: {poolAdjustmentKvP} {itemToEditKvP}"
-                                );
-                            }
+                            logger.Debug(
+                                $"Tried to edit a non - existent item for slot: {poolAdjustmentKvP} {itemToEditKvP}"
+                            );
                         }
                     }
                 }
@@ -565,12 +559,9 @@ public class BotEquipmentFilterService(
                     // We tried to add an item flagged as edit only
                     if (showEditWarnings)
                     {
-                        if (logger.IsLogEnabled(LogLevel.Debug))
-                        {
-                            logger.Debug(
-                                $"Tried to edit a non - existent item for slot: {poolAdjustmentKvP} {itemToEditKvP}"
-                            );
-                        }
+                        logger.Debug(
+                            $"Tried to edit a non - existent item for slot: {poolAdjustmentKvP} {itemToEditKvP}"
+                        );
                     }
                 }
             }

--- a/Libraries/SPTarkov.Server.Core/Services/BotNameService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BotNameService.cs
@@ -97,12 +97,9 @@ public class BotNameService(
                         // 5 attempts to generate a name, pool probably isn't big enough
                         var genericName =
                             $"{botGenerationDetails.Side} {randomUtil.GetInt(100000, 999999)}";
-                        if (logger.IsLogEnabled(LogLevel.Debug))
-                        {
-                            logger.Debug(
-                                $"Failed to find unique name for: {botRole} {botGenerationDetails.Side} after 5 attempts, using: {genericName}"
-                            );
-                        }
+                        logger.Debug(
+                            $"Failed to find unique name for: {botRole} {botGenerationDetails.Side} after 5 attempts, using: {genericName}"
+                        );
 
                         return genericName;
                     }

--- a/Libraries/SPTarkov.Server.Core/Services/BotWeaponModLimitService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BotWeaponModLimitService.cs
@@ -184,12 +184,9 @@ public class BotWeaponModLimitService(
         // Has mod limit for bot type been reached
         if (currentCount.Count >= maxLimit)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"[{botRole}] scope limit reached! tried to add {modTpl} but scope count is {currentCount.Count}"
-                );
-            }
+            logger.Debug(
+                $"[{botRole}] scope limit reached! tried to add {modTpl} but scope count is {currentCount.Count}"
+            );
 
             return true;
         }

--- a/Libraries/SPTarkov.Server.Core/Services/BtrDeliveryService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BtrDeliveryService.cs
@@ -140,12 +140,9 @@ public class BtrDeliveryService(
             .BtrDeliveryList.Where(package => package.Id != delivery.Id)
             .ToList();
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                $"Removed processed BTR delivery package. Remaining packages: {profile.BtrDeliveryList.Count}"
-            );
-        }
+        logger.Debug(
+            $"Removed processed BTR delivery package. Remaining packages: {profile.BtrDeliveryList.Count}"
+        );
     }
 
     /// <summary>
@@ -157,12 +154,9 @@ public class BtrDeliveryService(
         // If override in config is non-zero, use that
         if (_btrDeliveryConfig.ReturnTimeOverrideSeconds > 0)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"BTR delivery override used: returning in {_btrDeliveryConfig.ReturnTimeOverrideSeconds} seconds"
-                );
-            }
+            logger.Debug(
+                $"BTR delivery override used: returning in {_btrDeliveryConfig.ReturnTimeOverrideSeconds} seconds"
+            );
 
             return timeUtil.GetTimeStamp() + _btrDeliveryConfig.ReturnTimeOverrideSeconds;
         }

--- a/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
@@ -804,10 +804,7 @@ public class CircleOfCultistService(
                     continue;
                 }
 
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug($"Added Task Loot: {itemHelper.GetItemName(neededItem)}");
-                }
+                logger.Debug($"Added Task Loot: {itemHelper.GetItemName(neededItem)}");
 
                 rewardPool.Add(neededItem);
             }
@@ -852,12 +849,9 @@ public class CircleOfCultistService(
                         continue;
                     }
 
-                    if (logger.IsLogEnabled(LogLevel.Debug))
-                    {
-                        logger.Debug(
-                            $"Added Hideout Loot: {itemHelper.GetItemName(rewardToAdd.TemplateId)}"
-                        );
-                    }
+                    logger.Debug(
+                        $"Added Hideout Loot: {itemHelper.GetItemName(rewardToAdd.TemplateId)}"
+                    );
 
                     rewardPool.Add(rewardToAdd.TemplateId);
                 }
@@ -930,10 +924,7 @@ public class CircleOfCultistService(
                 }
             }
 
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Added: {itemHelper.GetItemName(randomItem.Key)}");
-            }
+            logger.Debug($"Added: {itemHelper.GetItemName(randomItem.Key)}");
 
             rewardPool.Add(randomItem.Key);
             currentItemCount++;

--- a/Libraries/SPTarkov.Server.Core/Services/CustomLocationWaveService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CustomLocationWaveService.cs
@@ -83,12 +83,9 @@ public class CustomLocationWaveService(
                 }
 
                 locationBase.BossLocationSpawn.Add(bossWave);
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        $"Added custom boss wave to {mapKvP.Key} of type {bossWave.BossName}, time: {bossWave.Time}, chance: {bossWave.BossChance}, zone: {(string.IsNullOrEmpty(bossWave.BossZone) ? "Global" : bossWave.BossZone)}"
-                    );
-                }
+                logger.Debug(
+                    $"Added custom boss wave to {mapKvP.Key} of type {bossWave.BossName}, time: {bossWave.Time}, chance: {bossWave.BossChance}, zone: {(string.IsNullOrEmpty(bossWave.BossZone) ? "Global" : bossWave.BossZone)}"
+                );
             }
         }
 

--- a/Libraries/SPTarkov.Server.Core/Services/DatabaseService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/DatabaseService.cs
@@ -397,10 +397,7 @@ public class DatabaseService(
         }
 
         start.Stop();
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"ID validation took: {start.ElapsedMilliseconds}ms");
-        }
+        logger.Debug($"ID validation took: {start.ElapsedMilliseconds}ms");
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/GiftService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/GiftService.cs
@@ -77,10 +77,7 @@ public class GiftService(
 
         if (profileHelper.PlayerHasReceivedMaxNumberOfGift(playerId, giftId, maxGiftsToSendCount))
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Player already received gift: {giftId}");
-            }
+            logger.Debug($"Player already received gift: {giftId}");
 
             return GiftSentResult.FAILED_GIFT_ALREADY_RECEIVED;
         }

--- a/Libraries/SPTarkov.Server.Core/Services/InsuranceService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/InsuranceService.cs
@@ -157,12 +157,9 @@ public class InsuranceService(
         // If override in config is non-zero, use that instead of trader values
         if (_insuranceConfig.ReturnTimeOverrideSeconds > 0)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Insurance override used: returning in {_insuranceConfig.ReturnTimeOverrideSeconds} seconds"
-                );
-            }
+            logger.Debug(
+                $"Insurance override used: returning in {_insuranceConfig.ReturnTimeOverrideSeconds} seconds"
+            );
 
             return timeUtil.GetTimeStamp() + _insuranceConfig.ReturnTimeOverrideSeconds;
         }

--- a/Libraries/SPTarkov.Server.Core/Services/ItemBaseClassService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/ItemBaseClassService.cs
@@ -93,12 +93,7 @@ public class ItemBaseClassService(
         if (!existsInCache)
         {
             // Not found
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    serverLocalisationService.GetText("baseclass-item_not_found", itemTpl)
-                );
-            }
+            logger.Debug(serverLocalisationService.GetText("baseclass-item_not_found", itemTpl));
 
             // Not found in cache, Hydrate again - some mods add items late in server startup lifecycle
             HydrateItemBaseClassCache();

--- a/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
@@ -359,10 +359,7 @@ public class LocationLifecycleService(
         var pmcProfile = fullProfile.CharacterData.PmcData;
         var scavProfile = fullProfile.CharacterData.ScavData;
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Raid: {request.ServerId} outcome: {request.Results.Result}");
-        }
+        logger.Debug($"Raid: {request.ServerId} outcome: {request.Results.Result}");
 
         // Reset flea interval time to out-of-raid value
         _ragfairConfig.RunIntervalSeconds = _ragfairConfig.RunIntervalValues.OutOfRaid;

--- a/Libraries/SPTarkov.Server.Core/Services/MailSendService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/MailSendService.cs
@@ -680,7 +680,7 @@ public class MailSendService(
             || messageDetails.DialogType == MessageType.NpcTraderMessage
         )
         {
-            if (messageDetails.Trader == null && logger.IsLogEnabled(LogLevel.Debug))
+            if (messageDetails.Trader == null)
             {
                 logger.Debug($"Trader was null for {messageDetails.TemplateId}");
             }

--- a/Libraries/SPTarkov.Server.Core/Services/PaymentService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/PaymentService.cs
@@ -148,10 +148,7 @@ public class PaymentService(
             traderHelper.LevelUp(requestTransactionId, pmcData);
         }
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug("Item(s) taken. Status OK.");
-        }
+        logger.Debug("Item(s) taken. Status OK.");
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/ProfileFixerService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/ProfileFixerService.cs
@@ -287,10 +287,7 @@ public class ProfileFixerService(
 
         foreach (var counterKeyToRemove in taskConditionKeysToRemove)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Removed: {counterKeyToRemove} TaskConditionCounter object");
-            }
+            logger.Debug($"Removed: {counterKeyToRemove} TaskConditionCounter object");
 
             pmcProfile.TaskConditionCounters.Remove(counterKeyToRemove);
         }
@@ -430,12 +427,9 @@ public class ProfileFixerService(
         var matchingProductionId = matchingProductions[0].Id;
         if (pmcProfile.UnlockedInfo.UnlockedProductionRecipe.Add(matchingProductionId))
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Added production: {matchingProductionId} to unlocked production recipes for: {questDetails.QuestName}"
-                );
-            }
+            logger.Debug(
+                $"Added production: {matchingProductionId} to unlocked production recipes for: {questDetails.QuestName}"
+            );
         }
     }
 
@@ -479,12 +473,9 @@ public class ProfileFixerService(
 
             if (genSlots < 6 + extraGenSlots)
             {
-                if (logger.IsLogEnabled(LogLevel.Debug))
-                {
-                    logger.Debug(
-                        "Updating generator area slots to a size of 6 + hideout management skill"
-                    );
-                }
+                logger.Debug(
+                    "Updating generator area slots to a size of 6 + hideout management skill"
+                );
 
                 AddEmptyObjectsToHideoutAreaSlots(
                     HideoutAreas.Generator,
@@ -507,12 +498,9 @@ public class ProfileFixerService(
 
         if (waterCollSlots < 1 + extraWaterCollSlots)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    "Updating water collector area slots to a size of 1 + hideout management skill"
-                );
-            }
+            logger.Debug(
+                "Updating water collector area slots to a size of 1 + hideout management skill"
+            );
 
             AddEmptyObjectsToHideoutAreaSlots(
                 HideoutAreas.WaterCollector,
@@ -534,12 +522,9 @@ public class ProfileFixerService(
 
         if (filterSlots < 3 + extraFilterSlots)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    "Updating air filter area slots to a size of 3 + hideout management skill"
-                );
-            }
+            logger.Debug(
+                "Updating air filter area slots to a size of 3 + hideout management skill"
+            );
 
             AddEmptyObjectsToHideoutAreaSlots(
                 HideoutAreas.AirFilteringUnit,
@@ -562,12 +547,9 @@ public class ProfileFixerService(
         // BTC Farm doesnt have extra slots for hideout management, but we still check for modded stuff!!
         if (btcFarmSlots < 50 + extraBtcSlots)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    "Updating bitcoin farm area slots to a size of 50 + hideout management skill"
-                );
-            }
+            logger.Debug(
+                "Updating bitcoin farm area slots to a size of 50 + hideout management skill"
+            );
 
             AddEmptyObjectsToHideoutAreaSlots(
                 HideoutAreas.BitcoinFarm,
@@ -581,10 +563,7 @@ public class ProfileFixerService(
             .Slots.Count;
         if (cultistAreaSlots < 1)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug("Updating cultist area slots to a size of 1");
-            }
+            logger.Debug("Updating cultist area slots to a size of 1");
 
             AddEmptyObjectsToHideoutAreaSlots(HideoutAreas.CircleOfCultists, 1, pmcProfile);
         }

--- a/Libraries/SPTarkov.Server.Core/Services/RagfairOfferService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RagfairOfferService.cs
@@ -291,10 +291,7 @@ public class RagfairOfferService(
         ragfairServerHelper.ReturnItems(offerCreatorProfile.SessionId.Value, unstackedItems);
         offerCreatorProfile.RagfairInfo.Offers.Splice(indexOfOfferInProfile, 1);
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Returned offer: {{playerOffer.Id}} items to player");
-        }
+        logger.Debug($"Returned offer: {{playerOffer.Id}} items to player");
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/RagfairPriceService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RagfairPriceService.cs
@@ -535,14 +535,11 @@ public class RagfairPriceService(
 
         var nonDefaultPresets = presetHelper.GetPresets(weapon.Template);
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug(
-                nonDefaultPresets.Count == 1
-                    ? $"Item Id: {weapon.Template} has no default encyclopedia entry but only one preset: ({nonDefaultPresets[0].Name}), choosing preset: ({nonDefaultPresets[0].Name})"
-                    : $"Item Id: {weapon.Template} has no default encyclopedia entry, choosing first preset({nonDefaultPresets[0].Name}) of {nonDefaultPresets.Count}"
-            );
-        }
+        logger.Debug(
+            nonDefaultPresets.Count == 1
+                ? $"Item Id: {weapon.Template} has no default encyclopedia entry but only one preset: ({nonDefaultPresets[0].Name}), choosing preset: ({nonDefaultPresets[0].Name})"
+                : $"Item Id: {weapon.Template} has no default encyclopedia entry, choosing first preset({nonDefaultPresets[0].Name}) of {nonDefaultPresets.Count}"
+        );
 
         return new WeaponPreset { IsDefault = false, Preset = nonDefaultPresets[0] };
     }

--- a/Libraries/SPTarkov.Server.Core/Services/RagfairTaxService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RagfairTaxService.cs
@@ -132,10 +132,7 @@ public class RagfairTaxService(
 
         var taxValue = Math.Round(discountedTax.Value * itemComissionMult);
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"Tax Calculated to be: {taxValue}");
-        }
+        logger.Debug($"Tax Calculated to be: {taxValue}");
 
         return taxValue;
     }

--- a/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
@@ -112,12 +112,9 @@ public class RepairService(
                 * _repairConfig.PriceMultiplier
         );
 
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"item base repair cost: {itemRepairCost}");
-            logger.Debug($"price multiplier: {_repairConfig.PriceMultiplier}");
-            logger.Debug($"repair cost: {repairCost}");
-        }
+        logger.Debug($"item base repair cost: {itemRepairCost}");
+        logger.Debug($"price multiplier: {_repairConfig.PriceMultiplier}");
+        logger.Debug($"repair cost: {repairCost}");
 
         return new RepairDetails
         {
@@ -508,12 +505,9 @@ public class RepairService(
         var maxRepairAmount = repairKitDetails.Properties.MaxRepairResource;
         if (repairKitInInventory.Upd is null)
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"Repair kit: {repairKitInInventory.Id} in inventory lacks upd object, adding"
-                );
-            }
+            logger.Debug(
+                $"Repair kit: {repairKitInInventory.Id} in inventory lacks upd object, adding"
+            );
 
             repairKitInInventory.Upd = new Upd
             {

--- a/Libraries/SPTarkov.Server.Core/Services/SeasonalEventService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/SeasonalEventService.cs
@@ -801,10 +801,7 @@ public class SeasonalEventService(
                     : Convert.ToDouble(
                         randomUtil.GetInt(Convert.ToInt32(infectionPercentage), 100)
                     );
-            if (logger.IsLogEnabled(LogLevel.Debug))
-                logger.Debug(
-                    $"Percent infected from map {locationId} is {randomInfectionPercentage}"
-                );
+            logger.Debug($"Percent infected from map {locationId} is {randomInfectionPercentage}");
             // Infection rates sometimes apply to multiple maps, e.g. Factory day/night or Sandbox/sandbox_high
             // Get the list of maps that should have infection value applied to their base
             // 90% of locations are just 1 map e.g. bigmap = customs

--- a/Libraries/SPTarkov.Server.Core/Utils/App.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/App.cs
@@ -42,29 +42,24 @@ public class App(
             await Task.Delay(Timeout.Infinite);
         }
 
-        if (_logger.IsLogEnabled(LogLevel.Debug))
+        _logger.Debug($"OS: {Environment.OSVersion.Version} | {Environment.OSVersion.Platform}");
+        _logger.Debug($"Ran as admin: {Environment.IsPrivilegedProcess}");
+        _logger.Debug($"CPU cores: {Environment.ProcessorCount}");
+        _logger.Debug(
+            $"PATH: {(Environment.ProcessPath ?? "null returned").Encode(EncodeType.BASE64)}"
+        );
+        _logger.Debug($"Server: {ProgramStatics.SPT_VERSION() ?? _coreConfig.SptVersion}");
+
+        // _logger.Debug($"RAM: {(os.totalmem() / 1024 / 1024 / 1024).toFixed(2)}GB");
+
+        if (ProgramStatics.BUILD_TIME() is not null)
         {
-            _logger.Debug(
-                $"OS: {Environment.OSVersion.Version} | {Environment.OSVersion.Platform}"
-            );
-            _logger.Debug($"Ran as admin: {Environment.IsPrivilegedProcess}");
-            _logger.Debug($"CPU cores: {Environment.ProcessorCount}");
-            _logger.Debug(
-                $"PATH: {(Environment.ProcessPath ?? "null returned").Encode(EncodeType.BASE64)}"
-            );
-            _logger.Debug($"Server: {ProgramStatics.SPT_VERSION() ?? _coreConfig.SptVersion}");
+            _logger.Debug($"Date: {ProgramStatics.BUILD_TIME()}");
+        }
 
-            // _logger.Debug($"RAM: {(os.totalmem() / 1024 / 1024 / 1024).toFixed(2)}GB");
-
-            if (ProgramStatics.BUILD_TIME() is not null)
-            {
-                _logger.Debug($"Date: {ProgramStatics.BUILD_TIME()}");
-            }
-
-            if (ProgramStatics.COMMIT() is not null)
-            {
-                _logger.Debug($"Commit: {ProgramStatics.COMMIT()}");
-            }
+        if (ProgramStatics.COMMIT() is not null)
+        {
+            _logger.Debug($"Commit: {ProgramStatics.COMMIT()}");
         }
 
         // execute onLoad callbacks

--- a/Libraries/SPTarkov.Server.Core/Utils/Cloners/ReflectionsCloner.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Cloners/ReflectionsCloner.cs
@@ -138,12 +138,7 @@ public class ReflectionsCloner(ISptLogger<ReflectionsCloner> logger) : ICloner
                         case MemberInfo:
                             break;
                         default:
-                            if (logger.IsLogEnabled(LogLevel.Debug))
-                            {
-                                logger.Debug(
-                                    $"Unknown member type {member.Name} {member.MemberType}"
-                                );
-                            }
+                            logger.Debug($"Unknown member type {member.Name} {member.MemberType}");
 
                             break;
                     }
@@ -157,10 +152,7 @@ public class ReflectionsCloner(ISptLogger<ReflectionsCloner> logger) : ICloner
         }
         else
         {
-            if (logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug($"Clone of type {objectType} is not supported");
-            }
+            logger.Debug($"Clone of type {objectType} is not supported");
         }
 
         return result;

--- a/Libraries/SPTarkov.Server.Core/Utils/Logger/SptLogger.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Logger/SptLogger.cs
@@ -6,7 +6,7 @@ using LogLevel = SPTarkov.Server.Core.Models.Spt.Logging.LogLevel;
 namespace SPTarkov.Server.Core.Utils.Logger;
 
 [Injectable(TypePriority = int.MinValue)]
-public class SptLogger<T> : ISptLogger<T>, IDisposable
+public class SptLogger<T> : SptLoggerBase<T>, IDisposable
 {
     private string _category;
     private readonly SptLoggerQueueManager _loggerQueueManager;
@@ -60,7 +60,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         _category = category;
     }
 
-    public void LogWithColor(
+    public override void LogWithColorInternal(
         string data,
         LogTextColor? textColor = null,
         LogBackgroundColor? backgroundColor = null,
@@ -82,7 +82,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public void Success(string data, Exception? ex = null)
+    protected override void SuccessInternal(string data, Exception? ex = null)
     {
         _loggerQueueManager.EnqueueMessage(
             new SptLogMessage(
@@ -98,7 +98,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public void Error(string data, Exception? ex = null)
+    protected override void ErrorInternal(string data, Exception? ex = null)
     {
         _loggerQueueManager.EnqueueMessage(
             new SptLogMessage(
@@ -114,7 +114,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public void Warning(string data, Exception? ex = null)
+    protected override void WarningInternal(string data, Exception? ex = null)
     {
         _loggerQueueManager.EnqueueMessage(
             new SptLogMessage(
@@ -130,7 +130,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public void Info(string data, Exception? ex = null)
+    protected override void InfoInternal(string data, Exception? ex = null)
     {
         _loggerQueueManager.EnqueueMessage(
             new SptLogMessage(
@@ -145,7 +145,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public void Debug(string data, Exception? ex = null)
+    protected override void DebugInternal(string data, Exception? ex = null)
     {
         _loggerQueueManager.EnqueueMessage(
             new SptLogMessage(
@@ -161,7 +161,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public void Critical(string data, Exception? ex = null)
+    protected override void CriticalInternal(string data, Exception? ex = null)
     {
         _loggerQueueManager.EnqueueMessage(
             new SptLogMessage(
@@ -178,7 +178,7 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public void Log(
+    protected override void LogInternal(
         LogLevel level,
         string data,
         LogTextColor? textColor = null,
@@ -201,12 +201,17 @@ public class SptLogger<T> : ISptLogger<T>, IDisposable
         );
     }
 
-    public bool IsLogEnabled(LogLevel level)
+    protected override bool IsLogEnabled(LogLevel level)
     {
         return _config.Loggers.Any(l => l.LogLevel.CanLog(level));
     }
 
-    public void DumpAndStop()
+    public bool IsEnabled(LogLevel level)
+    {
+        return IsLogEnabled(level);
+    }
+
+    public override void DumpAndStop()
     {
         _loggerQueueManager.DumpAndStop();
     }

--- a/SPTarkov.Server/Logger/SptLoggerWrapper.cs
+++ b/SPTarkov.Server/Logger/SptLoggerWrapper.cs
@@ -27,7 +27,7 @@ public class SptLoggerWrapper : ILogger
 
     public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
     {
-        return _logger.IsLogEnabled(ConvertLogLevel(logLevel));
+        return _logger.IsEnabled(ConvertLogLevel(logLevel));
     }
 
     public void Log<TState>(

--- a/SPTarkov.Server/Modding/ModValidator.cs
+++ b/SPTarkov.Server/Modding/ModValidator.cs
@@ -134,14 +134,11 @@ public class ModValidator(
         validMods.Sort((prev, next) => SortMods(prev, next, missingFromOrderJSON));
 
         // log the missing mods from order.json
-        if (logger.IsLogEnabled(LogLevel.Debug))
+        foreach (var missingMod in missingFromOrderJSON.Keys)
         {
-            foreach (var missingMod in missingFromOrderJSON.Keys)
-            {
-                logger.Debug(
-                    localisationService.GetText("modloader-mod_order_missing_from_json", missingMod)
-                );
-            }
+            logger.Debug(
+                localisationService.GetText("modloader-mod_order_missing_from_json", missingMod)
+            );
         }
 
         // add mods

--- a/Tools/HideoutCraftQuestIdGenerator/SptBasicLogger.cs
+++ b/Tools/HideoutCraftQuestIdGenerator/SptBasicLogger.cs
@@ -6,7 +6,7 @@ using SPTarkov.Server.Core.Models.Utils;
 namespace HideoutCraftQuestIdGenerator;
 
 [Injectable]
-public class SptBasicLogger<T> : ISptLogger<T>
+public class SptBasicLogger<T> : SptLoggerBase<T>
 {
     private readonly string categoryName;
 
@@ -15,7 +15,7 @@ public class SptBasicLogger<T> : ISptLogger<T>
         categoryName = typeof(T).Name;
     }
 
-    public void LogWithColor(
+    public override void LogWithColorInternal(
         string data,
         LogTextColor? textColor = null,
         LogBackgroundColor? backgroundColor = null,
@@ -25,37 +25,37 @@ public class SptBasicLogger<T> : ISptLogger<T>
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Success(string data, Exception? ex = null)
+    protected override void SuccessInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Error(string data, Exception? ex = null)
+    protected override void ErrorInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Warning(string data, Exception? ex = null)
+    protected override void WarningInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Info(string data, Exception? ex = null)
+    protected override void InfoInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Debug(string data, Exception? ex = null)
+    protected override void DebugInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Critical(string data, Exception? ex = null)
+    protected override void CriticalInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Log(
+    protected override void LogInternal(
         LogLevel level,
         string data,
         LogTextColor? textColor = null,
@@ -66,12 +66,12 @@ public class SptBasicLogger<T> : ISptLogger<T>
         throw new NotImplementedException();
     }
 
-    public bool IsLogEnabled(LogLevel level)
+    protected override bool IsLogEnabled(LogLevel level)
     {
         return true;
     }
 
-    public void DumpAndStop()
+    public override void DumpAndStop()
     {
         throw new NotImplementedException();
     }

--- a/Tools/ItemTplGenerator/SptBasicLogger.cs
+++ b/Tools/ItemTplGenerator/SptBasicLogger.cs
@@ -6,7 +6,7 @@ using SPTarkov.Server.Core.Models.Utils;
 namespace ItemTplGenerator;
 
 [Injectable]
-public class SptBasicLogger<T> : ISptLogger<T>
+public class SptBasicLogger<T> : SptLoggerBase<T>
 {
     private readonly string categoryName;
 
@@ -15,7 +15,7 @@ public class SptBasicLogger<T> : ISptLogger<T>
         categoryName = typeof(T).Name;
     }
 
-    public void LogWithColor(
+    public override void LogWithColorInternal(
         string data,
         LogTextColor? textColor = null,
         LogBackgroundColor? backgroundColor = null,
@@ -25,37 +25,37 @@ public class SptBasicLogger<T> : ISptLogger<T>
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Success(string data, Exception? ex = null)
+    protected override void SuccessInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Error(string data, Exception? ex = null)
+    protected override void ErrorInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Warning(string data, Exception? ex = null)
+    protected override void WarningInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Info(string data, Exception? ex = null)
+    protected override void InfoInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Debug(string data, Exception? ex = null)
+    protected override void DebugInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Critical(string data, Exception? ex = null)
+    protected override void CriticalInternal(string data, Exception? ex = null)
     {
         Console.WriteLine($"{categoryName}: {data}");
     }
 
-    public void Log(
+    protected override void LogInternal(
         LogLevel level,
         string data,
         LogTextColor? textColor = null,
@@ -71,12 +71,12 @@ public class SptBasicLogger<T> : ISptLogger<T>
         Console.WriteLine($"{categoryName}: {body}");
     }
 
-    public bool IsLogEnabled(LogLevel level)
+    protected override bool IsLogEnabled(LogLevel level)
     {
         return true;
     }
 
-    public void DumpAndStop()
+    public override void DumpAndStop()
     {
         throw new NotImplementedException();
     }

--- a/UnitTests/Mock/MockLogger.cs
+++ b/UnitTests/Mock/MockLogger.cs
@@ -4,9 +4,9 @@ using SPTarkov.Server.Core.Models.Utils;
 
 namespace UnitTests.Mock;
 
-public class MockLogger<T> : ISptLogger<T>
+public class MockLogger<T> : SptLoggerBase<T>
 {
-    public void LogWithColor(
+    public override void LogWithColorInternal(
         string data,
         LogTextColor? textColor = null,
         LogBackgroundColor? backgroundColor = null,
@@ -16,37 +16,37 @@ public class MockLogger<T> : ISptLogger<T>
         throw new NotImplementedException();
     }
 
-    public void Success(string data, Exception? ex = null)
+    protected override void SuccessInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Error(string data, Exception? ex = null)
+    protected override void ErrorInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Warning(string data, Exception? ex = null)
+    protected override void WarningInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Info(string data, Exception? ex = null)
+    protected override void InfoInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Debug(string data, Exception? ex = null)
+    protected override void DebugInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Critical(string data, Exception? ex = null)
+    protected override void CriticalInternal(string data, Exception? ex = null)
     {
         Console.WriteLine(data);
     }
 
-    public void Log(
+    protected override void LogInternal(
         LogLevel level,
         string data,
         LogTextColor? textColor = null,
@@ -62,12 +62,12 @@ public class MockLogger<T> : ISptLogger<T>
         throw new NotImplementedException();
     }
 
-    public bool IsLogEnabled(LogLevel level)
+    protected override bool IsLogEnabled(LogLevel level)
     {
         return true;
     }
 
-    public void DumpAndStop()
+    public override void DumpAndStop()
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
This change avoids all the calls to `logger.IsLogEnabled()` throughout the code base to make it more readable.
The new `SptLoggerBase<T>` checks if the logged level is enabled and all loggers derive from this new base class.
Also removed `bool IsLogEnabled(LogLevel level)` from the interface to avoid unnecessary checking.
Added new public method `SptLogger<T>.IsEnabled()` required for the wrapper since the interface method was removed.

The only slight downside is that `FormattableString`s passed to the log methods now get resolved/formatted even if they are not logged. Fixing this would require changing many log calls (i.e. by following the microsoft implementation with `params object?[] args`), since introducing overloads for `FormattableString` does not work because the compiler resolves the `string` overload. Imho this is a small enough performance hit to take for now.