### PR TITLE
Json adjustments (spelling/grammar, key name refactor)

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/pmc.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/pmc.json
@@ -276,7 +276,7 @@
           "value": 50000
         }
       ],
-      "locationMultipler": {
+      "locationMultiplier": {
         "default": 1,
         "laboratory": 2,
         "labyrinth": 4
@@ -290,7 +290,7 @@
           "value": 50000
         }
       ],
-      "locationMultipler": {
+      "locationMultiplier": {
         "default": 1,
         "laboratory": 2,
         "labyrinth": 4
@@ -324,7 +324,7 @@
           "value": 2500000
         }
       ],
-      "locationMultipler": {
+      "locationMultiplier": {
         "default": 1,
         "laboratory": 2,
         "labyrinth": 4

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
@@ -1,6 +1,5 @@
 {
   "dynamic": {
-    "_currencies": "what percentage of the offers are in each currency",
     "armor": {
       "plateSlotIdToRemovePool": [
         "front_plate",
@@ -229,7 +228,7 @@
         }
       }
     },
-    "currencies": {
+    "offerCurrencyChancePercent": {
       "5449016a4bdc2d6f028b456f": 78,
       "5696686a4bdc2da3298b456a": 14,
       "569668774bdc2da2298b4568": 8

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/trader.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/trader.json
@@ -84,7 +84,7 @@
   "updateTimeDefault": 3600,
   "tradersResetFromServerStart": true,
   "purchasesAreFoundInRaid": false,
-  "traderPriceMultipler": 1,
+  "traderPriceMultiplier": 1,
   "fence": {
     "discountOptions": {
       "assortSize": 45,

--- a/Libraries/SPTarkov.Server.Core/Extensions/LootContainerSettingsExtensions.cs
+++ b/Libraries/SPTarkov.Server.Core/Extensions/LootContainerSettingsExtensions.cs
@@ -24,9 +24,9 @@ namespace SPTarkov.Server.Core.Extensions
             }
 
             // Get multiplier for map, use default if map not found
-            if (!settings.LocationMultipler.TryGetValue(locationId, out var multiplier))
+            if (!settings.LocationMultiplier.TryGetValue(locationId, out var multiplier))
             {
-                if (!settings.LocationMultipler.TryGetValue("default", out multiplier))
+                if (!settings.LocationMultiplier.TryGetValue("default", out multiplier))
                 {
                     return roubleTotalByLevel;
                 }

--- a/Libraries/SPTarkov.Server.Core/Helpers/RagfairServerHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RagfairServerHelper.cs
@@ -199,7 +199,7 @@ public class RagfairServerHelper(
     /// <returns>Currency TPL</returns>
     public MongoId GetDynamicOfferCurrency()
     {
-        return weightedRandomHelper.GetWeightedValue(ragfairConfig.Dynamic.Currencies);
+        return weightedRandomHelper.GetWeightedValue(ragfairConfig.Dynamic.OfferCurrencyChangePercent);
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Helpers/RagfairServerHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RagfairServerHelper.cs
@@ -199,7 +199,9 @@ public class RagfairServerHelper(
     /// <returns>Currency TPL</returns>
     public MongoId GetDynamicOfferCurrency()
     {
-        return weightedRandomHelper.GetWeightedValue(ragfairConfig.Dynamic.OfferCurrencyChangePercent);
+        return weightedRandomHelper.GetWeightedValue(
+            ragfairConfig.Dynamic.OfferCurrencyChangePercent
+        );
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/PmcConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/PmcConfig.cs
@@ -172,8 +172,8 @@ public record LootContainerSettings
     [JsonPropertyName("totalRubByLevel")]
     public List<MinMaxLootValue> TotalRubByLevel { get; set; }
 
-    [JsonPropertyName("locationMultipler")]
-    public Dictionary<string, double> LocationMultipler { get; set; }
+    [JsonPropertyName("locationMultiplier")]
+    public Dictionary<string, double> LocationMultiplier { get; set; }
 }
 
 public record HostilitySettings

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
@@ -202,10 +202,10 @@ public record Dynamic
     public Dictionary<MongoId, double>? ItemPriceMultiplier { get; set; }
 
     /// <summary>
-    ///     Percentages to sell offers in each currency
+    ///     Percentage chance for offers to be listed in specified currency
     /// </summary>
-    [JsonPropertyName("currencies")]
-    public required Dictionary<MongoId, double> Currencies { get; set; }
+    [JsonPropertyName("offerCurrencyChancePercent")]
+    public required Dictionary<MongoId, double> OfferCurrencyChangePercent { get; set; }
 
     /// <summary>
     ///     Item tpls that should be forced to sell as a single item

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/TraderConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/TraderConfig.cs
@@ -24,7 +24,7 @@ public record TraderConfig : BaseConfig
     [JsonPropertyName("tradersResetFromServerStart")]
     public bool TradersResetFromServerStart { get; set; }
 
-    [JsonPropertyName("traderPriceMultipler")]
+    [JsonPropertyName("traderPriceMultiplier")]
     public double TraderPriceMultiplier { get; set; }
 
     [JsonPropertyName("fence")]


### PR DESCRIPTION
* 7ef7ada2 Refactor Json key name to offerCurrencyChancePercent
  - Json key change `currencies` --> `offerCurrencyChancePercent` together with corresponding method and references.
  - More descriptive key name allows to get rid of Json comment `_currencies` which is oddly located in the file and not consistent with comment usage for other keys/files.
* 2c03fdff Fix typo in locationMultipler
  - Json key change `locationMultipler` --> `locationMultiplier` together with corresponding method and references.
* a12b0680 Fix typo in traderPriceMultipler
  - Json key change `traderPriceMultipler` --> `traderPriceMultiplier`. Method name was correct.
  - Note that there are also related entries in the locale Jsons, which I did not touch but I will note below in case they should be handled. 
  - Key name `trader-price_multipler_is_zero_use_default` remains with a typo in 21 server locale files.
  - Value string for this key contains a string representation of `traderPriceMultipler` in most locale files (except `cs.json` has the typo fixed, probably by translators. and `uk.json` has the key/property name translated)
  - Example: <img width="1295" height="45" alt="image" src="https://github.com/user-attachments/assets/0c2c1c05-4dc2-4b1c-b0cd-cf5082d4d2f1" />