### PR TITLE
Fix daily quest always generating one quest type on replace.

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/RepeatableQuestController.cs
@@ -137,7 +137,7 @@ public class RepeatableQuestController(
         var repeatableConfig = QuestConfig.RepeatableQuests.FirstOrDefault(config => config.Name == repeatablesOfTypeInProfile.Name);
 
         // If the configuration dictates to replace with the same quest type, adjust the available quest types
-        if (repeatableConfig?.KeepDailyQuestTypeOnReplacement is not null)
+        if (repeatableConfig?.KeepDailyQuestTypeOnReplacement is not null && repeatableConfig.KeepDailyQuestTypeOnReplacement)
         {
             repeatableConfig.Types = [questToReplace.Type.ToString()];
         }


### PR DESCRIPTION
Value of `KeepDailyQuestTypeOnReplacement` is never checked and `repeatableConfig.Types` is stuck at the last replaced quest type.