### PR TITLE
Fix `checks.dat` Not Copied into Output Directory on Clean Compile

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPTarkov.Server.Assets.csproj
+++ b/Libraries/SPTarkov.Server.Assets/SPTarkov.Server.Assets.csproj
@@ -17,7 +17,15 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="build\PostBuild.cs" />
-    <None Include="SPT_Data\**">
+    <None Include="SPT_Data\**" Exclude="SPT_Data\checks.dat">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <PackageCopyToOutput>True</PackageCopyToOutput>
+      <ExcludeFromSingleFile>True</ExcludeFromSingleFile>
+      <buildAction>None</buildAction>
+      <Pack>true</Pack>
+      <PackagePath>contentFiles\any\any\SPT_Data\</PackagePath>
+    </None>
+    <None Include="SPT_Data\checks.dat" Condition="'$(Configuration)' == 'Release'">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <PackageCopyToOutput>True</PackageCopyToOutput>
       <ExcludeFromSingleFile>True</ExcludeFromSingleFile>
@@ -26,8 +34,11 @@
       <PackagePath>contentFiles\any\any\SPT_Data\</PackagePath>
     </None>
   </ItemGroup>
-  <Target Name="PostBuildHashFile" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(ProjectDir)PostBuild.ps1&quot;" />
+  <Target Name="PreBuildHashFile" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Release'">
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(ProjectDir)PostBuild.ps1&quot;">
+      <Output TaskParameter="ExitCode" PropertyName="HashFileExitCode" />
+    </Exec>
+    <Error Message="Failed to hash files" Condition=" '$(HashFileExitCode)' != '0'" />
   </Target>
   <ItemGroup>
     <Compile Remove="build\PostBuild.cs" />


### PR DESCRIPTION
The `checks.dat` file is generated after the build process, which means it doesn’t exist when the compiler initially collects the files to include. As a result, it isn’t copied into the output directory during a clean compile.

This issue doesn’t occur in the BE/release files because the Actions build process publishes the server twice, once for win-x64 and once for linux-x64, then merges the outputs into a single directory. During the first compile, `checks.dat` is generated but not copied. During the second compile, it’s included, so the final merged output contains the file.

If you download the server build artifacts from the Actions page, you’ll see that only one of the two artifacts includes `checks.dat`.

This PR fixes this issue by running the generation before project restore and again before compiling, in case the files are updated.