### PR TITLE
Fixes hardcrash on missing `LoyalLevelItem` when generating Trader's ragfair offer

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
@@ -623,6 +623,7 @@
   "ragfair-invalid_player_offer_request": "Unable to place offer, request is invalid",
   "ragfair-item_not_in_db_unable_to_generate_dynamic_stack_count": "Item with tpl: %s not found in db. Unable to generate a dynamic stack count",
   "ragfair-missing_barter_scheme": "generateFleaOffersForTrader() Failed to find barterScheme for item id: {{itemId}} tpl: {{tpl}} on {{name}}",
+  "ragfair-missing_loyal_level_item": "generateFleaOffersForTrader() Failed to find LoyalLevelItem for item id: {{itemId}} tpl: {{tpl}} on {{name}}",
   "ragfair-no_trader_assorts_cant_generate_flea_offers": "Unable to generate flea offers for trader %s, no assort found",
   "ragfair-offer_no_longer_exists": "Offer no longer exists",
   "ragfair-offer_not_found_in_profile": "Could not find offer with id: {{offerId}} in profile: {{profileId}} to remove",

--- a/Libraries/SPTarkov.Server.Core/Generators/RagfairOfferGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/RagfairOfferGenerator.cs
@@ -588,7 +588,21 @@ public class RagfairOfferGenerator(
             }
 
             var barterSchemeItems = barterScheme[0];
-            var loyalLevel = assortsClone.LoyalLevelItems[item.Id];
+            if (!assortsClone.LoyalLevelItems.TryGetValue(item.Id, out var loyalLevel))
+            {
+                logger.Warning(
+                    localisationService.GetText(
+                        "ragfair-missing_loyal_level_item",
+                        new
+                        {
+                            itemId = item.Id,
+                            tpl = item.Template,
+                            name = trader.Base.Nickname,
+                        }
+                    )
+                );
+                continue;
+            }
 
             var createOfferDetails = new CreateFleaOfferDetails
             {


### PR DESCRIPTION
In the current version of the server, when generating flea offers for the trader on `SPTarkov.Server.Core.Generators.RagfairOfferGenerator.CreateUserDataForFleaOffer()`, it will check if there's a valid barter, but it will just assume the item has a valid `LoyalLevelItem`, without really checking if it exists or not, causing an exception crash.

This PR fixes that issue by checking if the item has said property, and if it does not, outputs a message in the console and skips further processing of the problematic offer. 