### PR TITLE
Fix incorrect string handling for key hashing

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/CircleOfCultistService.cs
@@ -506,8 +506,8 @@ public class CircleOfCultistService(
         directReward.RequiredItems.Sort();
         directReward.Reward.Sort();
 
-        var required = string.Concat(directReward.RequiredItems, ",");
-        var reward = string.Concat(directReward.Reward, ",");
+        var required = string.Join(",", directReward.RequiredItems);
+        var reward = string.Join(",", directReward.Reward);
         // Key is sacrificed items separated by commas, a dash, then the rewards separated by commas
         var key = $"{{{required}-{reward}}}";
 


### PR DESCRIPTION
string.Concat hashes this key:
``{System.Collections.Generic.List`1[SPTarkov.Server.Core.Models.Common.MongoId],-System.Collections.Generic.List`1[SPTarkov.Server.Core.Models.Common.MongoId],}``

This always hashes to B7D493777C8E966B3AFE1651E3124AAE

Which means that every single key ever saved and checked against the profile is identical. This makes all direct rewards fail after a user completes a single non repeatable reward.

string.Join hashes this key: 
`{6937f02dfd6488bb27024839-5d403f9186f7743cac3f229b,63a39ce4cd6db0635c1975fa,620109578d82e67e7911abf2}`

These keys will hash correctly and be unique.

Resolves https://github.com/sp-tarkov/server-csharp/issues/757