### PR TITLE
Fix sending invalid skill information to client

### DIFF
--- a/Benchmarks/ClonerBenchmarks.cs
+++ b/Benchmarks/ClonerBenchmarks.cs
@@ -3,6 +3,7 @@ using Benchmarks.Mock;
 using SPTarkov.Server.Core.Models.Spt.Templates;
 using SPTarkov.Server.Core.Utils;
 using SPTarkov.Server.Core.Utils.Cloners;
+using SPTarkov.Server.Core.Utils.Json;
 using SPTarkov.Server.Core.Utils.Json.Converters;
 
 namespace Benchmarks;

--- a/Libraries/SPTarkov.Server.Core/Services/ProfileFixerService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/ProfileFixerService.cs
@@ -624,7 +624,7 @@ public class ProfileFixerService(
     ///     Check for and cap profile skills at 5100.
     /// </summary>
     /// <param name="pmcProfile"> Profile to check and fix </param>
-    protected void CheckForSkillsOverMaxLevel(PmcData pmcProfile)
+    public void CheckForSkillsOverMaxLevel(PmcData pmcProfile)
     {
         var skills = pmcProfile.Skills.Common;
 


### PR DESCRIPTION
Some users like to crank skill multipliers insanely high and send the client invalid data causing a json exception when the profile is received.

- Check the skills and cap them before sending them to the client
- Fix bad using in benchmarks