### PR TITLE
Http server refactor

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
@@ -62,6 +62,8 @@
   "chat-unable_to_register_command_already_registered": "Unable to register already registered command: %s",
   "client_request": "[Client Request] %s",
   "client_request_ip": "[Client Request] {{ip}} {{url}}",
+  "websocket_request": "[WebSocket Request] %s",
+  "websocket_request_ip": "[WebSocket Request] {{ip}} {{url}}",
   "custom-quest-service_quest_id_already_exists": "A quest with the id: {{questId}} already exists.",
   "custom-quest-service_no_languages_for_quest": "No languages have been added for custom quest id: {{questId}}",
   "custom-quest-service_no_entries_for_language": "No locale entries have been added for language key: {{languageKey}}, was this intentional?",

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/IHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/IHttpListener.cs
@@ -6,5 +6,5 @@ namespace SPTarkov.Server.Core.Servers.Http;
 public interface IHttpListener
 {
     bool CanHandle(MongoId sessionId, HttpRequest req);
-    Task Handle(MongoId sessionId, HttpRequest req, HttpResponse resp);
+    Task Handle(MongoId sessionId, RequestDelegate next, HttpContext context);
 }

--- a/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
@@ -12,8 +12,6 @@ namespace SPTarkov.Server.Core.Servers;
 
 [Injectable(InjectionType.Singleton)]
 public class HttpServer(
-    ISptLogger<HttpServer> logger,
-    ServerLocalisationService serverLocalisationService,
     ConfigServer configServer,
     WebSocketServer webSocketServer,
     ProfileActivityService profileActivityService,
@@ -22,7 +20,7 @@ public class HttpServer(
 {
     protected readonly HttpConfig HttpConfig = configServer.GetConfig<HttpConfig>();
 
-    public async Task HandleRequest(HttpContext context)
+    public async Task HandleRequest(HttpContext context, RequestDelegate next)
     {
         if (context.WebSockets.IsWebSocketRequest)
         {
@@ -34,114 +32,22 @@ public class HttpServer(
         var sessionId = context.Request.Cookies.TryGetValue("PHPSESSID", out var sessionIdString)
             ? new MongoId(sessionIdString)
             : MongoId.Empty();
+
         if (!string.IsNullOrEmpty(sessionIdString))
         {
             profileActivityService.SetActivityTimestamp(sessionId);
         }
 
-        var realIp = context.Connection.RemoteIpAddress ?? IPAddress.Parse("127.0.0.1");
+        var listener = httpListeners.FirstOrDefault(listener => listener.CanHandle(sessionId, context.Request));
 
-        if (HttpConfig.LogRequests)
+        if (listener != null)
         {
-            LogRequest(context, realIp, IsPrivateOrLocalAddress(realIp));
-        }
-
-        try
-        {
-            var listener = httpListeners.FirstOrDefault(listener => listener.CanHandle(sessionId, context.Request));
-
-            if (listener != null)
-            {
-                await listener.Handle(sessionId, context.Request, context.Response);
-            }
-        }
-        catch (Exception ex)
-        {
-            logger.Critical("Error handling request: " + context.Request.Path);
-            logger.Critical(ex.Message);
-            logger.Critical(ex.StackTrace);
-#if DEBUG
-            throw; // added this so we can debug something.
-#endif
-        }
-
-        // This http request would be passed through the SPT Router and handled by an ICallback
-    }
-
-    /// <summary>
-    ///     Log request - handle differently if request is local
-    /// </summary>
-    /// <param name="context">HttpContext of request</param>
-    /// <param name="clientIp">Ip of requester</param>
-    /// <param name="isLocalRequest">Is this local request</param>
-    protected void LogRequest(HttpContext context, IPAddress clientIp, bool isLocalRequest)
-    {
-        if (isLocalRequest)
-        {
-            logger.Info(serverLocalisationService.GetText("client_request", context.Request.Path.Value));
+            await listener.Handle(sessionId, next, context);
         }
         else
         {
-            logger.Info(serverLocalisationService.GetText("client_request_ip", new { ip = clientIp, url = context.Request.Path.Value }));
+            await next(context);
         }
-    }
-
-    /// <summary>
-    ///     Check against hardcoded values that determine it's from a local address
-    /// </summary>
-    /// <param name="remoteAddress"> Address to check </param>
-    /// <returns> True if its local </returns>
-    protected bool IsPrivateOrLocalAddress(IPAddress remoteAddress)
-    {
-        if (IPAddress.IsLoopback(remoteAddress))
-        {
-            return true;
-        }
-
-        if (remoteAddress.AddressFamily == AddressFamily.InterNetwork)
-        {
-            var bytes = remoteAddress.GetAddressBytes();
-
-            switch (bytes[0])
-            {
-                case 10:
-                    return true; // 10.0.0.0/8 (private)
-
-                case 169:
-                    return bytes[1] == 254; // 169.254.0.0/16 (APIPA/link-local)
-
-                case 172:
-                    return bytes[1] >= 16 && bytes[1] <= 31; // 172.16.0.0/12 (private)
-
-                case 192:
-                    return bytes[1] == 168; // 192.168.0.0/16 (private)
-
-                default:
-                    return false;
-            }
-        }
-
-        if (remoteAddress.AddressFamily == AddressFamily.InterNetworkV6)
-        {
-            if (remoteAddress.IsIPv6LinkLocal)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    protected Dictionary<string, string> GetCookies(HttpRequest req)
-    {
-        var found = new Dictionary<string, string>();
-
-        foreach (var keyValuePair in req.Cookies)
-        {
-            found.Add(keyValuePair.Key, keyValuePair.Value);
-        }
-
-        return found;
     }
 
     public string ListeningUrl()

--- a/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
@@ -27,10 +27,6 @@ public class HttpServer(
             await webSocketServer.OnConnection(context);
             return;
         }
-        else
-        {
-            await next(context);
-        }
 
         // Use default empty mongoId if not found in cookie
         var sessionId = context.Request.Cookies.TryGetValue("PHPSESSID", out var sessionIdString)

--- a/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
@@ -1,10 +1,7 @@
-﻿using System.Net;
-using System.Net.Sockets;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.Models.Common;
 using SPTarkov.Server.Core.Models.Spt.Config;
-using SPTarkov.Server.Core.Models.Utils;
 using SPTarkov.Server.Core.Servers.Http;
 using SPTarkov.Server.Core.Services;
 

--- a/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
@@ -22,10 +22,14 @@ public class HttpServer(
 
     public async Task HandleRequest(HttpContext context, RequestDelegate next)
     {
-        if (context.WebSockets.IsWebSocketRequest)
+        if (context.WebSockets.IsWebSocketRequest && webSocketServer.CanHandle(context))
         {
             await webSocketServer.OnConnection(context);
             return;
+        }
+        else
+        {
+            await next(context);
         }
 
         // Use default empty mongoId if not found in cookie

--- a/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
@@ -10,6 +10,11 @@ namespace SPTarkov.Server.Core.Servers;
 [Injectable(InjectionType.Singleton)]
 public class WebSocketServer(IEnumerable<IWebSocketConnectionHandler> webSocketConnectionHandler, ISptLogger<WebSocketServer> logger)
 {
+    public bool CanHandle(HttpContext context)
+    {
+        return webSocketConnectionHandler.Any(wsh => context.Request.Path.Value.Contains(wsh.GetHookUrl()));
+    }
+
     public async Task OnConnection(HttpContext httpContext)
     {
         var socket = await httpContext.WebSockets.AcceptWebSocketAsync();

--- a/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
@@ -27,16 +27,6 @@ public class WebSocketServer(IEnumerable<IWebSocketConnectionHandler> webSocketC
 
         var cts = new CancellationTokenSource();
         var wsToken = cts.Token;
-
-        if (!socketHandlers.Any())
-        {
-            var message =
-                $"Socket connection received for url {context.Request.Path.Value}, but there is no websocket handler configured for it!";
-            logger.Debug(message);
-            await webSocket.CloseAsync(WebSocketCloseStatus.ProtocolError, message, CancellationToken.None);
-            return;
-        }
-
         var webSocketIdContext = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
 
         if (logger.IsLogEnabled(LogLevel.Debug))

--- a/Libraries/SPTarkov.Server.Core/Status/StatusPage.cs
+++ b/Libraries/SPTarkov.Server.Core/Status/StatusPage.cs
@@ -20,8 +20,10 @@ public class StatusPage(TimeUtil timeUtil, ProfileActivityService profileActivit
         return req.Method == "GET" && req.Path.Value.Contains("/status");
     }
 
-    public async Task Handle(MongoId sessionId, HttpRequest req, HttpResponse resp)
+    public async Task Handle(MongoId sessionId, RequestDelegate next, HttpContext context)
     {
+        var resp = context.Response;
+
         var sptVersion = $"SPT version: {ProgramStatics.SPT_VERSION()}";
         var debugEnabled = $"Debug enabled: {ProgramStatics.DEBUG()}";
         var modsEnabled = $"Mods enabled: {ProgramStatics.MODS()}";

--- a/SPTarkov.Server/Logger/SptLoggerMiddleware.cs
+++ b/SPTarkov.Server/Logger/SptLoggerMiddleware.cs
@@ -1,0 +1,117 @@
+﻿using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using Microsoft.Extensions.Primitives;
+using SPTarkov.Common.Extensions;
+using SPTarkov.Server.Core.Models.Spt.Config;
+using SPTarkov.Server.Core.Models.Utils;
+using SPTarkov.Server.Core.Servers;
+using SPTarkov.Server.Core.Services;
+
+namespace SPTarkov.Server.Logger;
+
+public class SptLoggerMiddleware(
+    RequestDelegate next,
+    ServerLocalisationService serverLocalisationService,
+    ConfigServer configServer,
+    ISptLogger<SptLoggerMiddleware> logger
+)
+{
+    protected readonly HttpConfig HttpConfig = configServer.GetConfig<HttpConfig>();
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!HttpConfig.LogRequests)
+        {
+            await next(context);
+            return;
+        }
+
+        var realIp = context.Connection.RemoteIpAddress ?? IPAddress.Parse("127.0.0.1");
+        LogRequest(context, realIp, IsPrivateOrLocalAddress(realIp));
+
+        try
+        {
+            await next(context);
+
+            if (context.Response.StatusCode == 404)
+            {
+                logger.Error(serverLocalisationService.GetText("unhandled_response", context.Request.Path.ToString()));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Critical("Error handling request: " + context.Request.Path);
+            logger.Critical(ex.Message);
+            logger.Critical(ex.StackTrace);
+#if DEBUG
+            throw; // added this so we can debug something.
+#endif
+        }
+    }
+
+    /// <summary>
+    ///     Log request - handle differently if request is local
+    /// </summary>
+    /// <param name="context">HttpContext of request</param>
+    /// <param name="clientIp">Ip of requester</param>
+    /// <param name="isLocalRequest">Is this local request</param>
+    protected void LogRequest(HttpContext context, IPAddress clientIp, bool isLocalRequest)
+    {
+        if (isLocalRequest)
+        {
+            logger.Info(serverLocalisationService.GetText("client_request", context.Request.Path.Value));
+        }
+        else
+        {
+            logger.Info(serverLocalisationService.GetText("client_request_ip", new { ip = clientIp, url = context.Request.Path.Value }));
+        }
+    }
+
+    /// <summary>
+    ///     Check against hardcoded values that determine it's from a local address
+    /// </summary>
+    /// <param name="remoteAddress"> Address to check </param>
+    /// <returns> True if its local </returns>
+    protected bool IsPrivateOrLocalAddress(IPAddress remoteAddress)
+    {
+        if (IPAddress.IsLoopback(remoteAddress))
+        {
+            return true;
+        }
+
+        if (remoteAddress.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var bytes = remoteAddress.GetAddressBytes();
+
+            switch (bytes[0])
+            {
+                case 10:
+                    return true; // 10.0.0.0/8 (private)
+
+                case 169:
+                    return bytes[1] == 254; // 169.254.0.0/16 (APIPA/link-local)
+
+                case 172:
+                    return bytes[1] >= 16 && bytes[1] <= 31; // 172.16.0.0/12 (private)
+
+                case 192:
+                    return bytes[1] == 168; // 192.168.0.0/16 (private)
+
+                default:
+                    return false;
+            }
+        }
+
+        if (remoteAddress.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (remoteAddress.IsIPv6LinkLocal)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/SPTarkov.Server/Logger/SptLoggerMiddleware.cs
+++ b/SPTarkov.Server/Logger/SptLoggerMiddleware.cs
@@ -29,7 +29,7 @@ public class SptLoggerMiddleware(
         }
 
         var realIp = context.Connection.RemoteIpAddress ?? IPAddress.Parse("127.0.0.1");
-        LogRequest(context, realIp, IsPrivateOrLocalAddress(realIp));
+        LogRequest(context, realIp, IsPrivateOrLocalAddress(realIp), context.WebSockets.IsWebSocketRequest);
 
         try
         {
@@ -57,15 +57,33 @@ public class SptLoggerMiddleware(
     /// <param name="context">HttpContext of request</param>
     /// <param name="clientIp">Ip of requester</param>
     /// <param name="isLocalRequest">Is this local request</param>
-    protected void LogRequest(HttpContext context, IPAddress clientIp, bool isLocalRequest)
+    protected void LogRequest(HttpContext context, IPAddress clientIp, bool isLocalRequest, bool isWSRequest)
     {
-        if (isLocalRequest)
+        if (isWSRequest)
         {
-            logger.Info(serverLocalisationService.GetText("client_request", context.Request.Path.Value));
+            if (isLocalRequest)
+            {
+                logger.Info(serverLocalisationService.GetText("websocket_request", context.Request.Path.Value));
+            }
+            else
+            {
+                logger.Info(
+                    serverLocalisationService.GetText("websocket_request_ip", new { ip = clientIp, url = context.Request.Path.Value })
+                );
+            }
         }
         else
         {
-            logger.Info(serverLocalisationService.GetText("client_request_ip", new { ip = clientIp, url = context.Request.Path.Value }));
+            if (isLocalRequest)
+            {
+                logger.Info(serverLocalisationService.GetText("client_request", context.Request.Path.Value));
+            }
+            else
+            {
+                logger.Info(
+                    serverLocalisationService.GetText("client_request_ip", new { ip = clientIp, url = context.Request.Path.Value })
+                );
+            }
         }
     }
 

--- a/SPTarkov.Server/Logger/SptLoggerMiddleware.cs
+++ b/SPTarkov.Server/Logger/SptLoggerMiddleware.cs
@@ -1,9 +1,5 @@
-﻿using System.Diagnostics;
-using System.Net;
+﻿using System.Net;
 using System.Net.Sockets;
-using System.Text.Json;
-using Microsoft.Extensions.Primitives;
-using SPTarkov.Common.Extensions;
 using SPTarkov.Server.Core.Models.Spt.Config;
 using SPTarkov.Server.Core.Models.Utils;
 using SPTarkov.Server.Core.Servers;

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -116,10 +116,13 @@ public static class Program
                 KeepAliveInterval = TimeSpan.FromSeconds(60),
             }
         );
+
+        app.UseMiddleware<SptLoggerMiddleware>();
+
         app.Use(
             async (HttpContext context, RequestDelegate _) =>
             {
-                await context.RequestServices.GetRequiredService<HttpServer>().HandleRequest(context);
+                await context.RequestServices.GetRequiredService<HttpServer>().HandleRequest(context, next);
             }
         );
     }

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -120,7 +120,7 @@ public static class Program
         app.UseMiddleware<SptLoggerMiddleware>();
 
         app.Use(
-            async (HttpContext context, RequestDelegate _) =>
+            async (HttpContext context, RequestDelegate next) =>
             {
                 await context.RequestServices.GetRequiredService<HttpServer>().HandleRequest(context, next);
             }


### PR DESCRIPTION
This refactors various parts of the WebSocketServer & HttpServer to handle other Kestrel middleware better should we eventually want to extend upon the usage of it further.

The changes I made:
- Moved all logging of requests to a central `SptLoggerMiddleware`
- Pulled through RequestDelegate's and HttpContext in IHttpListener, this is so that if a route isn't found `await next(context)` can be called (We may want to refactor this even more further down the line, just like the WebSocket server where we can check if this route is handled by SptHttpListener, and if not we continue without having to be so deep in those methods)
- Added logging for WS Requests (Will need new translations)