### PR TITLE
Prepatcher

### DIFF
--- a/Libraries/SPTarkov.Reflection/Patching/AbstractPrepatch.cs
+++ b/Libraries/SPTarkov.Reflection/Patching/AbstractPrepatch.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Mono.Cecil;
+
+namespace SPTarkov.Reflection.Patching;
+
+public abstract class AbstractPrepatch : IPrepatch
+{
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public abstract string ModGuid { get; }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public abstract bool IsActive { get; }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="serverCoreModule"><inheritdoc/></param>
+    public abstract void Patch(ModuleDefinition serverCoreModule);
+}

--- a/Libraries/SPTarkov.Reflection/Patching/IPrepatch.cs
+++ b/Libraries/SPTarkov.Reflection/Patching/IPrepatch.cs
@@ -1,0 +1,22 @@
+using Mono.Cecil;
+
+namespace SPTarkov.Reflection.Patching;
+
+public interface IPrepatch
+{
+    /// <summary>
+    ///     Guid of the mod this prepatch belongs to
+    /// </summary>
+    public string ModGuid { get; }
+
+    /// <summary>
+    ///     Is this patch active?
+    /// </summary>
+    public bool IsActive { get; }
+
+    /// <summary>
+    ///     prepatch method called by the mod loader
+    /// </summary>
+    /// <param name="serverCoreModule">Server core module to patch</param>
+    void Patch(ModuleDefinition serverCoreModule);
+}

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/AbstractModMetadata.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/AbstractModMetadata.cs
@@ -62,9 +62,9 @@ public abstract record AbstractModMetadata
     public abstract Range SptVersion { get; init; }
 
     /// <summary>
-    ///     Indicates whether this mod includes a pre-patcher.
+    ///     Indicates whether this mod includes a pre-patcher. If you don't know what this means, leave it false.
     /// </summary>
-    public abstract bool HasPatcher { get; init; }
+    public abstract bool HasPrepatcher { get; init; }
 
     /// <summary>
     /// List of mods not compatible with this mod

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/AbstractModMetadata.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/AbstractModMetadata.cs
@@ -62,6 +62,11 @@ public abstract record AbstractModMetadata
     public abstract Range SptVersion { get; init; }
 
     /// <summary>
+    ///     Indicates whether this mod includes a pre-patcher.
+    /// </summary>
+    public abstract bool HasPatcher { get; init; }
+
+    /// <summary>
     /// List of mods not compatible with this mod
     /// </summary>
     public abstract List<string>? Incompatibilities { get; init; }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/PrepatchResultEntry.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/PrepatchResultEntry.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace SPTarkov.Server.Core.Models.Spt.Mod;
 
-public record PrepatchResultEntry
+public sealed record PrepatchResultEntry
 {
     [JsonPropertyName("modGuid")]
     public required string ModGuid { get; init; }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/PrepatchResultEntry.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/PrepatchResultEntry.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace SPTarkov.Server.Core.Models.Spt.Mod;
+
+public record PrepatchResultEntry
+{
+    [JsonPropertyName("modGuid")]
+    public required string ModGuid { get; init; }
+
+    [JsonPropertyName("succeeded")]
+    public required bool Succeeded { get; init; }
+}

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/SptMod.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/SptMod.cs
@@ -13,4 +13,7 @@ public class SptMod
 
     [JsonPropertyName("assemblies")]
     public required IEnumerable<Assembly> Assemblies { get; init; }
+
+    [JsonPropertyName("patcherAssemblies")]
+    public IEnumerable<Assembly>? PatcherAssemblies { get; init; }
 }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/SptMod.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/SptMod.cs
@@ -9,11 +9,11 @@ public class SptMod
     public required string Directory { get; init; }
 
     [JsonPropertyName("modMetadata")]
-    public required AbstractModMetadata ModMetadata { get; init; }
+    public AbstractModMetadata ModMetadata { get; set; } = null!;
 
     [JsonPropertyName("assemblies")]
     public required IEnumerable<Assembly> Assemblies { get; init; }
 
-    [JsonPropertyName("patcherAssemblies")]
-    public IEnumerable<Assembly>? PatcherAssemblies { get; init; }
+    [JsonPropertyName("patcherAssembly")]
+    public Assembly? PatcherAssembly { get; set; }
 }

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/SptMod.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Mod/SptMod.cs
@@ -9,7 +9,7 @@ public class SptMod
     public required string Directory { get; init; }
 
     [JsonPropertyName("modMetadata")]
-    public AbstractModMetadata ModMetadata { get; set; } = null!;
+    public required AbstractModMetadata ModMetadata { get; init; }
 
     [JsonPropertyName("assemblies")]
     public required IEnumerable<Assembly> Assemblies { get; init; }

--- a/SPTarkov.Server/Modding/ModLoaderController.cs
+++ b/SPTarkov.Server/Modding/ModLoaderController.cs
@@ -123,8 +123,12 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
             throw new ModLoaderException($"No Assemblies found in path: {Path.GetFullPath(path)}");
         }
 
-        SptMod result = new() { Directory = path, Assemblies = assemblyList };
-        LoadModMetadata(result, assemblyList, path);
+        SptMod result = new()
+        {
+            Directory = path,
+            Assemblies = assemblyList,
+            ModMetadata = LoadModMetadata(assemblyList, path),
+        };
 
         if (
             string.IsNullOrEmpty(result.ModMetadata.ModGuid)
@@ -138,6 +142,11 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
             );
         }
 
+        if (result.ModMetadata.HasPatcher)
+        {
+            LoadModPatchers(result, Path.Combine(PatcherPath, result.ModMetadata.ModGuid));
+        }
+
         return result;
     }
 
@@ -149,7 +158,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
     /// <param name="path">Path of the mod directory</param>
     /// <returns>Mod metadata</returns>
     /// <exception cref="ModLoaderException">Thrown if duplicate metadata implementations are found</exception>
-    private void LoadModMetadata(SptMod mod, IEnumerable<Assembly> assemblies, string path)
+    private AbstractModMetadata LoadModMetadata(IEnumerable<Assembly> assemblies, string path)
     {
         AbstractModMetadata? result = null;
 
@@ -185,11 +194,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
             );
         }
 
-        mod.ModMetadata = result;
-        if (result.HasPatcher)
-        {
-            LoadModPatchers(mod, Path.Combine(PatcherPath, result.ModGuid));
-        }
+        return result;
     }
 
     private void LoadModPatchers(SptMod mod, string path)

--- a/SPTarkov.Server/Modding/ModLoaderController.cs
+++ b/SPTarkov.Server/Modding/ModLoaderController.cs
@@ -182,7 +182,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
             );
         }
 
-        if (result.ModMetadata.HasPatcher)
+        if (result.ModMetadata.HasPrepatcher)
         {
             LoadModPatchers(result, Path.Combine(PatcherPath, result.ModMetadata.ModGuid));
         }

--- a/SPTarkov.Server/Modding/ModLoaderController.cs
+++ b/SPTarkov.Server/Modding/ModLoaderController.cs
@@ -1,26 +1,55 @@
 using System.Reflection;
 using System.Runtime.Loader;
