### PR TITLE
Enable Player Scav Brain Swapping

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/bot.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/bot.json
@@ -2741,61 +2741,87 @@
   "playerScavBrainType": {
     "bigmap": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "factory4_day": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "factory4_night": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "interchange": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "laboratory": {
-      "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "assault": 0,
+      "bossKilla": 2,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "lighthouse": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "rezervbase": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "sandbox": {
-      "assault": 1,
-      "pmcBot": 0
+      "assault": 4,
+      "bossKilla": 0,
+      "pmcBot": 0,
+      "pmcBEAR": 1,
+      "pmcUSEC": 1
     },
     "sandbox_high": {
-      "assault": 2,
-      "pmcBot": 0
+      "assault": 3,
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 1,
+      "pmcUSEC": 1
     },
     "shoreline": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "tarkovstreets": {
       "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     },
     "woods": {
-      "assault": 1,
-      "bossKilla": 0,
-      "pmcBot": 0
+      "assault": 2,
+      "bossKilla": 1,
+      "pmcBot": 0,
+      "pmcBEAR": 2,
+      "pmcUSEC": 2
     }
   },
   "presetBatch": {


### PR DESCRIPTION
Allows player Scav brain types to be replaced. This will ONLY work if [Bug Fix for Player Scav Brain Swapping](https://github.com/sp-tarkov/modules/pull/89) is merged too. 

Feel free to change the chance weightings if you don't like my settings. 