### PR TITLE
Fix ListOrT when using Value types

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/ListOrTConverter.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/ListOrTConverter.cs
@@ -41,13 +41,13 @@ public class ListOrTConverter<T> : JsonConverter<ListOrT<T>?>
 
     public override void Write(Utf8JsonWriter writer, ListOrT<T> value, JsonSerializerOptions options)
     {
-        if (value.IsItem)
+        if (value.IsList)
         {
-            JsonSerializer.Serialize(writer, value.Item, options);
+            JsonSerializer.Serialize(writer, value.List, options);
         }
         else
         {
-            JsonSerializer.Serialize(writer, value.List, options);
+            JsonSerializer.Serialize(writer, value.Item, options);
         }
     }
 }


### PR DESCRIPTION
Switch the IsItem check in the serializer Write to check if IsList, instead of IsItem, as IsList will always handle null