### PR TITLE
Add some currency for trader ref to EDITPROFILE gift

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/gifts.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/gifts.json
@@ -2141,6 +2141,30 @@
                     },
                     "parentId": "6571e74a4a27570f5926ecb2",
                     "slotId": "main"
+                }, {
+                    "_id": "6571e74a4a9823b15926f4d1",
+                    "_tpl": "5d235b4d86f7742e017bc88a",
+                    "upd": {
+                        "StackObjectsCount": 100
+                    },
+                    "parentId": "6571e74a4a27570f5926ecb2",
+                    "slotId": "main"
+                }, {
+                    "_id": "6571e74a4a9823b15926f4d2",
+                    "_tpl": "5d235b4d86f7742e017bc88a",
+                    "upd": {
+                        "StackObjectsCount": 100
+                    },
+                    "parentId": "6571e74a4a27570f5926ecb2",
+                    "slotId": "main"
+                }, {
+                    "_id": "6571e74a4a9823b15926f4d3",
+                    "_tpl": "5d235b4d86f7742e017bc88a",
+                    "upd": {
+                        "StackObjectsCount": 100
+                    },
+                    "parentId": "6571e74a4a27570f5926ecb2",
+                    "slotId": "main"
                 }
             ],
             "profileChangeEvents": [{


### PR DESCRIPTION
The gift EDITPROFILE sets traders to max loyalty (including Ref) and already sends 10mil RUB and 100k USD to the player which they could use for purchases. However Ref only accepts GP Coins, so even though the gift sets him to LL4, no currency is provided to allow for any purchases.

This change includes 300 GP Coins (3 stacks) as well in the EDITPROFILE gift.

Before
<img width="841" height="177" alt="image" src="https://github.com/user-attachments/assets/702e9f4c-b04a-441b-a3ec-352f722265a2" />

After
<img width="841" height="177" alt="image" src="https://github.com/user-attachments/assets/406c40fc-8090-457a-8852-7d7b9319d622" />

