### PR TITLE
Add `MeansImplicitUse` Attribute to Patch and Injectable Attributes

### DIFF
--- a/Libraries/SPTarkov.DI/Annotations/Injectable.cs
+++ b/Libraries/SPTarkov.DI/Annotations/Injectable.cs
@@ -1,6 +1,9 @@
-﻿namespace SPTarkov.DI.Annotations;
+﻿using JetBrains.Annotations;
+
+namespace SPTarkov.DI.Annotations;
 
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+[MeansImplicitUse]
 public class Injectable(InjectionType injectionType = InjectionType.Scoped, Type? typeOverride = null, int typePriority = int.MaxValue)
     : Attribute
 {

--- a/Libraries/SPTarkov.DI/SPTarkov.DI.csproj
+++ b/Libraries/SPTarkov.DI/SPTarkov.DI.csproj
@@ -15,6 +15,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/Libraries/SPTarkov.Reflection/Patching/Attributes.cs
+++ b/Libraries/SPTarkov.Reflection/Patching/Attributes.cs
@@ -1,18 +1,25 @@
-﻿namespace SPTarkov.Reflection.Patching;
+﻿using JetBrains.Annotations;
+
+namespace SPTarkov.Reflection.Patching;
 
 [AttributeUsage(AttributeTargets.Method)]
+[MeansImplicitUse]
 public class PatchPrefixAttribute : Attribute { }
 
 [AttributeUsage(AttributeTargets.Method)]
+[MeansImplicitUse]
 public class PatchPostfixAttribute : Attribute { }
 
 [AttributeUsage(AttributeTargets.Method)]
+[MeansImplicitUse]
 public class PatchTranspilerAttribute : Attribute { }
 
 [AttributeUsage(AttributeTargets.Method)]
+[MeansImplicitUse]
 public class PatchFinalizerAttribute : Attribute { }
 
 [AttributeUsage(AttributeTargets.Method)]
+[MeansImplicitUse]
 public class PatchIlManipulatorAttribute : Attribute { }
 
 /// <summary>

--- a/Libraries/SPTarkov.Reflection/SPTarkov.Reflection.csproj
+++ b/Libraries/SPTarkov.Reflection/SPTarkov.Reflection.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HarmonyX" Version="2.15.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SPTarkov.DI\SPTarkov.DI.csproj" />


### PR DESCRIPTION
For mod entry points, they are used by mod loaders. There will be no usage of these classes in the code base, so the code analyzer will complain about the classes not being used where it is actually implicitly used. 

![Screenshot](https://github.com/user-attachments/assets/4730977a-47e4-471e-b689-5dcd702d8b94)

Instead of making modders add `[UsedImplicitly]` attribute to all the places, adding `[MeansImplicitUse]` to the `Injectable` attribute tells the analyzer that classes with this attribute are implicitly used. 

It is similar for the patch attributes, where the methods are implicitly used by `PatchManager`