### PR TITLE
Json adjustments (spelling, grammar)

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/core.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/core.json
@@ -25,7 +25,7 @@
                 "question_1": "An update to a popular mod that makes the game more realistic has been released, which of the following actions on discord will you do?",
                 "question_1_answer_1": "Ignore the changelog",
                 "question_1_answer_2": "Ignore the readme",
-                "question_1_answer_3": "Ask in general chat why the guns dont shoot",
+                "question_1_answer_3": "Ask in general chat why the guns don't shoot",
                 "question_1_answer_4": "Argue with general chat when they tell you to read the readme",
                 "question_1_answer_5": "Install as many mods as you can at the same time and get mad when everything breaks",
                 "question_1_answer_6": "Inform general chat of your displeasure and get mad when they laugh at you",
@@ -39,11 +39,11 @@
                 "question_2_answer_2": "Get REAL mad and voice your opinion in every possible chat you can",
                 "question_2_answer_3": "Travel around various discords informing anyone who listens what bad people SPT are",
                 "question_2_answer_4": "Create dozens of alt accounts to DM staff and inform them of your displeasure",
-                "question_2_answer_5": "Ask when the old SPT verison is coming back every day for weeks",
+                "question_2_answer_5": "Ask when the old SPT version is coming back every day for weeks",
                 "title": "Feedback survey",
                 "time": "About 1 minute",
                 "description": "This was the second SPT survey, what a valuable use of 20 minutes that was.",
-                "farewell": "You knew the first survey didnt do anything yet you still submitted the second one, you're quite an odd one."
+                "farewell": "You knew the first survey didn't do anything yet you still submitted the second one, you're quite an odd one."
             }
         },
         "survey": {

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/hideout.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/hideout.json
@@ -12,7 +12,7 @@
   "cultistCircle": {
     "maxRewardItemCount": 5,
     "maxAttemptsToPickRewardsWithinBudget": 5,
-    "rewardPriceMultiplerMinMax": {
+    "rewardPriceMultiplierMinMax": {
       "min": 0.7,
       "max": 1.4
     },

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/hideout.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/hideout.json
@@ -20,7 +20,7 @@
     "highValueThresholdRub": 70000,
     "hideoutTaskRewardTimeSeconds": 21600,
     "hideoutCraftSacrificeThresholdRub": 400000,
-    "craftTimeThreshholds": [
+    "craftTimeThresholds": [
       {
         "min": 1,
         "max": 350000,

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/inventory.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/inventory.json
@@ -1592,7 +1592,7 @@
         "allowBossItems": false
     },
     "customMoneyTpls": [],
-    "skillGainMultiplers": {
+    "skillGainMultipliers": {
         "Strength": 1
     },
     "deprioritisedMoneyContainers": ["590c60fc86f77412b13fddcf", "5d235bb686f77443f4331278"]

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
@@ -261,7 +261,7 @@
     },
     "offerAdjustment": {
       "adjustPriceWhenBelowHandbookPrice": false,
-      "handbookPriceMultipier": 1.1,
+      "handbookPriceMultiplier": 1.1,
       "maxPriceDifferenceBelowHandbookPercent": 64,
       "priceThreshholdRub": 20000
     },

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
@@ -263,7 +263,7 @@
       "adjustPriceWhenBelowHandbookPrice": false,
       "handbookPriceMultiplier": 1.1,
       "maxPriceDifferenceBelowHandbookPercent": 64,
-      "priceThreshholdRub": 20000
+      "priceThresholdRub": 20000
     },
     "offerItemCount": {
 		"default": {

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/HideoutConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/HideoutConfig.cs
@@ -102,8 +102,8 @@ public record CultistCircleSettings
     [JsonPropertyName("hideoutCraftSacrificeThresholdRub")]
     public int HideoutCraftSacrificeThresholdRub { get; set; }
 
-    [JsonPropertyName("craftTimeThreshholds")]
-    public required List<CraftTimeThreshold> CraftTimeThreshholds { get; set; }
+    [JsonPropertyName("craftTimeThresholds")]
+    public required List<CraftTimeThreshold> CraftTimeThresholds { get; set; }
 
     /// <summary>
     ///     -1 means no override, value in seconds

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/HideoutConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/HideoutConfig.cs
@@ -78,7 +78,7 @@ public record CultistCircleSettings
     [JsonPropertyName("maxAttemptsToPickRewardsWithinBudget")]
     public int MaxAttemptsToPickRewardsWithinBudget { get; set; }
 
-    [JsonPropertyName("rewardPriceMultiplerMinMax")]
+    [JsonPropertyName("rewardPriceMultiplierMinMax")]
     public required MinMax<double> RewardPriceMultiplierMinMax { get; set; }
 
     [JsonPropertyName("bonusChanceMultiplier")]

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/InventoryConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/InventoryConfig.cs
@@ -23,7 +23,7 @@ public record InventoryConfig : BaseConfig
     /// <summary>
     ///     Multipliers for skill gain when inside menus, NOT in-game
     /// </summary>
-    [JsonPropertyName("skillGainMultiplers")]
+    [JsonPropertyName("skillGainMultipliers")]
     public required Dictionary<string, double> SkillGainMultipliers { get; set; }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
@@ -357,7 +357,7 @@ public record OfferAdjustment
     /// <summary>
     ///     What is the minimum rouble price to consider adjusting price of item
     /// </summary>
-    [JsonPropertyName("priceThreshholdRub")]
+    [JsonPropertyName("priceThresholdRub")]
     public double PriceThresholdRub { get; set; }
 }
 

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
@@ -351,7 +351,7 @@ public record OfferAdjustment
     /// <summary>
     ///     How much to multiply the handbook price to get the new price
     /// </summary>
-    [JsonPropertyName("handbookPriceMultipier")]
+    [JsonPropertyName("handbookPriceMultiplier")]
     public double HandbookPriceMultiplier { get; set; }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
@@ -250,7 +250,7 @@ public class CircleOfCultistService(
 
         // Get a threshold where sacrificed amount is between thresholds min and max
         var matchingThreshold = GetMatchingThreshold(
-            circleConfig.CraftTimeThreshholds,
+            circleConfig.CraftTimeThresholds,
             rewardAmountRoubles
         );
         if (


### PR DESCRIPTION
* eda041dd Fix typo in priceThreshholdRub
  -  Json key change `priceThreshholdRub` --> `priceThresholdRub`. Method name was correct, no other references.
* d242891f Fix typo in handbookPriceMultipier
  -  Json key change `handbookPriceMultipier` --> `handbookPriceMultiplier`. Method name was correct, no other references.
* 69d5e1e2 Fix typo in skillGainMultiplers
  -  Json key change `skillGainMultiplers` --> `skillGainMultipliers`. Method name was correct
* 896e7348 Fix typo in cultistCircle.craftTimeThreshholds
  -  Json keychange `craftTimeThreshholds` --> `craftTimeThresholds` together with corresponding method and references
* 59e6b8bc Fix typo in cultistCircle.rewardPriceMultiplerMinMax
  - Json key change `rewardPriceMultiplerMinMax` --> `rewardPriceMultiplierMinMax`. Method name was correct, no other references.
* d42bfa52 Fix spelling