### PR TITLE
Fixed item quality calculation for keys.

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Helpers/ItemHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ItemHelper.cs
@@ -616,8 +616,8 @@ public class ItemHelper(
         else if (item.Upd.Key?.NumberOfUsages > 0 && itemDetails.Properties?.MaximumNumberOfUsage > 0)
         {
             // keys - keys count upwards, not down like everything else
-            var maxNumOfUsages = itemDetails.Properties.MaximumNumberOfUsage;
-            result = (maxNumOfUsages ?? 0 - item.Upd.Key.NumberOfUsages) / maxNumOfUsages ?? 0;
+            var maxNumOfUsages = itemDetails.Properties.MaximumNumberOfUsage ?? 0d;
+            result = (maxNumOfUsages - item.Upd.Key.NumberOfUsages) / maxNumOfUsages ?? 0;
         }
         else if (item.Upd.Resource?.UnitsConsumed > 0) // Item is less than 100% usage
         {


### PR DESCRIPTION
Fixed item quality calculation for keys. Only integers were used for the calculation for keys, which meant that only 1 or 0 could be the result. At least one value must be a double for the calculation to result in a double.