### PR TITLE
Allow bypass of SetConsoleOutputMode function

### DIFF
--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -234,7 +234,9 @@ public static class Program
 
     private static void SetConsoleOutputMode()
     {
-        if (!OperatingSystem.IsWindows() || Environment.GetEnvironmentVariable("DISABLE_VIRTUAL_TERMINAL") == "1")
+        var disableFlag = Environment.GetEnvironmentVariable("DISABLE_VIRTUAL_TERMINAL");
+        
+        if (!OperatingSystem.IsWindows() || disableFlag == "1" || string.Equals(disableFlag, "true", StringComparison.OrdinalIgnoreCase))
         {
             return;
         }


### PR DESCRIPTION
This PR adds an environment variable that allows the `SetConsoleOutputMode` function to be bypassed on Windows in an appropriate environment.

Specifically the use case is a server panel environment that manages the server console output itself. In this environment, the `SetConsoleOutputMode` function conflicts, resulting in the server not being able to be run.

Credit to @PhonicUK for the code.