### PR TITLE
Remove tagilla brain from PMC brain pool

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/pmc.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/pmc.json
@@ -182,11 +182,9 @@
   "pmcType": {
     "pmcbear": {
       "factory4_day": {
-        "bossTagilla": 1,
         "pmcBEAR": 10
       },
       "factory4_night": {
-        "bossTagilla": 1,
         "pmcBEAR": 10
       },
       "bigmap": {
@@ -225,11 +223,9 @@
     },
     "pmcusec": {
       "factory4_day": {
-        "bossTagilla": 1,
         "pmcUSEC": 10
       },
       "factory4_night": {
-        "bossTagilla": 1,
         "pmcUSEC": 10
       },
       "bigmap": {


### PR DESCRIPTION
PMCs should only be using PMC brains, including any boss brains at all is going to cause issues with mods that expect them to only have PMC brains