### PR TITLE
Fix exception sometimes thrown on save

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/FileUtil.cs
@@ -135,14 +135,7 @@ public class FileUtil
             }
 
             // Overwrite over the old file
-            if (File.Exists(filePath))
-            {
-                File.Replace(tempFilePath, filePath, null);
-            }
-            else
-            {
-                File.Move(tempFilePath, filePath);
-            }
+            File.Move(tempFilePath, filePath, overwrite: true);
         }
         catch
         {


### PR DESCRIPTION
- Switch back from File.Rename to File.Move, as Rename is throwing exceptions on some users systems