### PR TITLE
Harden AddTaskItemRequirementsToRewardPool against NullReferenceExceptions

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
@@ -687,7 +687,12 @@ public class CircleOfCultistService(
         foreach (var task in activeTasks ?? [])
         {
             var questData = questHelper.GetQuestFromDb(task.QId, pmcData);
-            var handoverConditions = questData?.Conditions.AvailableForFinish?.Where(condition => condition.ConditionType == "HandoverItem");
+            if (questData is null)
+            {
+                logger.Warning($"Could not get quest data for QId {task.QId}.");
+                continue;
+            }
+            var handoverConditions = questData.Conditions.AvailableForFinish?.Where(condition => condition.ConditionType == "HandoverItem");
             foreach (var condition in handoverConditions ?? [])
             {
                 foreach (var neededItem in condition?.Target?.List ?? [])


### PR DESCRIPTION
The SPT Server can on occasion produce `NullReferenceException` when calling `AddTaskItemRequirementsToRewardPool`. 

It is not clear to me whether it is `pmcData.Quests` or `questData` being `null` in this case due a lack of line numbers in the logs, but either has the potential to be null based on the codebase definition.

To avoid the operation from crashing entirely and losing the sacrifice to the server, defaults for potential null objects are added which allows the function to gracefully finish, even if it means skipping over some of potentially added TaskItemRequirements. For future debugging, a log entry in case of missing quest data has been added.