### PR TITLE
Fix stash upgrade usage limit

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/core.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/core.json
@@ -190,7 +190,7 @@
         "giveCommandEnabled": true
       },
       "commandUseLimits": {
-        "StashRows": 29
+        "StashRows": 28
       },
       "ids": {
         "commando": "6723fd51c5924c57ce0ca01e",


### PR DESCRIPTION
The Stash upgrade should be a maximum of 56 lines