### PR TITLE
random.Next -> random.NextDouble in CultistCircle

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
@@ -210,7 +210,7 @@ public class CircleOfCultistService(
         var matchingThreshold = GetMatchingThreshold(circleConfig.CraftTimeThresholds, rewardAmountRoubles);
         if (
             rewardAmountRoubles >= circleConfig.HideoutCraftSacrificeThresholdRub
-            && random.Next(0, 1) <= circleConfig.BonusChanceMultiplier
+            && random.NextDouble() <= circleConfig.BonusChanceMultiplier
         )
         {
             // Sacrifice amount is enough + passed 25% check to get hideout/task rewards


### PR DESCRIPTION
random.Next(0,1) will always return 0 because the maxValue is exclusive 

BonusChanceMultiplier is a double (default 0.25)

random.NextDouble will return 0.0 (inclusive) - 1.0 (exclusive) which will properly check the BonusChanceMultiplier instead of always being true