### PR TITLE
Various Skill Progress Hideout Adjustments

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/hideout.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/hideout.json
@@ -5,7 +5,8 @@
     "inRaid": 60,
     "outOfRaid": 10
   },
-  "expCraftAmount": 10,
+  "craftingExpAmount": 12.5,
+  "craftingExpForHoursOfCrafting": 3.75,
   "overrideCraftTimeSeconds": -1,
   "overrideBuildTimeSeconds": -1,
   "updateProfileHideoutWhenActiveWithinMinutes": 90,

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/repair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/repair.json
@@ -1,7 +1,7 @@
 {
   "priceMultiplier": 1,
   "applyRandomizeDurabilityLoss": true,
-  "armorKitSkillPointGainPerRepairPointMultiplier": 0.05,
+  "armorKitSkillPointGainPerRepairPointMultiplier": 0.1,
   "repairKitIntellectGainMultiplier": {
     "weapon": 0.111,
     "armor": 0.077

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/repair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/repair.json
@@ -11,7 +11,7 @@
     "critSuccessAmount": 4,
     "critFailureChance": 0.1,
     "critFailureAmount": 4,
-    "pointGainMultiplier": 0.6
+    "pointGainMultiplier": 0.1
   },
   "repairKit": {
     "armor": {

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/repair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/repair.json
@@ -3,15 +3,15 @@
   "applyRandomizeDurabilityLoss": true,
   "armorKitSkillPointGainPerRepairPointMultiplier": 0.1,
   "repairKitIntellectGainMultiplier": {
-    "weapon": 0.111,
-    "armor": 0.077
+    "weapon": 0.1,
+    "armor": 0.1
   },
   "weaponTreatment": {
     "critSuccessChance": 0.1,
     "critSuccessAmount": 4,
     "critFailureChance": 0.1,
     "critFailureAmount": 4,
-    "pointGainMultiplier": 0.1
+    "pointGainMultiplier": 0.2
   },
   "repairKit": {
     "armor": {

--- a/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
@@ -688,8 +688,9 @@ public class HideoutController(
         );
         pmcData.Hideout.Production[request.RecipeId].SptIsScavCase = true;
 
-        // reward charisma based on skill progress rate for each scav production start
+        // reward charisma and hideout management based on skill progress rate for each scav production start
         profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.Charisma, 1, true);
+        profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1, true);
 
         return output;
     }

--- a/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
@@ -864,7 +864,7 @@ public class HideoutController(
         // Check if the recipe is the same as the last one - get bonus when crafting same thing multiple times
         var area = pmcData.Hideout.Areas.FirstOrDefault(area => area.Type == recipe.AreaType);
         if (area is not null && request.RecipeId != area.LastRecipe)
-        // 1 point per craft upon the end of production for alternating between 2 different crafting recipes in the same module
+        // 5 points per craft upon the end of production for alternating between 2 different crafting recipes in the same module
         {
             craftingExpAmount += HideoutConfig.CraftingExpAmount; // Default is 12.5, scaled (at 0.4 scale => 5 points per alternating craft)
         }
@@ -946,6 +946,7 @@ public class HideoutController(
         {
             profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.Crafting, craftingExpAmount, true);
 
+            // TODO: verify this is still giving intellect skill points on live
             var intellectAmountToGive = 0.5 * Math.Round((double)(craftingExpAmount / 15));
             if (intellectAmountToGive > 0)
             {

--- a/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
@@ -823,7 +823,7 @@ public class HideoutController(
         }
 
         // Variables for management of skill
-        var craftingExpAmount = 0;
+        double craftingExpAmount = 0;
         var counterHoursCrafting = GetCustomSptHoursCraftingTaskConditionCounter(pmcData, recipe);
         var totalCraftingHours = counterHoursCrafting.Value;
 
@@ -866,17 +866,17 @@ public class HideoutController(
         if (area is not null && request.RecipeId != area.LastRecipe)
         // 1 point per craft upon the end of production for alternating between 2 different crafting recipes in the same module
         {
-            craftingExpAmount += HideoutConfig.ExpCraftAmount; // Default is 10
+            craftingExpAmount += HideoutConfig.CraftingExpAmount; // Default is 12.5, scaled (at 0.4 scale => 5 points per alternating craft)
         }
 
         // Update variable with time spent crafting item(s)
-        // 1 point per 8 hours of crafting
+        // 1.5 (3.75 w/ applying default 0.4 scale) points per 8 hours of crafting
         totalCraftingHours += recipe.ProductionTime;
         if (totalCraftingHours / HideoutConfig.HoursForSkillCrafting >= 1)
         {
             // Spent enough time crafting to get a bonus xp multiplier
             var multiplierCrafting = Math.Floor(totalCraftingHours.Value / HideoutConfig.HoursForSkillCrafting);
-            craftingExpAmount += (int)(1 * multiplierCrafting);
+            craftingExpAmount += (HideoutConfig.CraftingExpForHoursOfCrafting * multiplierCrafting);
             totalCraftingHours -= HideoutConfig.HoursForSkillCrafting * multiplierCrafting;
         }
 
@@ -944,7 +944,7 @@ public class HideoutController(
         // Add Crafting skill to player profile
         if (craftingExpAmount > 0)
         {
-            profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.Crafting, craftingExpAmount);
+            profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.Crafting, craftingExpAmount, true);
 
             var intellectAmountToGive = 0.5 * Math.Round((double)(craftingExpAmount / 15));
             if (intellectAmountToGive > 0)

--- a/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
@@ -217,7 +217,8 @@ public class HideoutController(
         profileHelper.AddSkillPointsToPlayer(
             pmcData,
             SkillTypes.HideoutManagement,
-            globals.Configuration.SkillsSettings.HideoutManagement.SkillPointsPerAreaUpgrade
+            globals.Configuration.SkillsSettings.HideoutManagement.SkillPointsPerAreaUpgrade,
+            true
         );
     }
 

--- a/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/HideoutController.cs
@@ -950,7 +950,12 @@ public class HideoutController(
             var intellectAmountToGive = 0.5 * Math.Round((double)(craftingExpAmount / 15));
             if (intellectAmountToGive > 0)
             {
-                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.Intellect, intellectAmountToGive);
+                profileHelper.AddSkillPointsToPlayer(
+                    pmcData,
+                    SkillTypes.Intellect,
+                    intellectAmountToGive,
+                    useSkillProgressRateMultiplier: false
+                );
             }
         }
 

--- a/Libraries/SPTarkov.Server.Core/Controllers/InventoryController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/InventoryController.cs
@@ -277,6 +277,7 @@ public class InventoryController(
         }
 
         // TODO: update this with correct calculation using values from globals json
+        // TODO: verify this is still giving intellect skill points on live
         profileHelper.AddSkillPointsToPlayer(fullProfile.CharacterData.PmcData, SkillTypes.Intellect, 0.05 * itemTpls.Count());
     }
 

--- a/Libraries/SPTarkov.Server.Core/Controllers/InventoryController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/InventoryController.cs
@@ -278,7 +278,12 @@ public class InventoryController(
 
         // TODO: update this with correct calculation using values from globals json
         // TODO: verify this is still giving intellect skill points on live
-        profileHelper.AddSkillPointsToPlayer(fullProfile.CharacterData.PmcData, SkillTypes.Intellect, 0.05 * itemTpls.Count());
+        profileHelper.AddSkillPointsToPlayer(
+            fullProfile.CharacterData.PmcData,
+            SkillTypes.Intellect,
+            0.05 * itemTpls.Count(),
+            useSkillProgressRateMultiplier: false
+        );
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
@@ -723,7 +723,7 @@ public class HideoutHelper(
             // Fuel consumed / 10 is over 1, add hideout management skill point
             if (pmcData is not null && Math.Floor(pointsConsumed / 10) >= 1)
             {
-                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1);
+                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1, useSkillProgressRateMultiplier: false);
                 pointsConsumed -= 10;
             }
 
@@ -925,7 +925,7 @@ public class HideoutHelper(
             // Check units consumed for possible increment of hideout mgmt skill point
             if (pmcData is not null && Math.Floor(pointsConsumed / 10) >= 1)
             {
-                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1);
+                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1, useSkillProgressRateMultiplier: false);
                 pointsConsumed -= 10;
             }
 
@@ -1076,7 +1076,7 @@ public class HideoutHelper(
             // check unit consumed for increment skill point
             if (pmcData is not null && Math.Floor(pointsConsumed / 10) >= 1)
             {
-                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1);
+                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1, useSkillProgressRateMultiplier: false);
                 pointsConsumed -= 10;
             }
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/HideoutHelper.cs
@@ -723,7 +723,7 @@ public class HideoutHelper(
             // Fuel consumed / 10 is over 1, add hideout management skill point
             if (pmcData is not null && Math.Floor(pointsConsumed / 10) >= 1)
             {
-                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1, useSkillProgressRateMultiplier: false);
+                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 2, useSkillProgressRateMultiplier: true);
                 pointsConsumed -= 10;
             }
 
@@ -925,7 +925,7 @@ public class HideoutHelper(
             // Check units consumed for possible increment of hideout mgmt skill point
             if (pmcData is not null && Math.Floor(pointsConsumed / 10) >= 1)
             {
-                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1, useSkillProgressRateMultiplier: false);
+                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 2, useSkillProgressRateMultiplier: true);
                 pointsConsumed -= 10;
             }
 
