### PR TITLE
Fixed unnecessary debug logging when processing hideout areas with resources

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
@@ -467,7 +467,7 @@ public class HideoutController(
         }
 
         // Handle areas that have resources that can be placed in/taken out of slots from the area
-        if (_areasWithResources.Contains(hideoutArea.Type ?? HideoutAreas.NotSet))
+        if (_areasWithResources.Contains(hideoutArea.Type))
         {
             var response = RemoveResourceFromArea(sessionID, pmcData, request, output, hideoutArea);
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
@@ -606,7 +606,8 @@ public class HideoutHelper(
             throw new HideoutHelperException(message);
         }
 
-        foreach (var area in pmcData.Hideout.Areas ?? [])
+        var areas = GetAreasWithResourceUse(pmcData.Hideout.Areas ?? []);
+        foreach (var area in areas)
         {
             switch (area.Type)
             {
@@ -628,11 +629,22 @@ public class HideoutHelper(
                 default:
                     if (logger.IsLogEnabled(LogLevel.Debug))
                     {
-                        logger.Debug($"Unhandled area type {area.Type} when trying to update areas with resources");
+                        logger.Debug($"Unhandled area type: {area.Type} when trying to update areas with resources");
                     }
                     break;
             }
         }
+    }
+
+    /// <summary>
+    /// Get Hideout areas that consume resources
+    /// </summary>
+    /// <param name="hideoutAreas">Areas to filter</param>
+    /// <returns>Collection of hideout areas</returns>
+    protected IEnumerable<BotHideoutArea> GetAreasWithResourceUse(List<BotHideoutArea> hideoutAreas)
+    {
+        HashSet<HideoutAreas> resourceUseAreas = [HideoutAreas.Generator, HideoutAreas.WaterCollector, HideoutAreas.AirFilteringUnit];
+        return hideoutAreas.Where(area => resourceUseAreas.Contains(area.Type));
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/BotBase.cs
@@ -926,7 +926,7 @@ public record BotHideoutArea
     public Dictionary<string, object>? ExtensionData { get; set; }
 
     [JsonPropertyName("type")]
-    public HideoutAreas? Type { get; set; }
+    public HideoutAreas Type { get; set; }
 
     [JsonPropertyName("level")]
     public int? Level { get; set; }


### PR DESCRIPTION
Filter down hideout areas prior to processing them in `UpdateAreasWithResources`

Updated hideout area "type" property to not be nullable