### PR TITLE
Repeatable quest tuning

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
@@ -518,7 +518,9 @@
       ],
       "questConfig": {
         "Exploration": {
+          "minExtracts": 1,
           "maxExtracts": 4,
+          "minExtractsWithSpecificExit": 1,
           "maxExtractsWithSpecificExit": 2,
           "possibleSkillRewards": [
             "Endurance",
@@ -1606,8 +1608,10 @@
       ],
       "questConfig": {
         "Exploration": {
+          "minExtracts": 5,
           "maxExtracts": 15,
-          "maxExtractsWithSpecificExit": 4,
+          "minExtractsWithSpecificExit": 3,
+          "maxExtractsWithSpecificExit": 7,
           "possibleSkillRewards": [
             "Endurance",
             "Strength",
@@ -2628,7 +2632,9 @@
             "Strength",
             "Vitality"
           ],
+          "minExtracts": 1,
           "maxExtracts": 3,
+          "minExtractsWithSpecificExit": 1,
           "maxExtractsWithSpecificExit": 1,
           "specificExits": {
             "chance": 20,

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
@@ -517,28 +517,86 @@
         }
       ],
       "questConfig": {
-        "Exploration": {
-          "minExtracts": 1,
-          "maxExtracts": 4,
-          "minExtractsWithSpecificExit": 1,
-          "maxExtractsWithSpecificExit": 2,
-          "possibleSkillRewards": [
-            "Endurance",
-            "Strength",
-            "Vitality"
-          ],
-          "specificExits": {
-            "chance": 20,
-            "passageRequirementWhitelist": [
-              "None",
-              "TransferItem",
-              "WorldEvent",
-              "Train",
-              "Reference",
-              "Empty"
-            ]
+        "Exploration": [
+          {
+            "levelRange": {
+              "min": 1,
+              "max": 15
+            },
+            "minExtracts": 1,
+            "maxExtracts": 3,
+            "minExtractsWithSpecificExit": 1,
+            "maxExtractsWithSpecificExit": 2,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 10,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
+          },
+          {
+            "levelRange": {
+              "min": 16,
+              "max": 40
+            },
+            "minExtracts": 2,
+            "maxExtracts": 7,
+            "minExtractsWithSpecificExit": 1,
+            "maxExtractsWithSpecificExit": 3,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 15,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
+          },
+          {
+            "levelRange": {
+              "min": 41,
+              "max": 100
+            },
+            "minExtracts": 3,
+            "maxExtracts": 15,
+            "minExtractsWithSpecificExit": 2,
+            "maxExtractsWithSpecificExit": 4,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 20,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
           }
-        },
+        ],
         "Completion": {
           "possibleSkillRewards": [
             "Endurance",
@@ -1607,28 +1665,86 @@
         }
       ],
       "questConfig": {
-        "Exploration": {
-          "minExtracts": 5,
-          "maxExtracts": 15,
-          "minExtractsWithSpecificExit": 3,
-          "maxExtractsWithSpecificExit": 7,
-          "possibleSkillRewards": [
-            "Endurance",
-            "Strength",
-            "Vitality"
-          ],
-          "specificExits": {
-            "chance": 10,
-            "passageRequirementWhitelist": [
-              "None",
-              "TransferItem",
-              "WorldEvent",
-              "Train",
-              "Reference",
-              "Empty"
-            ]
+        "Exploration": [
+          {
+            "levelRange": {
+              "min": 1,
+              "max": 15
+            },
+            "minExtracts": 3,
+            "maxExtracts": 5,
+            "minExtractsWithSpecificExit": 1,
+            "maxExtractsWithSpecificExit": 4,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 10,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
+          },
+          {
+            "levelRange": {
+              "min": 16,
+              "max": 40
+            },
+            "minExtracts": 4,
+            "maxExtracts": 8,
+            "minExtractsWithSpecificExit": 2,
+            "maxExtractsWithSpecificExit": 5,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 15,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
+          },
+          {
+            "levelRange": {
+              "min": 41,
+              "max": 100
+            },
+            "minExtracts": 5,
+            "maxExtracts": 15,
+            "minExtractsWithSpecificExit": 3,
+            "maxExtractsWithSpecificExit": 6,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 20,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
           }
-        },
+        ],
         "Completion": {
           "possibleSkillRewards": [
             "Endurance",
@@ -2626,27 +2742,86 @@
         }
       ],
       "questConfig": {
-        "Exploration": {
-          "possibleSkillRewards": [
-            "Endurance",
-            "Strength",
-            "Vitality"
-          ],
-          "minExtracts": 1,
-          "maxExtracts": 3,
-          "minExtractsWithSpecificExit": 1,
-          "maxExtractsWithSpecificExit": 1,
-          "specificExits": {
-            "chance": 20,
-            "passageRequirementWhitelist": [
-              "None",
-              "WorldEvent",
-              "Train",
-              "Reference",
-              "Empty"
-            ]
+        "Exploration": [
+          {
+            "levelRange": {
+              "min": 1,
+              "max": 15
+            },
+            "minExtracts": 1,
+            "maxExtracts": 3,
+            "minExtractsWithSpecificExit": 1,
+            "maxExtractsWithSpecificExit": 2,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 10,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
+          },
+          {
+            "levelRange": {
+              "min": 16,
+              "max": 40
+            },
+            "minExtracts": 2,
+            "maxExtracts": 7,
+            "minExtractsWithSpecificExit": 1,
+            "maxExtractsWithSpecificExit": 3,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 15,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
+          },
+          {
+            "levelRange": {
+              "min": 41,
+              "max": 100
+            },
+            "minExtracts": 3,
+            "maxExtracts": 15,
+            "minExtractsWithSpecificExit": 2,
+            "maxExtractsWithSpecificExit": 4,
+            "possibleSkillRewards": [
+              "Endurance",
+              "Strength",
+              "Vitality"
+            ],
+            "specificExits": {
+              "chance": 20,
+              "passageRequirementWhitelist": [
+                "None",
+                "TransferItem",
+                "WorldEvent",
+                "Train",
+                "Reference",
+                "Empty"
+              ]
+            }
           }
-        },
+        ],
         "Pickup": {
           "possibleSkillRewards": [
             "Endurance",

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/quest.json
@@ -281,7 +281,7 @@
           0.03,
           0.03
         ],
-        "rewardSpread": 0.4,
+        "rewardSpread": 0.25,
         "skillRewardChance": [
           0,
           1,
@@ -1388,7 +1388,7 @@
           0.06,
           0.07
         ],
-        "rewardSpread": 0.5,
+        "rewardSpread": 0.35,
         "skillRewardChance": [
           0,
           5,
@@ -2550,7 +2550,7 @@
           0.04,
           0.05
         ],
-        "rewardSpread": 0.5,
+        "rewardSpread": 0.35,
         "skillRewardChance": [
           0,
           0,

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
@@ -665,6 +665,7 @@
   "repeatable-accepted_repeatable_quest_not_found_in_active_quests": "Accepted a repeatable quest: %s which could not be found in the activeQuests array. Please report this bug",
   "repeatable-completion_quest_whitelist_too_small_or_blacklist_too_restrictive": "Generate Completion Quest: No items remain. Either Whitelist is too small or Blacklist too restrictive",
   "repeatable-difficulty_was_nan": "Repeatable Reward Generation: Difficulty was NaN. Setting to 1.",
+  "repeatable-exploration_config_no_template": "Unable to find exploration config for pmc level: {{pmcLevel}}",
   "repeatable-no_reward_item_found_in_price_range": "Repeatable Reward Generation: No item found in price range {{minPrice}} to {{roublesBudget}}",
   "repeatable-quest_handover_failed_condition_already_satisfied": "Quest handover error: condition is already satisfied? qid: {{questId}}, condition: {{conditionId}}, profileCounter:{{profileCounter}}, value:{{value}}",
   "repeatable-quest_handover_failed_condition_invalid": "Quest handover error: condition not found or incorrect value. qid: {{body.qid}}, condition: {{body.conditionId}}",

--- a/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RepeatableQuestGeneration/ExplorationQuestGenerator.cs
@@ -116,10 +116,10 @@ public class ExplorationQuestGenerator(
         out LocationInfo? locationInfo
     )
     {
-        if (pool.Pool?.Exploration?.Locations?.Count is null or 0)
+        if (pool.Pool.Exploration.Locations?.Count is null or 0)
         {
             // there are no more locations left for exploration; delete it as a possible quest type
-            pool.Types = pool.Types?.Where(t => t != "Exploration").ToList();
+            pool.Types = pool.Types.Where(t => t != "Exploration").ToList();
             locationInfo = null;
             return false;
         }
@@ -129,7 +129,7 @@ public class ExplorationQuestGenerator(
         var locationKey = randomUtil.DrawRandomFromDict(pool.Pool.Exploration.Locations)[0];
 
         // Make the location info object
-        var locationTarget = pool.Pool!.Exploration!.Locations![locationKey];
+        var locationTarget = pool.Pool.Exploration.Locations![locationKey];
 
         var requiresSpecificExtract = randomUtil.GetChance100(repeatableConfig.QuestConfig.Exploration.SpecificExits.Chance);
 
@@ -146,15 +146,19 @@ public class ExplorationQuestGenerator(
     /// <summary>
     ///     Get the number of times the player needs to exit
     /// </summary>
-    /// <param name="config">Exploration config</param>
+    /// <param name="explorationConfig">Exploration config</param>
     /// <param name="requiresSpecificExtract">Is this a specific extract</param>
     /// <returns>Number of exit requirements</returns>
-    protected int GetNumberOfExits(Exploration config, bool requiresSpecificExtract)
+    protected int GetNumberOfExits(Exploration explorationConfig, bool requiresSpecificExtract)
     {
-        // Different max extract count when specific extract needed
-        var exitTimesMax = requiresSpecificExtract ? config.MaximumExtractsWithSpecificExit : config.MaximumExtracts + 1;
+        var exitTimesMin = requiresSpecificExtract ? explorationConfig.MinimumExtractsWithSpecificExit : explorationConfig.MinimumExtracts;
 
-        return randomUtil.RandInt(1, exitTimesMax);
+        // Different max extract count when specific extract needed
+        var exitTimesMax = requiresSpecificExtract
+            ? explorationConfig.MaximumExtractsWithSpecificExit + 1
+            : explorationConfig.MaximumExtracts + 1;
+
+        return randomUtil.RandInt(exitTimesMin, exitTimesMax);
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Helpers/RepeatableQuestHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RepeatableQuestHelper.cs
@@ -33,6 +33,19 @@ public class RepeatableQuestHelper(
     }
 
     /// <summary>
+    ///     Get the relevant exploration config based on the current players PMC level
+    /// </summary>
+    /// <param name="pmcLevel">Level of PMC character</param>
+    /// <param name="repeatableConfig">Main repeatable config</param>
+    /// <returns>ExplorationConfig</returns>
+    public ExplorationConfig? GetExplorationConfigByPmcLevel(int pmcLevel, RepeatableQuestConfig repeatableConfig)
+    {
+        return repeatableConfig.QuestConfig.ExplorationConfig.FirstOrDefault(x =>
+            pmcLevel >= x.LevelRange.Min && pmcLevel <= x.LevelRange.Max
+        );
+    }
+
+    /// <summary>
     ///     Gets a cloned repeatable quest template for the provided type with a unique id
     /// </summary>
     /// <param name="type">Type of template to retrieve</param>

--- a/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Eft/Common/Tables/Quest.cs
@@ -329,7 +329,7 @@ public record QuestConditionCounter
 public record QuestConditionCounterCondition
 {
     [JsonPropertyName("id")]
-    public string? Id { get; set; }
+    public MongoId? Id { get; set; }
 
     [JsonPropertyName("dynamicLocale")]
     public bool? DynamicLocale { get; set; }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/QuestConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/QuestConfig.cs
@@ -338,16 +338,16 @@ public record RepeatableQuestTypesConfig
     ///     Defines exploration repeatable task generation parameters
     /// </summary>
     [JsonPropertyName("Exploration")]
-    public required Exploration Exploration { get; set; }
+    public required List<ExplorationConfig> ExplorationConfig { get; set; }
 
     /// <summary>
     ///     Defines completion repeatable task generation parameters
     /// </summary>
     [JsonPropertyName("Completion")]
-    public required Completion Completion { get; set; }
+    public required CompletionConfig CompletionConfig { get; set; }
 
     /// <summary>
-    ///     Defines pickup repeatable task generation parameters - TODO: Not implemented/No Data
+    ///     Defines pickup repeatable task generation parameters - TODO: Not implemented/No Data - NOTE: Does not work with dynamicLocale
     /// </summary>
     [JsonPropertyName("Pickup")]
     public Pickup? Pickup { get; set; }
@@ -359,8 +359,14 @@ public record RepeatableQuestTypesConfig
     public required List<EliminationConfig> Elimination { get; set; }
 }
 
-public record Exploration : BaseQuestConfig
+public record ExplorationConfig : BaseQuestConfig
 {
+    /// <summary>
+    ///     Level range at which elimination tasks should be generated from this config
+    /// </summary>
+    [JsonPropertyName("levelRange")]
+    public required MinMax<int> LevelRange { get; set; }
+
     /// <summary>
     ///     Minimum extract count that a per map extract requirement can be generated with
     /// </summary>
@@ -407,7 +413,7 @@ public record SpecificExits
     public required HashSet<string> PassageRequirementWhitelist { get; set; }
 }
 
-public record Completion : BaseQuestConfig
+public record CompletionConfig : BaseQuestConfig
 {
     /// <summary>
     ///     Minimum item count that can be requested

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/QuestConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/QuestConfig.cs
@@ -362,10 +362,22 @@ public record RepeatableQuestTypesConfig
 public record Exploration : BaseQuestConfig
 {
     /// <summary>
+    ///     Minimum extract count that a per map extract requirement can be generated with
+    /// </summary>
+    [JsonPropertyName("minExtracts")]
+    public required int MinimumExtracts { get; set; }
+
+    /// <summary>
     ///     Maximum extract count that a per map extract requirement can be generated with
     /// </summary>
     [JsonPropertyName("maxExtracts")]
     public required int MaximumExtracts { get; set; }
+
+    /// <summary>
+    ///     Minimum extract count that a specific extract can be generated with
+    /// </summary>
+    [JsonPropertyName("minExtractsWithSpecificExit")]
+    public required int MinimumExtractsWithSpecificExit { get; set; }
 
     /// <summary>
     ///     Maximum extract count that a specific extract can be generated with


### PR DESCRIPTION
- Generate Exploration requirements within set level ranges [1-15], [16-40], [41-100]
- Add min extract count requirement properties (Both map and specific)
- Rename `Exploration` and `Completion` to `ExplorationConfig` and `CompletionConfig` for clarity
- Reduce reward spread by 15% across the board 
- Fix a few warnings
- String to mongoId change