+using Mono.Cecil;
+using SPTarkov.Common.Models.Logging;
 using SPTarkov.Server.Core.Models.Spt.Mod;
-using SPTarkov.Server.Core.Utils;
 
 namespace SPTarkov.Server.Modding;
 
-public class ModDllLoader
+public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModValidator modValidator)
 {
     private const string ModPath = "./user/mods/";
+    private const string PatcherPath = "./user/patchers/";
 
-    public static List<SptMod> LoadAllMods()
+    public List<SptMod> ValidRuntimeMods
+    {
+        get { return modValidator.ValidateMods(_loadedMods); }
+    }
+
+    private List<SptMod> _loadedMods = [];
+    private ModuleDefinition? _serverCoreModule;
+
+    public void LoadMods()
+    {
+        if (!TryLoadServerCoreBytes())
+        {
+            return;
+        }
+
+        LoadAllPatchers();
+        LoadAllMods();
+    }
+
+    // We need control and coupling between pre-patchers and the associated primary assembly,
+    // handle that here and any state needed.
+    // This will control the process of both patchers and the mods themselves
+
+    private void LoadAllPatchers()
+    {
+        var files = Directory.GetFiles(PatcherPath, "*.dll");
+        foreach (var file in files)
+        {
+            LoadPatcher(file);
+        }
+    }
+
+    private void LoadPatcher(string path) { }
+
+    private void LoadAllMods()
     {
         if (!Directory.Exists(ModPath))
         {
             Directory.CreateDirectory(ModPath);
-        }
-
-        var mods = new List<SptMod>();
-
-        if (!ProgramStatics.MODS())
-        {
-            return mods;
         }
 
         // foreach directory in /user/mods/
@@ -35,7 +64,7 @@ public class ModDllLoader
         {
             try
             {
-                mods.Add(LoadMod(modDirectory));
+                _loadedMods.Add(LoadMod(modDirectory));
             }
             catch (Exception e)
             {
@@ -43,7 +72,7 @@ public class ModDllLoader
             }
         }
 
-        return mods.OrderBy(m => m.ModMetadata.ModGuid, StringComparer.OrdinalIgnoreCase).ToList();
+        _loadedMods = _loadedMods.OrderBy(m => m.ModMetadata.ModGuid, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>
@@ -73,6 +102,8 @@ public class ModDllLoader
             Assemblies = assemblyList,
             ModMetadata = LoadModMetadata(assemblyList, path),
         };
+
+        if (result.ModMetadata.HasPatcher) { }
 
         if (
             string.IsNullOrEmpty(result.ModMetadata.ModGuid)
@@ -131,5 +162,25 @@ public class ModDllLoader
         }
 
         return result;
+    }
+
+    private bool TryLoadServerCoreBytes()
+    {
+        try
+        {
+            using var fs = new FileStream(
+                Path.Combine(Assembly.GetExecutingAssembly().Location, "SPTarkov.Server.Core.dll"),
+                FileMode.Open
+            );
+
+            _serverCoreModule = ModuleDefinition.ReadModule(fs);
+        }
+        catch (Exception e)
+        {
+            logger.Critical("Critical error occured while loading the server core dll for the pre-patcher: ", e);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/SPTarkov.Server/Modding/ModLoaderController.cs
+++ b/SPTarkov.Server/Modding/ModLoaderController.cs
@@ -4,12 +4,14 @@ using Mono.Cecil;
 using SPTarkov.Common.Models.Logging;
 using SPTarkov.Reflection.Patching;
 using SPTarkov.Server.Core.Models.Spt.Mod;
+using SPTarkov.Server.Core.Utils;
 
 namespace SPTarkov.Server.Modding;
 
-public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModValidator modValidator)
+public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModValidator modValidator, JsonUtil jsonUtil, FileUtil fileUtil)
 {
     public const string PatchedAssemblyName = "./SPTarkov.Server.Core.Patched.dll";
+    public const string PrepatchStagePath = "./user/cache/prepatcher/server";
 
     public List<SptMod> ValidRuntimeMods
     {
@@ -26,6 +28,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
 
     private ModuleDefinition? _serverCoreModule;
     private MemoryStream? _serverCoreModuleStream;
+    private List<PrepatchResultEntry> _prepatchResults = [];
 
     private const string ModPath = "./user/mods/";
     private const string PatcherPath = "./user/patchers/";
@@ -70,7 +73,12 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
         _loadedMods = _loadedMods.OrderBy(m => m.ModMetadata.ModGuid, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
-    public void ApplyPrepatches(IReadOnlyCollection<SptMod> validRuntimeMods)
+    /// <summary>
+    ///     Applies all prepatches to the server core
+    /// </summary>
+    /// <param name="validRuntimeMods">Validated runtime mods</param>
+    /// <returns>True if all patches succeeded</returns>
+    public async Task<bool> ApplyPrepatches(IReadOnlyCollection<SptMod> validRuntimeMods)
     {
         if (_serverCoreModule is null)
         {
@@ -86,7 +94,19 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
         foreach (var prepatch in activePrepatches)
         {
             logger.Info($"Applying prepatch: {prepatch.GetType().FullName}");
-            prepatch.Patch(_serverCoreModule);
+            var succeeded = false;
+            try
+            {
+                prepatch.Patch(_serverCoreModule);
+                succeeded = true;
+            }
+            catch (Exception e)
+            {
+                logger.Critical($"Critical error occured while applying a prepatch from mod: {prepatch.ModGuid}", e);
+            }
+
+            var result = new PrepatchResultEntry { ModGuid = prepatch.ModGuid, Succeeded = succeeded };
+            _prepatchResults.Add(result);
         }
 
         try
@@ -99,6 +119,26 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
             _serverCoreModule = null;
             _serverCoreModuleStream?.Dispose();
             _serverCoreModuleStream = null;
+        }
+
+        return _prepatchResults.All(r => r.Succeeded);
+    }
+
+    public async Task WriteResultLog()
+    {
+        var text = jsonUtil.Serialize(_prepatchResults);
+        await fileUtil.WriteFileAsync(Path.Combine(Path.GetFullPath(PrepatchStagePath), "prepatch-result.json"), text);
+    }
+
+    public async Task LogPrepatches()
+    {
+        var text = await fileUtil.ReadFileAsync(Path.Combine(Path.GetFullPath(PrepatchStagePath), "prepatch-result.json"));
+        var results = jsonUtil.Deserialize<List<PrepatchResultEntry>>(text);
+
+        logger.Info($"ModLoader: Applied {results?.Count ?? 0} prepatches");
+        foreach (var result in results ?? [])
+        {
+            logger.Info($"ModLoader: Applied prepatch from mod: {result.ModGuid}");
         }
     }
 

--- a/SPTarkov.Server/Modding/ModLoaderController.cs
+++ b/SPTarkov.Server/Modding/ModLoaderController.cs
@@ -170,7 +170,9 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
         {
             using var fs = new FileStream(
                 Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "SPTarkov.Server.Core.dll"),
-                FileMode.Open
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite
             );
 
             _serverCoreModule = ModuleDefinition.ReadModule(fs);

--- a/SPTarkov.Server/Modding/ModLoaderController.cs
+++ b/SPTarkov.Server/Modding/ModLoaderController.cs
@@ -169,7 +169,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
         try
         {
             using var fs = new FileStream(
-                Path.Combine(Assembly.GetExecutingAssembly().Location, "SPTarkov.Server.Core.dll"),
+                Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "SPTarkov.Server.Core.dll"),
                 FileMode.Open
             );
 

--- a/SPTarkov.Server/Modding/ModLoaderController.cs
+++ b/SPTarkov.Server/Modding/ModLoaderController.cs
@@ -2,61 +2,56 @@ using System.Reflection;
 using System.Runtime.Loader;
 using Mono.Cecil;
 using SPTarkov.Common.Models.Logging;
+using SPTarkov.Reflection.Patching;
 using SPTarkov.Server.Core.Models.Spt.Mod;
 
 namespace SPTarkov.Server.Modding;
 
 public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModValidator modValidator)
 {
-    private const string ModPath = "./user/mods/";
-    private const string PatcherPath = "./user/patchers/";
+    public const string PatchedAssemblyName = "./SPTarkov.Server.Core.Patched.dll";
 
     public List<SptMod> ValidRuntimeMods
     {
         get { return modValidator.ValidateMods(_loadedMods); }
     }
 
-    private List<SptMod> _loadedMods = [];
-    private ModuleDefinition? _serverCoreModule;
-
-    public void LoadMods()
+    public bool HasPatchers
     {
-        if (!TryLoadServerCoreBytes())
+        get { return _prepatches.Count > 0; }
+    }
+
+    private List<SptMod> _loadedMods = [];
+    private readonly List<AbstractPrepatch> _prepatches = [];
+
+    private ModuleDefinition? _serverCoreModule;
+    private MemoryStream? _serverCoreModuleStream;
+
+    private const string ModPath = "./user/mods/";
+    private const string PatcherPath = "./user/patchers/";
+
+    public async Task LoadMods()
+    {
+        if (!await TryLoadServerCoreBytes())
         {
             return;
         }
 
-        LoadAllPatchers();
-        LoadAllMods();
-    }
-
-    // We need control and coupling between pre-patchers and the associated primary assembly,
-    // handle that here and any state needed.
-    // This will control the process of both patchers and the mods themselves
-
-    private void LoadAllPatchers()
-    {
-        var files = Directory.GetFiles(PatcherPath, "*.dll");
-        foreach (var file in files)
-        {
-            LoadPatcher(file);
-        }
-    }
-
-    private void LoadPatcher(string path) { }
-
-    private void LoadAllMods()
-    {
         if (!Directory.Exists(ModPath))
         {
             Directory.CreateDirectory(ModPath);
+        }
+
+        // Delete the old patched assembly
+        if (File.Exists(PatchedAssemblyName))
+        {
+            File.Delete(PatchedAssemblyName);
         }
 
         // foreach directory in /user/mods/
         // treat this as the MOD
         // should contain a dll
         // if dll is missing Throw Warning and skip
-
         var modDirectories = Directory.GetDirectories(ModPath);
 
         // Load mods found in dir
@@ -68,11 +63,43 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                logger.Critical($"Exception occured while loading a mod at path: {modDirectory}", e);
             }
         }
 
         _loadedMods = _loadedMods.OrderBy(m => m.ModMetadata.ModGuid, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    public void ApplyPrepatches(IReadOnlyCollection<SptMod> validRuntimeMods)
+    {
+        if (_serverCoreModule is null)
+        {
+            throw new ModLoaderException("Server core module was not loaded, unable to apply prepatches.");
+        }
+
+        var validModGuids = validRuntimeMods.Select(mod => mod.ModMetadata.ModGuid).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var activePrepatches = _prepatches
+            .Where(prepatch => prepatch.IsActive && validModGuids.Contains(prepatch.ModGuid))
+            .OrderBy(prepatch => prepatch.ModGuid, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(prepatch => prepatch.GetType().FullName, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var prepatch in activePrepatches)
+        {
+            logger.Info($"Applying prepatch: {prepatch.GetType().FullName}");
+            prepatch.Patch(_serverCoreModule);
+        }
+
+        try
+        {
+            _serverCoreModule.Write(PatchedAssemblyName);
+        }
+        finally
+        {
+            _serverCoreModule.Dispose();
+            _serverCoreModule = null;
+            _serverCoreModuleStream?.Dispose();
+            _serverCoreModuleStream = null;
+        }
     }
 
     /// <summary>
@@ -80,7 +107,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
     /// </summary>
     /// <param name="path">Directory path that contains mod files</param>
     /// <returns>SptMod</returns>
-    private static SptMod LoadMod(string path)
+    private SptMod LoadMod(string path)
     {
         List<Assembly> assemblyList = [];
         foreach (var file in new DirectoryInfo(path).GetFiles()) // Only search top level
@@ -93,17 +120,11 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
 
         if (assemblyList.Count == 0)
         {
-            throw new Exception($"No Assemblies found in path: {Path.GetFullPath(path)}");
+            throw new ModLoaderException($"No Assemblies found in path: {Path.GetFullPath(path)}");
         }
 
-        SptMod result = new()
-        {
-            Directory = path,
-            Assemblies = assemblyList,
-            ModMetadata = LoadModMetadata(assemblyList, path),
-        };
-
-        if (result.ModMetadata.HasPatcher) { }
+        SptMod result = new() { Directory = path, Assemblies = assemblyList };
+        LoadModMetadata(result, assemblyList, path);
 
         if (
             string.IsNullOrEmpty(result.ModMetadata.ModGuid)
@@ -112,7 +133,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
             || string.IsNullOrEmpty(result.ModMetadata.License)
         )
         {
-            throw new Exception(
+            throw new ModLoaderException(
                 $"The mod metadata for: {Path.GetFullPath(path)} is missing one of these properties: ModGuid, Name, Author, or License"
             );
         }
@@ -123,11 +144,12 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
     /// <summary>
     /// Finds and returns the mod metadata for this mod
     /// </summary>
+    /// <param name="mod">mod</param>
     /// <param name="assemblies">All mod assemblies</param>
     /// <param name="path">Path of the mod directory</param>
     /// <returns>Mod metadata</returns>
-    /// <exception cref="Exception">Thrown if duplicate metadata implementations are found</exception>
-    private static AbstractModMetadata LoadModMetadata(IEnumerable<Assembly> assemblies, string path)
+    /// <exception cref="ModLoaderException">Thrown if duplicate metadata implementations are found</exception>
+    private void LoadModMetadata(SptMod mod, IEnumerable<Assembly> assemblies, string path)
     {
         AbstractModMetadata? result = null;
 
@@ -139,7 +161,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
 
                 if (result != null && modMetadata != null)
                 {
-                    throw new Exception($"Duplicate mod metadata found for mod at path: {Path.GetFullPath(path)}");
+                    throw new ModLoaderException($"Duplicate mod metadata found for mod at path: {Path.GetFullPath(path)}");
                 }
 
                 if (modMetadata != null)
@@ -150,7 +172,7 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
                     }
                     catch (Exception ex)
                     {
-                        throw new Exception($"Failed to load mod metadata for: {Path.GetFullPath(path)} \n{ex}");
+                        throw new ModLoaderException($"Failed to load mod metadata for: {Path.GetFullPath(path)} \n{ex}");
                     }
                 }
             }
@@ -158,24 +180,63 @@ public class ModLoaderController(ISptLogger<ModLoaderController> logger, ModVali
 
         if (result == null)
         {
-            throw new Exception($"Failed to load mod metadata for: {Path.GetFullPath(path)} \ndid you override `AbstractModMetadata`?");
+            throw new ModLoaderException(
+                $"Failed to load mod metadata for: {Path.GetFullPath(path)} \ndid you override `AbstractModMetadata`?"
+            );
         }
 
-        return result;
+        mod.ModMetadata = result;
+        if (result.HasPatcher)
+        {
+            LoadModPatchers(mod, Path.Combine(PatcherPath, result.ModGuid));
+        }
     }
 
-    private bool TryLoadServerCoreBytes()
+    private void LoadModPatchers(SptMod mod, string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            throw new ModLoaderException(
+                $"Failed to locate patcher directory for mod: `{mod.ModMetadata.ModGuid}`. Expected directory: `{Path.GetFullPath(path)}`"
+            );
+        }
+
+        var patcherPath = Directory.GetFiles(path, "*.dll", SearchOption.TopDirectoryOnly).FirstOrDefault();
+        if (patcherPath is null)
+        {
+            throw new ModLoaderException(
+                $"Failed to locate a patcher for mod: `{mod.ModMetadata.ModGuid}`. If you did not intend to ship a patcher. Disable `HasPatcher` in AbstractModMetadata."
+            );
+        }
+
+        mod.PatcherAssembly = Assembly.LoadFrom(patcherPath);
+
+        var prepatchTypes = mod
+            .PatcherAssembly.GetTypes()
+            .Where(type => !type.IsAbstract && typeof(AbstractPrepatch).IsAssignableFrom(type));
+        if (!prepatchTypes.Any())
+        {
+            throw new ModLoaderException($"Patcher at path: `{patcherPath}` has no patcher entry point(s) of type `AbstractPrepatch`");
+        }
+
+        foreach (var prepatchType in prepatchTypes)
+        {
+            _prepatches.Add((AbstractPrepatch)Activator.CreateInstance(prepatchType)!);
+        }
+    }
+
+    private async Task<bool> TryLoadServerCoreBytes()
     {
         try
         {
-            using var fs = new FileStream(
-                Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "SPTarkov.Server.Core.dll"),
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.ReadWrite
-            );
+            var serverCorePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "SPTarkov.Server.Core.dll");
 
-            _serverCoreModule = ModuleDefinition.ReadModule(fs);
+            // Don't dispose the stream, keep it open, it will cause cecil to have a stroke if it's disposed of
+            _serverCoreModuleStream = new MemoryStream(await File.ReadAllBytesAsync(serverCorePath), writable: false);
+            _serverCoreModule = ModuleDefinition.ReadModule(
+                _serverCoreModuleStream,
+                new ReaderParameters { ReadingMode = ReadingMode.Immediate, InMemory = true }
+            );
         }
         catch (Exception e)
         {

--- a/SPTarkov.Server/Modding/ModLoaderException.cs
+++ b/SPTarkov.Server/Modding/ModLoaderException.cs
@@ -1,6 +1,6 @@
 namespace SPTarkov.Server.Modding;
 
-public class ModLoaderException : Exception
+public sealed class ModLoaderException : Exception
 {
     public ModLoaderException(string message)
         : base(message) { }

--- a/SPTarkov.Server/Modding/ModLoaderException.cs
+++ b/SPTarkov.Server/Modding/ModLoaderException.cs
@@ -1,0 +1,10 @@
+namespace SPTarkov.Server.Modding;
+
+public class ModLoaderException : Exception
+{
+    public ModLoaderException(string message)
+        : base(message) { }
+
+    public ModLoaderException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -28,7 +28,6 @@ namespace SPTarkov.Server;
 public static class Program
 {
     private const string PrepatchedArg = "--prepatched";
-    private const string PrepatchStagePath = "./user/cache/prepatcher/server";
 
     internal static ILogger? _earlyLogger;
     private static ModLoaderController? _modLoaderController;
@@ -107,14 +106,6 @@ public static class Program
     {
         Console.OutputEncoding = Encoding.UTF8;
 
-        // Clean the console a bit
-        // TODO: Carry over pre-patcher data so it can be logged to console. Create a cache json that can be read in the copied cache dir
-        var isPrepatchedProcess = args.Contains(PrepatchedArg, StringComparer.OrdinalIgnoreCase);
-        if (isPrepatchedProcess)
-        {
-            ClearConsole();
-        }
-
         var configuration = await ConfigLoader.Initialize(_earlyLogger!);
 
         // Init mod loader
@@ -124,16 +115,23 @@ public static class Program
             modLoaderController = InitModLoader(loggerFactory, configuration);
         }
 
+        // Clean the console a bit
+        var isPrepatchedProcess = args.Contains(PrepatchedArg, StringComparer.OrdinalIgnoreCase);
+        if (ProgramStatics.MODS() && isPrepatchedProcess && modLoaderController != null)
+        {
+            ClearConsole();
+            await modLoaderController.LogPrepatches();
+        }
+
         List<SptMod> loadedMods = [];
         if (ProgramStatics.MODS() && modLoaderController != null)
         {
             await modLoaderController.LoadMods();
             loadedMods = modLoaderController.ValidRuntimeMods;
 
-            if (!isPrepatchedProcess && modLoaderController.HasPatchers)
+            if (!isPrepatchedProcess && modLoaderController.HasPatchers && await modLoaderController.ApplyPrepatches(loadedMods))
             {
-                modLoaderController.ApplyPrepatches(loadedMods);
-                await StartPrepatchedServerProcess(args);
+                await StartPrepatchedServerProcess(args, modLoaderController);
                 return;
             }
         }
@@ -271,12 +269,13 @@ public static class Program
     /// <summary>
     ///     Starts the patched server as a new process. This one is destroyed in release and held open in debug so IDE's don't die.
     /// </summary>
-    private static async Task StartPrepatchedServerProcess(string[] args)
+    private static async Task StartPrepatchedServerProcess(string[] args, ModLoaderController modLoaderController)
     {
         var sourceDirectory = AppContext.BaseDirectory;
-        var stageDirectory = Path.GetFullPath(PrepatchStagePath);
+        var stageDirectory = Path.GetFullPath(ModLoaderController.PrepatchStagePath);
 
         CopyApplicationToCache(sourceDirectory, stageDirectory);
+        await modLoaderController.WriteResultLog();
 
         File.Copy(
             Path.GetFullPath(ModLoaderController.PatchedAssemblyName),

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -129,9 +129,13 @@ public static class Program
             await modLoaderController.LoadMods();
             loadedMods = modLoaderController.ValidRuntimeMods;
 
-            if (!isPrepatchedProcess && modLoaderController.HasPatchers && await modLoaderController.ApplyPrepatches(loadedMods))
+            if (!isPrepatchedProcess && modLoaderController.HasPatchers)
             {
-                await StartPrepatchedServerProcess(args, modLoaderController);
+                if (await modLoaderController.ApplyPrepatches(loadedMods))
+                {
+                    await StartPrepatchedServerProcess(args, modLoaderController);
+                }
+
                 return;
             }
         }

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -26,6 +26,7 @@ namespace SPTarkov.Server;
 public static class Program
 {
     internal static ILogger? _earlyLogger;
+    private static ModLoaderController? _modLoaderController;
 
     public static async Task Main(string[] args)
     {
@@ -93,7 +94,7 @@ public static class Program
         }
         finally
         {
-            loggerFactory?.Provider.Dispose();
+            loggerFactory.Provider.Dispose();
         }
     }
 
@@ -102,6 +103,13 @@ public static class Program
         Console.OutputEncoding = Encoding.UTF8;
 
         var configuration = await ConfigLoader.Initialize(_earlyLogger!);
+
+        // Init mod loader
+        ModLoaderController? modLoaderController = null;
+        if (ProgramStatics.MODS())
+        {
+            modLoaderController = InitModLoader(loggerFactory, configuration);
+        }
 
         // Create web builder and logger
         var builder = CreateNewHostBuilder(loggerFactory, configuration);
@@ -115,24 +123,33 @@ public static class Program
         });
 #endif
         var diHandler = new DependencyInjectionHandler(builder.Services);
+
         // register SPT components
         diHandler.AddInjectableTypesFromTypeAssembly(typeof(Program));
-        diHandler.AddInjectableTypesFromTypeAssembly(typeof(SPTStartupHostedService));
         diHandler.AddInjectableTypesFromTypeAssembly(typeof(PatchManager));
 
+        // TODO: Clean this up? Move to method?
+
+        // SPTStartupHostedService can potentially exist in two places and which one we load is based on if mods are enabled.
+        // If mods are enabled, we will run the entire mod loader process, apply prepatches, load/validate mods, and save the patched asm to disk.
+        // If mods are enabled, we will load the patched `Assembly` from disk as bytes and feed that into the DI handler
+        // If mods are NOT enabled, we will just load the one in context.
         List<SptMod> loadedMods = [];
-        if (ProgramStatics.MODS())
+        if (ProgramStatics.MODS() && modLoaderController != null)
         {
-            // Search for mod dlls
-            loadedMods = ModDllLoader.LoadAllMods();
-            // validate and sort mods, this will also discard any mods that are invalid
-            var validatedLoadedMods = ValidateMods(loggerFactory, loadedMods, configuration);
+            modLoaderController.LoadMods();
+            loadedMods = modLoaderController.ValidRuntimeMods;
 
-            // update the loadedMods list with our validated mods
-            loadedMods = validatedLoadedMods;
+            diHandler.AddInjectableTypesFromAssemblies(loadedMods.SelectMany(a => a.Assemblies));
 
-            diHandler.AddInjectableTypesFromAssemblies(validatedLoadedMods.SelectMany(a => a.Assemblies));
+            // TODO: Read patched ASM from disk as bytes and feed it directly do DI as an assembly
+            //diHandler.AddInjectableTypesFromAssembly();
         }
+        else
+        {
+            diHandler.AddInjectableTypesFromTypeAssembly(typeof(SPTStartupHostedService));
+        }
+
         diHandler.InjectAll();
 
         builder.InitializeSptBlazor(loadedMods);
@@ -236,17 +253,11 @@ public static class Program
         return builder;
     }
 
-    private static List<SptMod> ValidateMods(
+    private static ModLoaderController InitModLoader(
         SptEarlyLoggerFactory loggerFactory,
-        IEnumerable<SptMod> mods,
         IReadOnlyDictionary<Type, BaseConfig> configuration
     )
     {
-        if (!ProgramStatics.MODS())
-        {
-            return [];
-        }
-
         // We need the SPT dependencies for the ModValidator, but mods are loaded before the web application
         // So we create a disposable web application that we will throw away after getting the mods to load
         var builder = CreateNewHostBuilder(loggerFactory, configuration);
@@ -255,14 +266,16 @@ public static class Program
         diHandler.AddInjectableTypesFromAssembly(typeof(Program).Assembly);
         diHandler.AddInjectableTypesFromAssembly(typeof(SPTStartupHostedService).Assembly);
         diHandler.InjectAll();
-        // register the mod validator components
+
+        // register the mod loader components
         var provider = builder
             .Services.AddScoped<ISemVer, SemanticVersioningSemVer>()
+            .AddSingleton<ModLoaderController>()
             .AddSingleton<ModValidator>()
             .AddSptLoggerWithoutProvider(loggerFactory.ServiceProvider)
             .BuildServiceProvider();
-        var modValidator = provider.GetRequiredService<ModValidator>();
-        return modValidator.ValidateMods(mods);
+
+        return provider.GetRequiredService<ModLoaderController>();
     }
 
     private static bool IsRunFromInstallationFolder()

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -110,33 +110,31 @@ public static class Program
 
         // Init mod loader
         ModLoaderController? modLoaderController = null;
-        if (ProgramStatics.MODS())
-        {
-            modLoaderController = InitModLoader(loggerFactory, configuration);
-        }
-
-        // Clean the console a bit
-        var isPrepatchedProcess = args.Contains(PrepatchedArg, StringComparer.OrdinalIgnoreCase);
-        if (ProgramStatics.MODS() && isPrepatchedProcess && modLoaderController != null)
-        {
-            ClearConsole();
-            await modLoaderController.LogPrepatches();
-        }
-
         List<SptMod> loadedMods = [];
-        if (ProgramStatics.MODS() && modLoaderController != null)
+        if (InitModLoader(loggerFactory, configuration, out modLoaderController))
         {
-            await modLoaderController.LoadMods();
-            loadedMods = modLoaderController.ValidRuntimeMods;
-
-            if (!isPrepatchedProcess && modLoaderController.HasPatchers)
+            // Clean the console a bit
+            var isPrepatchedProcess = args.Contains(PrepatchedArg, StringComparer.OrdinalIgnoreCase);
+            if (ProgramStatics.MODS() && isPrepatchedProcess && modLoaderController != null)
             {
-                if (await modLoaderController.ApplyPrepatches(loadedMods))
-                {
-                    await StartPrepatchedServerProcess(args, modLoaderController);
-                }
+                ClearConsole();
+                await modLoaderController.LogPrepatches();
+            }
 
-                return;
+            if (ProgramStatics.MODS() && modLoaderController != null)
+            {
+                await modLoaderController.LoadMods();
+                loadedMods = modLoaderController.ValidRuntimeMods;
+
+                if (!isPrepatchedProcess && modLoaderController.HasPatchers)
+                {
+                    if (await modLoaderController.ApplyPrepatches(loadedMods))
+                    {
+                        await StartPrepatchedServerProcess(args, modLoaderController);
+                    }
+
+                    return;
+                }
             }
         }
 
@@ -405,11 +403,22 @@ public static class Program
         }
     }
 
-    private static ModLoaderController InitModLoader(
+    /// <summary>
+    ///     Initializes the mod loader container
+    /// </summary>
+    /// <returns>True if mods are enabled</returns>
+    private static bool InitModLoader(
         SptEarlyLoggerFactory loggerFactory,
-        IReadOnlyDictionary<Type, BaseConfig> configuration
+        IReadOnlyDictionary<Type, BaseConfig> configuration,
+        out ModLoaderController? modLoaderController
     )
     {
+        if (!ProgramStatics.MODS())
+        {
+            modLoaderController = null;
+            return false;
+        }
+
         // We need the SPT dependencies for the ModValidator, but mods are loaded before the web application
         // So we create a disposable web application that we will throw away after getting the mods to load
         var builder = CreateNewHostBuilder(loggerFactory, configuration);
@@ -427,7 +436,11 @@ public static class Program
             .AddSptLoggerWithoutProvider(loggerFactory.ServiceProvider)
             .BuildServiceProvider();
 
-        return provider.GetRequiredService<ModLoaderController>();
+        modLoaderController =
+            provider.GetService<ModLoaderController>()
+            ?? throw new NullReferenceException("Could not retrieve `ModLoaderController` during initialization.");
+
+        return ProgramStatics.MODS();
     }
 
     private static bool IsRunFromInstallationFolder()

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Security.Authentication;
 using System.Text;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -25,6 +27,9 @@ namespace SPTarkov.Server;
 
 public static class Program
 {
+    private const string PrepatchedArg = "--prepatched";
+    private const string PrepatchStagePath = "./user/cache/prepatcher/server";
+
     internal static ILogger? _earlyLogger;
     private static ModLoaderController? _modLoaderController;
 
@@ -102,6 +107,14 @@ public static class Program
     {
         Console.OutputEncoding = Encoding.UTF8;
 
+        // Clean the console a bit
+        // TODO: Carry over pre-patcher data so it can be logged to console. Create a cache json that can be read in the copied cache dir
+        var isPrepatchedProcess = args.Contains(PrepatchedArg, StringComparer.OrdinalIgnoreCase);
+        if (isPrepatchedProcess)
+        {
+            ClearConsole();
+        }
+
         var configuration = await ConfigLoader.Initialize(_earlyLogger!);
 
         // Init mod loader
@@ -109,6 +122,20 @@ public static class Program
         if (ProgramStatics.MODS())
         {
             modLoaderController = InitModLoader(loggerFactory, configuration);
+        }
+
+        List<SptMod> loadedMods = [];
+        if (ProgramStatics.MODS() && modLoaderController != null)
+        {
+            await modLoaderController.LoadMods();
+            loadedMods = modLoaderController.ValidRuntimeMods;
+
+            if (!isPrepatchedProcess && modLoaderController.HasPatchers)
+            {
+                modLoaderController.ApplyPrepatches(loadedMods);
+                await StartPrepatchedServerProcess(args);
+                return;
+            }
         }
 
         // Create web builder and logger
@@ -128,22 +155,10 @@ public static class Program
         diHandler.AddInjectableTypesFromTypeAssembly(typeof(Program));
         diHandler.AddInjectableTypesFromTypeAssembly(typeof(PatchManager));
 
-        // TODO: Clean this up? Move to method?
-
-        // SPTStartupHostedService can potentially exist in two places and which one we load is based on if mods are enabled.
-        // If mods are enabled, we will run the entire mod loader process, apply prepatches, load/validate mods, and save the patched asm to disk.
-        // If mods are enabled, we will load the patched `Assembly` from disk as bytes and feed that into the DI handler
-        // If mods are NOT enabled, we will just load the one in context.
-        List<SptMod> loadedMods = [];
         if (ProgramStatics.MODS() && modLoaderController != null)
         {
-            modLoaderController.LoadMods();
-            loadedMods = modLoaderController.ValidRuntimeMods;
-
             diHandler.AddInjectableTypesFromAssemblies(loadedMods.SelectMany(a => a.Assemblies));
-
-            // TODO: Read patched ASM from disk as bytes and feed it directly do DI as an assembly
-            //diHandler.AddInjectableTypesFromAssembly();
+            diHandler.AddInjectableTypesFromTypeAssembly(typeof(SPTStartupHostedService));
         }
         else
         {
@@ -251,6 +266,140 @@ public static class Program
         }
 
         return builder;
+    }
+
+    /// <summary>
+    ///     Starts the patched server as a new process. This one is destroyed in release and held open in debug so IDE's don't die.
+    /// </summary>
+    private static async Task StartPrepatchedServerProcess(string[] args)
+    {
+        var sourceDirectory = AppContext.BaseDirectory;
+        var stageDirectory = Path.GetFullPath(PrepatchStagePath);
+
+        CopyApplicationToCache(sourceDirectory, stageDirectory);
+
+        File.Copy(
+            Path.GetFullPath(ModLoaderController.PatchedAssemblyName),
+            Path.Combine(stageDirectory, "SPTarkov.Server.Core.dll"),
+            overwrite: true
+        );
+
+        var startInfo = CreatePrepatchedProcessStartInfo(stageDirectory);
+
+        foreach (var arg in args.Where(arg => !string.Equals(arg, PrepatchedArg, StringComparison.OrdinalIgnoreCase)))
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+        startInfo.ArgumentList.Add(PrepatchedArg);
+
+        var prepatchedProcess = Process.Start(startInfo);
+        if (prepatchedProcess is null)
+        {
+            throw new ModLoaderException($"Failed to start prepatched server process: {startInfo.FileName}");
+        }
+
+        // Needed for IDE development so the console doesn't just cease to exist when the process relaunches,
+        // in a normal environment it just reattaches to the old console, but this behavior doesn't work in Rider/VS
+#if DEBUG
+        await prepatchedProcess.WaitForExitAsync();
+        Environment.ExitCode = prepatchedProcess.ExitCode;
+#endif
+    }
+
+    private static ProcessStartInfo CreatePrepatchedProcessStartInfo(string stageDirectory)
+    {
+        var processPath = Environment.ProcessPath;
+        var entryAssemblyPath = Assembly.GetEntryAssembly()?.Location;
+
+        if (IsDotnetHost(processPath) && !string.IsNullOrEmpty(entryAssemblyPath))
+        {
+            var stagedAssemblyPath = Path.Combine(stageDirectory, Path.GetFileName(entryAssemblyPath));
+            var startInfo = CreateProcessStartInfo(processPath!);
+            startInfo.ArgumentList.Add(stagedAssemblyPath);
+            return startInfo;
+        }
+
+        var executableName = Path.GetFileName(processPath);
+        if (string.IsNullOrEmpty(executableName))
+        {
+            executableName = OperatingSystem.IsWindows() ? "SPT.Server.exe" : "SPT.Server";
+        }
+
+        return CreateProcessStartInfo(Path.Combine(stageDirectory, executableName));
+    }
+
+    private static bool IsDotnetHost(string? processPath)
+    {
+        if (string.IsNullOrEmpty(processPath))
+        {
+            return false;
+        }
+
+        return string.Equals(Path.GetFileNameWithoutExtension(processPath), "dotnet", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ProcessStartInfo CreateProcessStartInfo(string executablePath)
+    {
+        return new ProcessStartInfo(executablePath) { WorkingDirectory = Directory.GetCurrentDirectory(), UseShellExecute = false };
+    }
+
+    private static void ClearConsole()
+    {
+        if (Console.IsOutputRedirected)
+        {
+            return;
+        }
+
+        Console.Clear();
+    }
+
+    /// <summary>
+    ///     Copies the patched application to a cache
+    /// </summary>
+    /// <param name="sourceDirectory">Source dir</param>
+    /// <param name="cacheDirectory"></param>
+    private static void CopyApplicationToCache(string sourceDirectory, string cacheDirectory)
+    {
+        if (Directory.Exists(cacheDirectory))
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+
+        Directory.CreateDirectory(cacheDirectory);
+
+        foreach (var file in Directory.GetFiles(sourceDirectory))
+        {
+            File.Copy(file, Path.Combine(cacheDirectory, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (var directory in Directory.GetDirectories(sourceDirectory))
+        {
+            var directoryName = Path.GetFileName(directory);
+            if (
+                string.Equals(directoryName, "user", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(directoryName, "SPT_Data", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                continue;
+            }
+
+            CopyDirectory(directory, Path.Combine(cacheDirectory, directoryName));
+        }
+    }
+
+    private static void CopyDirectory(string sourceDirectory, string targetDirectory)
+    {
+        Directory.CreateDirectory(targetDirectory);
+
+        foreach (var file in Directory.GetFiles(sourceDirectory))
+        {
+            File.Copy(file, Path.Combine(targetDirectory, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (var directory in Directory.GetDirectories(sourceDirectory))
+        {
+            CopyDirectory(directory, Path.Combine(targetDirectory, Path.GetFileName(directory)));
+        }
     }
 
     private static ModLoaderController InitModLoader(

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -115,26 +115,23 @@ public static class Program
         {
             // Clean the console a bit
             var isPrepatchedProcess = args.Contains(PrepatchedArg, StringComparer.OrdinalIgnoreCase);
-            if (ProgramStatics.MODS() && isPrepatchedProcess && modLoaderController != null)
+            if (isPrepatchedProcess && modLoaderController != null)
             {
                 ClearConsole();
                 await modLoaderController.LogPrepatches();
             }
 
-            if (ProgramStatics.MODS() && modLoaderController != null)
+            await modLoaderController!.LoadMods();
+            loadedMods = modLoaderController.ValidRuntimeMods;
+
+            if (!isPrepatchedProcess && modLoaderController.HasPatchers)
             {
-                await modLoaderController.LoadMods();
-                loadedMods = modLoaderController.ValidRuntimeMods;
-
-                if (!isPrepatchedProcess && modLoaderController.HasPatchers)
+                if (await modLoaderController.ApplyPrepatches(loadedMods))
                 {
-                    if (await modLoaderController.ApplyPrepatches(loadedMods))
-                    {
-                        await StartPrepatchedServerProcess(args, modLoaderController);
-                    }
-
-                    return;
+                    await StartPrepatchedServerProcess(args, modLoaderController);
                 }
+
+                return;
             }
         }
 

--- a/Testing/TestMod/TestMod.cs
+++ b/Testing/TestMod/TestMod.cs
@@ -17,6 +17,7 @@ public record TestModMetadata : AbstractModMetadata, IModWebMetadata
     public override List<string>? Contributors { get; init; }
     public override Version Version { get; init; } = new("1.0.0");
     public override Range SptVersion { get; init; } = new("~4.1.0");
+    public override bool HasPatcher { get; init; } = false;
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, Range>? ModDependencies { get; init; }
     public override string? Url { get; init; }

--- a/Testing/TestMod/TestMod.cs
+++ b/Testing/TestMod/TestMod.cs
@@ -17,7 +17,7 @@ public record TestModMetadata : AbstractModMetadata, IModWebMetadata
     public override List<string>? Contributors { get; init; }
     public override Version Version { get; init; } = new("1.0.0");
     public override Range SptVersion { get; init; } = new("~4.1.0");
-    public override bool HasPatcher { get; init; } = false;
+    public override bool HasPrepatcher { get; init; } = false;
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, Range>? ModDependencies { get; init; }
     public override string? Url { get; init; }

--- a/Testing/TestMod2/TestMod2.cs
+++ b/Testing/TestMod2/TestMod2.cs
@@ -17,6 +17,7 @@ public record TestMod2Metadata : AbstractModMetadata, IModWebMetadata
     public override List<string>? Contributors { get; init; }
     public override Version Version { get; init; } = new("1.0.0");
     public override Range SptVersion { get; init; } = new("~4.1.0");
+    public override bool HasPatcher { get; init; } = false;
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, Range>? ModDependencies { get; init; }
     public override string? Url { get; init; }

--- a/Testing/TestMod2/TestMod2.cs
+++ b/Testing/TestMod2/TestMod2.cs
@@ -17,7 +17,7 @@ public record TestMod2Metadata : AbstractModMetadata, IModWebMetadata
     public override List<string>? Contributors { get; init; }
     public override Version Version { get; init; } = new("1.0.0");
     public override Range SptVersion { get; init; } = new("~4.1.0");
-    public override bool HasPatcher { get; init; } = true;
+    public override bool HasPrepatcher { get; init; } = true;
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, Range>? ModDependencies { get; init; }
     public override string? Url { get; init; }

--- a/Testing/TestMod2/TestMod2.cs
+++ b/Testing/TestMod2/TestMod2.cs
@@ -17,7 +17,7 @@ public record TestMod2Metadata : AbstractModMetadata, IModWebMetadata
     public override List<string>? Contributors { get; init; }
     public override Version Version { get; init; } = new("1.0.0");
     public override Range SptVersion { get; init; } = new("~4.1.0");
-    public override bool HasPatcher { get; init; } = false;
+    public override bool HasPatcher { get; init; } = true;
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, Range>? ModDependencies { get; init; }
     public override string? Url { get; init; }

--- a/Testing/TestMod2/TestMod2.csproj
+++ b/Testing/TestMod2/TestMod2.csproj
@@ -15,6 +15,13 @@
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
+  <Target Name="BuildTestPrepatch" BeforeTargets="CopyToServer">
+    <MSBuild
+      Projects="$(MSBuildProjectDirectory)\..\TestPrepatch\TestPrepatch.csproj"
+      Targets="Build"
+      Properties="Configuration=$(Configuration)"
+    />
+  </Target>
   <Target Name="CopyToServer" AfterTargets="PostBuildEvent">
     <ItemGroup>
       <OutputDLL Include="$(ProjectDir)$(OutDir)$(TargetName).dll" />
@@ -22,15 +29,18 @@
       <WebAssets Include="$(ProjectDir)wwwroot\**\*.*" />
     </ItemGroup>
     <!-- Copies the output dll -->
-    <Copy SourceFiles="@(OutputDLL);" DestinationFolder="$(SolutionDir)\SPTarkov.Server\bin\$(Configuration)\net10.0\user\mods\TestMod2" />
+    <Copy
+      SourceFiles="@(OutputDLL);"
+      DestinationFolder="$(MSBuildProjectDirectory)\..\..\SPTarkov.Server\bin\$(Configuration)\net10.0\user\mods\TestMod2"
+    />
     <Copy
       SourceFiles="@(Resources);"
-      DestinationFolder="$(SolutionDir)\SPTarkov.Server\bin\$(Configuration)\net10.0\user\mods\TestMod2\Resources\%(RecursiveDir)"
+      DestinationFolder="$(MSBuildProjectDirectory)\..\..\SPTarkov.Server\bin\$(Configuration)\net10.0\user\mods\TestMod2\Resources\%(RecursiveDir)"
     />
     <!-- Copy the wwwroot folder -->
     <Copy
       SourceFiles="@(WebAssets)"
-      DestinationFolder="$(SolutionDir)\SPTarkov.Server\bin\$(Configuration)\net10.0\user\mods\TestMod2\wwwroot\%(RecursiveDir)"
+      DestinationFolder="$(MSBuildProjectDirectory)\..\..\SPTarkov.Server\bin\$(Configuration)\net10.0\user\mods\TestMod2\wwwroot\%(RecursiveDir)"
     />
   </Target>
 </Project>

--- a/Testing/TestPrepatch/TestPrepatch.cs
+++ b/Testing/TestPrepatch/TestPrepatch.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using Mono.Cecil;
+using SPTarkov.Reflection.Patching;
+
+namespace TestPrepatch;
+
+public sealed class TestPrepatch : AbstractPrepatch
+{
+    private const string MetadataKey = "TestPrepatch";
+    private const string MetadataValue = "Applied";
+
+    public override string ModGuid
+    {
+        get { return "com.sp-tarkov.test-mod2"; }
+    }
+
+    public override bool IsActive
+    {
+        get { return true; }
+    }
+
+    public override void Patch(ModuleDefinition serverCoreModule)
+    {
+        if (serverCoreModule.Assembly.CustomAttributes.Any(IsTestPrepatchMarker))
+        {
+            return;
+        }
+
+        var constructor = typeof(AssemblyMetadataAttribute).GetConstructor([typeof(string), typeof(string)]);
+        var metadataAttribute = new CustomAttribute(serverCoreModule.ImportReference(constructor));
+        metadataAttribute.ConstructorArguments.Add(new CustomAttributeArgument(serverCoreModule.TypeSystem.String, MetadataKey));
+        metadataAttribute.ConstructorArguments.Add(new CustomAttributeArgument(serverCoreModule.TypeSystem.String, MetadataValue));
+
+        serverCoreModule.Assembly.CustomAttributes.Add(metadataAttribute);
+    }
+
+    private static bool IsTestPrepatchMarker(CustomAttribute attribute)
+    {
+        return attribute.AttributeType.FullName == typeof(AssemblyMetadataAttribute).FullName
+            && attribute.ConstructorArguments.Count == 2
+            && string.Equals(attribute.ConstructorArguments[0].Value as string, MetadataKey, StringComparison.Ordinal);
+    }
+}

--- a/Testing/TestPrepatch/TestPrepatch.csproj
+++ b/Testing/TestPrepatch/TestPrepatch.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\Build.props" />
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>TestPrepatch</AssemblyName>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Libraries\SPTarkov.Reflection\SPTarkov.Reflection.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToServerPatchers" AfterTargets="PostBuildEvent">
+    <ItemGroup>
+      <OutputDLL Include="$(ProjectDir)$(OutDir)$(TargetName).dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(OutputDLL)"
+      DestinationFolder="$(MSBuildProjectDirectory)\..\..\SPTarkov.Server\bin\$(Configuration)\net10.0\user\patchers\com.sp-tarkov.test-mod2"
+    />
+  </Target>
+</Project>

--- a/server-csharp.slnx
+++ b/server-csharp.slnx
@@ -17,7 +17,10 @@
   <Folder Name="/Testing/">
     <Project Path="Testing/Benchmarks/Benchmarks.csproj" />
     <Project Path="Testing/TestMod/TestMod.csproj" />
-    <Project Path="Testing/TestMod2/TestMod2.csproj" />
+    <Project Path="Testing/TestMod2/TestMod2.csproj">
+      <BuildDependency Project="Testing/TestPrepatch/TestPrepatch.csproj" />
+    </Project>
+    <Project Path="Testing/TestPrepatch/TestPrepatch.csproj" />
     <Project Path="Testing/UnitTests/UnitTests.csproj" />
   </Folder>
   <Folder Name="/Tools/">


### PR DESCRIPTION
# Summary

This PR enables the ability to apply pre-runtime patches, otherwise known as "pre-patching". This allows for modifications that are impossible during runtime. Examples include but are not limited to; Enum constant extensions, changing publicity, added fields, adding properties, IL modifications (Alternate to Transpiler patching, more powerful, however more difficult). 

# How it works

First, we load all runtime mods as they are what define the ability to load a pre-patch inside of `AbstractModMetadata` with the `HasPatcher` bool set to true.  This may seem counter intuitive, but the runtime is the core of the mod and thus should define the existence of external components. If it has `HasPatcher` set to true the mod loader will then search for a pre-patcher in the path `./user/patchers/[ModGuid]/patcher.dll`. It will throw an exception if it declares a pre-patcher, but none exists. 

After all mods are loaded and if we have pending any pre-patch to apply, we will call all found patch class entry points in the patcher assembly, we do this for every mod. Once patching is complete we then copy the server core contents (server exe and all dependents) to a cache in the user folder, this cache is cleaned every run. The server after copying itself will relaunch itself with the `--prepatched` argument, this argument prevents the pre-patching process from running again. Then the startup is normal.

# How to use it
- HARD reference the `SPT.Server.Core.dll`
- Inherit from `AbstractPrepatch` and implement the required members
- Make a patch
- Profit

You are free to reference the `SPT.Server.Core.dll` in the cached path for your project, this will include your modifications.

# Caveats
- Running the server in an IDE with a pre-patch will result in difficulty debugging due to the server restarting itself. This only applies if you build the `TestPrepatch` project. 
- Debug builds hold the original process open so that IDE runners don't lose the console in testing. This will as a side effect, apply to Bleeding edge builds. The memory footprint is small, an additional ~200mb, and its idle.
- Mod devs who use this feature will have to hard ref the server core assembly and recompile for EVERY update. Nuget will not save you here. There is no way around this.

# Tested
- Patches apply
- Patched server is loaded
- Tested on Windows 11 and Linux