### PR TITLE
Use local time on server status page

### DIFF
--- a/Libraries/SPTarkov.Server.Web/Components/Pages/Status.razor
+++ b/Libraries/SPTarkov.Server.Web/Components/Pages/Status.razor
@@ -73,7 +73,7 @@
         _sptVersion = ProgramStatics.SPT_VERSION().ToString();
         _debugEnabled = ProgramStatics.DEBUG();
         _modsEnabled = ProgramStatics.MODS();
-        _startTime = TimeUtil.GetDateTimeFromTimeStamp(coreConfig.ServerStartTime.Value);
+        _startTime = TimeUtil.GetDateTimeFromTimeStamp(coreConfig.ServerStartTime.Value).ToLocalTime();
         _uptimeSeconds = DateTimeOffset.Now.ToUnixTimeSeconds() - coreConfig.ServerStartTime.Value;
 
         var activeProfileIds = ProfileActivityService.GetActiveProfileIdsWithinMinutes(30);


### PR DESCRIPTION
The server start parameter that renders on the status page is using a timestamp which is UTC. This will convert it to the servers local time. I am GMT-4 and provided a screenshot of the fix.

<img width="1580" height="1219" alt="image" src="https://github.com/user-attachments/assets/4be2d719-3224-48fc-bbaa-2975dd16969d" />
