### PR TITLE
Fix pmc customitem

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
@@ -158,7 +158,17 @@ public class CustomItemService(
 
         if (newItemDetails.AddToFleaPriceDb)
         {
+            if (newItemDetails.FleaPriceRoubles is null or <= 0)
+            {
+                throw new InvalidOperationException($"{nameof(newItemDetails.FleaPriceRoubles)} is null or 0 while trying to add to flea!");
+            }
+
             AddToFleaPriceDb(newItem.Id, newItemDetails.FleaPriceRoubles);
+        }
+        else
+        {
+            // Prevent item with no flea entry being added to pmc loot
+            pmcConfig.GlobalLootBlacklist.Add(newItem.Id);
         }
 
         itemBaseClassService.AddItemToCache(newItem.Id);

--- a/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
@@ -5,6 +5,7 @@ using SPTarkov.Server.Core.Helpers;
 using SPTarkov.Server.Core.Models.Common;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Enums;
+using SPTarkov.Server.Core.Models.Spt.Config;
 using SPTarkov.Server.Core.Models.Spt.Mod;
 using SPTarkov.Server.Core.Utils.Cloners;
 
@@ -15,6 +16,7 @@ public class CustomItemService(
     ISptLogger<CustomItemService> logger,
     DatabaseService databaseService,
     ItemHelper itemHelper,
+    PmcConfig pmcConfig,
     ItemBaseClassService itemBaseClassService,
     ModItemCacheService modItemCacheService,
     ICloner cloner
@@ -77,6 +79,11 @@ public class CustomItemService(
         if (newItemDetails.AddToFleaPriceDb)
         {
             AddToFleaPriceDb(newItemId, newItemDetails.FleaPriceRoubles);
+        }
+        else
+        {
+            // Prevent item with no flea entry being added to pmc loot
+            pmcConfig.GlobalLootBlacklist.Add(newItemId);
         }
 
         itemBaseClassService.AddItemToCache(newItemId);

--- a/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Mod/CustomItemService.cs
@@ -78,6 +78,11 @@ public class CustomItemService(
 
         if (newItemDetails.AddToFleaPriceDb)
         {
+            if (newItemDetails.FleaPriceRoubles is null or <= 0)
+            {
+                throw new InvalidOperationException($"{nameof(newItemDetails.FleaPriceRoubles)} is null or 0 while trying to add to flea!");
+            }
+
             AddToFleaPriceDb(newItemId, newItemDetails.FleaPriceRoubles);
         }
         else


### PR DESCRIPTION
This can be handled or it can throw. After talking with Arch I just made it throw. Also added throwing if price is 0, which I'm not sure why we would not want to? There may be a scenario where you want it on the flea but 0 but I have no idea.

Comes down to if you want it to be loud and notify mod authors or silently fall back to putting it on the blacklist.