### PR TITLE
Fix traders salessum not increasing on purchase

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/PaymentService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/PaymentService.cs
@@ -79,7 +79,7 @@ public class PaymentService(
         var requestTransactionId = new MongoId(request.TransactionId);
 
         // Who is recipient of money player is sending
-        var payToTrader = request.Type == "buy_from_ragfair_trader" && traderHelper.TraderExists(requestTransactionId);
+        var payToTrader = traderHelper.TraderExists(requestTransactionId);
 
         // May need to convert to trader currency
         var trader = payToTrader ? traderHelper.GetTrader(requestTransactionId, sessionID) : new TraderBase { Currency = CurrencyType.RUB }; // TODO: cleanup


### PR DESCRIPTION
The chance of a PMC transaction ID overlapping with a trader is slim to none, but the request type can be multiple things for traders. Skip checking type, and validate just using the transaction ID == valid traderId