### PR TITLE
Fix PatchManager Only Finding Patch Types Directly Inheriting `AbstractPatch`

### DIFF
--- a/Libraries/SPTarkov.Reflection/Patching/PatchManager.cs
+++ b/Libraries/SPTarkov.Reflection/Patching/PatchManager.cs
@@ -75,7 +75,7 @@ public class PatchManager
 
         foreach (var type in assembly.GetTypes())
         {
-            if (type.BaseType != baseType)
+            if (!type.IsAssignableTo(baseType) || type.IsAbstract)
             {
                 continue;
             }


### PR DESCRIPTION
Consider this scenario:
```cs
public abstract class PatchBase : AbstractPatch
{
// custom shared logic ...
}

public class PatchA : PatchBase
{
// patch methods...
}

public class PatchB : PatchBase
{
// patch methods...
}
```
The `PatchManager` would only find `PatchBase` and then failed to initialize it due to it being abstract.
By using `Type.IsAssignableTo`, it can now find patch classes that are not directly inheriting `AbstractPatch`.