@@ -1076,7 +1076,7 @@ public class HideoutHelper(
             // check unit consumed for increment skill point
             if (pmcData is not null && Math.Floor(pointsConsumed / 10) >= 1)
             {
-                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 1, useSkillProgressRateMultiplier: false);
+                profileHelper.AddSkillPointsToPlayer(pmcData, SkillTypes.HideoutManagement, 2, useSkillProgressRateMultiplier: true);
                 pointsConsumed -= 10;
             }
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
@@ -195,6 +195,7 @@ public class PrestigeHelper(
                 case RewardType.Skill:
                     if (Enum.TryParse(reward.Target, out SkillTypes result))
                     {
+                        // skill reward values are always 100 (+1 level), so adjustment for low levels will give a wrong result
                         profileHelper.AddSkillPointsToPlayer(
                             newProfile.CharacterData!.PmcData!,
                             result,

--- a/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
@@ -200,6 +200,7 @@ public class PrestigeHelper(
                             newProfile.CharacterData!.PmcData!,
                             result,
                             reward.Value.GetValueOrDefault(0),
+                            useSkillProgressRateMultiplier: false,
                             adjustSkillExpForLowLevels: false
                         );
                     }

--- a/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
@@ -195,7 +195,7 @@ public class PrestigeHelper(
                 case RewardType.Skill:
                     if (Enum.TryParse(reward.Target, out SkillTypes result))
                     {
-                        profileHelper.AddSkillPointsToPlayer(newProfile.CharacterData!.PmcData!, result, reward.Value.GetValueOrDefault(0));
+                        profileHelper.AddSkillPointsToPlayer(newProfile.CharacterData!.PmcData!, result, reward.Value.GetValueOrDefault(0), adjustSkillExpForLowLevels: false);
                     }
                     else
                     {

--- a/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/PrestigeHelper.cs
@@ -195,7 +195,12 @@ public class PrestigeHelper(
                 case RewardType.Skill:
                     if (Enum.TryParse(reward.Target, out SkillTypes result))
                     {
-                        profileHelper.AddSkillPointsToPlayer(newProfile.CharacterData!.PmcData!, result, reward.Value.GetValueOrDefault(0), adjustSkillExpForLowLevels: false);
+                        profileHelper.AddSkillPointsToPlayer(
+                            newProfile.CharacterData!.PmcData!,
+                            result,
+                            reward.Value.GetValueOrDefault(0),
+                            adjustSkillExpForLowLevels: false
+                        );
                     }
                     else
                     {

--- a/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
@@ -519,7 +519,9 @@ public class ProfileHelper(
             pointsToAddToSkill *= multiplier;
         }
 
-        var adjustedSkillProgress = adjustSkillExpForLowLevels ? AdjustSkillExpForLowLevels(profileSkill.Progress, pointsToAddToSkill) : pointsToAddToSkill;
+        var adjustedSkillProgress = adjustSkillExpForLowLevels
+            ? AdjustSkillExpForLowLevels(profileSkill.Progress, pointsToAddToSkill)
+            : pointsToAddToSkill;
         profileSkill.Progress += adjustedSkillProgress;
         profileSkill.Progress = Math.Min(profileSkill.Progress, 5100); // Prevent skill from ever going above level 51 (5100)
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
@@ -467,11 +467,13 @@ public class ProfileHelper(
     /// <param name="skill">Skill to add points to</param>
     /// <param name="pointsToAddToSkill">Points to add</param>
     /// <param name="useSkillProgressRateMultiplier">Skills are multiplied by a value in globals, default is off to maintain compatibility with legacy code</param>
+    /// <param name="adjustSkillExpForLowLevels">Skills are multiplied by a multiplier for lower levels; if false, treats every level as requiring 100 points</param>
     public void AddSkillPointsToPlayer(
         PmcData pmcProfile,
         SkillTypes skill,
         double pointsToAddToSkill,
-        bool useSkillProgressRateMultiplier = false
+        bool useSkillProgressRateMultiplier = false,
+        bool adjustSkillExpForLowLevels = true
     )
     {
         if (pointsToAddToSkill < 0D)
@@ -517,7 +519,7 @@ public class ProfileHelper(
             pointsToAddToSkill *= multiplier;
         }
 
-        var adjustedSkillProgress = AdjustSkillExpForLowLevels(profileSkill.Progress, pointsToAddToSkill);
+        var adjustedSkillProgress = adjustSkillExpForLowLevels ? AdjustSkillExpForLowLevels(profileSkill.Progress, pointsToAddToSkill) : pointsToAddToSkill;
         profileSkill.Progress += adjustedSkillProgress;
         profileSkill.Progress = Math.Min(profileSkill.Progress, 5100); // Prevent skill from ever going above level 51 (5100)
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/ProfileHelper.cs
@@ -461,6 +461,23 @@ public class ProfileHelper(
     }
 
     /// <summary>
+    ///     Add points to a specific skill in player profile, adjusted for low levels by default
+    /// </summary>
+    /// <param name="pmcProfile">Player profile with skill</param>
+    /// <param name="skill">Skill to add points to</param>
+    /// <param name="pointsToAddToSkill">Points to add</param>
+    /// <param name="useSkillProgressRateMultiplier">Skills are multiplied by a value in globals, default is off to maintain compatibility with legacy code</param>
+    public void AddSkillPointsToPlayer(
+        PmcData pmcProfile,
+        SkillTypes skill,
+        double pointsToAddToSkill,
+        bool useSkillProgressRateMultiplier = false
+    )
+    {
+        AddSkillPointsToPlayer(pmcProfile, skill, pointsToAddToSkill, useSkillProgressRateMultiplier, true);
+    }
+
+    /// <summary>
     ///     Add points to a specific skill in player profile
     /// </summary>
     /// <param name="pmcProfile">Player profile with skill</param>

--- a/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
@@ -73,6 +73,7 @@ public class RewardHelper(
             {
                 case RewardType.Skill:
                     // This needs to use the passed in profileData, as it could be the scav profile
+                    // skill reward values are always 100 (+1 level), so adjustment for low levels will give a wrong result
                     profileHelper.AddSkillPointsToPlayer(
                         profileData,
                         Enum.Parse<SkillTypes>(reward.Target),

--- a/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
@@ -76,7 +76,8 @@ public class RewardHelper(
                     profileHelper.AddSkillPointsToPlayer(
                         profileData,
                         Enum.Parse<SkillTypes>(reward.Target),
-                        reward.Value.GetValueOrDefault(0)
+                        reward.Value.GetValueOrDefault(0),
+                        adjustSkillExpForLowLevels: false
                     );
                     break;
                 case RewardType.Experience:

--- a/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
@@ -78,6 +78,7 @@ public class RewardHelper(
                         profileData,
                         Enum.Parse<SkillTypes>(reward.Target),
                         reward.Value.GetValueOrDefault(0),
+                        useSkillProgressRateMultiplier: false,
                         adjustSkillExpForLowLevels: false
                     );
                     break;

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/HideoutConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/HideoutConfig.cs
@@ -24,8 +24,14 @@ public record HideoutConfig : BaseConfig
     [JsonPropertyName("hoursForSkillCrafting")]
     public int HoursForSkillCrafting { get; set; }
 
-    [JsonPropertyName("expCraftAmount")]
-    public int ExpCraftAmount { get; set; }
+    [Obsolete("Will be removed in 4.1, use CraftingExpAmount")]
+    public int ExpCraftAmount { get; set; } = 0;
+
+    [JsonPropertyName("craftingExpAmount")]
+    public double CraftingExpAmount { get; set; }
+
+    [JsonPropertyName("craftingExpForHoursOfCrafting")]
+    public double CraftingExpForHoursOfCrafting { get; set; }
 
     [JsonPropertyName("overrideCraftTimeSeconds")]
     public int OverrideCraftTimeSeconds { get; set; }

--- a/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
@@ -247,7 +247,7 @@ public class RepairService(
     protected double GetWeaponRepairSkillPoints(RepairDetails repairDetails)
     {
         var random = new Random();
-        // Every 5 points repaired with kit should give 0.4 skill points, so PointGainMultiplier is 0.1
+        // Every 5 points repaired with kit should give 0.4 skill points, so PointGainMultiplier is 0.2
         // The return value is later scaled in AddSkillPointsToPlayer, i.e. 1 skill point returned here = 0.4 skill points added
         var skillPoints = repairDetails.RepairAmount.GetValueOrDefault(0) * RepairConfig.WeaponTreatment.PointGainMultiplier;
 

--- a/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
@@ -188,7 +188,7 @@ public class RepairService(
             var pointsToAddToVestSkill = repairDetails.RepairPoints * RepairConfig.ArmorKitSkillPointGainPerRepairPointMultiplier;
 
             logger.Debug($"Added: {pointsToAddToVestSkill} {vestSkillToLevel} skill");
-            profileHelper.AddSkillPointsToPlayer(pmcData, vestSkillToLevel, pointsToAddToVestSkill.GetValueOrDefault(0));
+            profileHelper.AddSkillPointsToPlayer(pmcData, vestSkillToLevel, pointsToAddToVestSkill.GetValueOrDefault(0), true);
         }
 
         // Handle trader repair - gives charisma based on (repair cost/10 * skill progress rate)

--- a/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
@@ -185,6 +185,8 @@ public class RepairService(
                 );
             }
 
+            // Every 10 points of repair gives 1 skill point scaled by skillProgressRate
+            // ArmorKitSkillPointGainPerRepairPointMultiplier is 0.1
             var pointsToAddToVestSkill = repairDetails.RepairPoints * RepairConfig.ArmorKitSkillPointGainPerRepairPointMultiplier;
 
             logger.Debug($"Added: {pointsToAddToVestSkill} {vestSkillToLevel} skill");
@@ -245,18 +247,9 @@ public class RepairService(
     protected double GetWeaponRepairSkillPoints(RepairDetails repairDetails)
     {
         var random = new Random();
-        // This formula and associated configs is calculated based on 30 repairs done on live
-        // The points always came out 2-aligned, which is why there's a divide/multiply by 2 with ceil calls
-        var gainMult = RepairConfig.WeaponTreatment.PointGainMultiplier;
-
-        // First we get a baseline based on our repair amount, and gain multiplier with a bit of rounding
-        var step1 = Math.Ceiling(repairDetails.RepairAmount.Value / 2) * gainMult;
-
-        // Then we have to get the next even number
-        var step2 = Math.Ceiling(step1 / 2) * 2;
-
-        // Then multiply by 2 again to hopefully get to what live would give us
-        var skillPoints = step2 * 2;
+        // Every 10 points repaired should give 0.4 skill points, so PointGainMultiplier is 0.1
+        // The return value is later scaled in AddSkillPointsToPlayer, i.e. 1 skill point returned here = 0.4 skill points added
+        var skillPoints = repairDetails.RepairAmount.GetValueOrDefault(0) * RepairConfig.WeaponTreatment.PointGainMultiplier;
 
         // You can both crit fail and succeed at the same time, for fun (Balances out to 0 with default settings)
         // Add a random chance to crit-fail

--- a/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RepairService.cs
@@ -247,7 +247,7 @@ public class RepairService(
     protected double GetWeaponRepairSkillPoints(RepairDetails repairDetails)
     {
         var random = new Random();
-        // Every 10 points repaired should give 0.4 skill points, so PointGainMultiplier is 0.1
+        // Every 5 points repaired with kit should give 0.4 skill points, so PointGainMultiplier is 0.1
         // The return value is later scaled in AddSkillPointsToPlayer, i.e. 1 skill point returned here = 0.4 skill points added
         var skillPoints = repairDetails.RepairAmount.GetValueOrDefault(0) * RepairConfig.WeaponTreatment.PointGainMultiplier;
 


### PR DESCRIPTION
This PR aims to further adjust a variety of skill progression as provided through the SPT server to align it with the values as described in the Tarkov Wiki.

Following adjustments have been made:
- HideoutManagement skill in `HideoutController.UpgradeComplete` now gives 12 points per completed upgrade
- Crafting skill in `HideoutController.HandleRecipe` now gives 5 points per alternating craft and 1.5 points per 8h of crafting
  - A TODO was added to check whether or not Crafting an item still gives Intellect on live
- A TODO was added to `InventoryController.FlagItemsAsInspectedAndRewardXp` whether it still gives Intellect on live
- `PrestigeHelper` and `RewardHelper` applying Skill rewards were adjusted to not use low level scaling and no progress rate multiplier, now yielding skill rewards always being +1 level
- `RepairService.AddRepairSkillPoints` was adjusted to more accurately represent live
  - Repairing a weapon with kit now gives 0.8 points of WeaponTreatment skill per 5 durability repaired 
  - Repairing a Light/Heavy vest with kit now gives 0.4 points of Light/HeavyVest skill per 10 durability repaired
  - Intellect gain for armor and weapon repair was adjusted to 0.4 points per 10 durability repaired
- `HideoutHelper` `UpdateFuel` `UpdateWaterFilters` and `UpdateAirFilters` should now give 0.8 points per 10 points durability consumed
- `HideoutHelper.ScavCaseProductionStart` now gives 0.4 points of HideoutManagement for starting scav case
- All skill points changes except `Prestige`/`RewardHelper` are now scalable via `SkillProgressRate`

Open points as of now are still the two TODO's I've added and whether HideoutManagement skill progression in `HideoutHelper` `UpdateFuel`, `UpdateWaterFilters` and `UpdateAirFilters` is correct (there are values in globals but who knows how accurate they are), also it seems like when having SolarPower it should yield 1.2 points per 50 fuel consumed (?).
It is also not 100% clear how many points of HideoutManagement should be provided for sending out scav case. I set it to 0.4 as per default skill progression rate for now.