### PR TITLE
Fix exhaustablearray

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Services/ItemFilterService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/ItemFilterService.cs
@@ -11,8 +11,8 @@ namespace SPTarkov.Server.Core.Services;
 [Injectable(InjectionType.Singleton)]
 public class ItemFilterService(ISptLogger<ItemFilterService> logger, ItemConfig itemConfig)
 {
-    protected readonly HashSet<MongoId> ItemBlacklistCache = [];
-    protected readonly HashSet<MongoId> LootableItemBlacklistCache = [];
+    protected readonly HashSet<MongoId> ItemBlacklistCache = [..itemConfig.Blacklist];
+    protected readonly HashSet<MongoId> LootableItemBlacklistCache = [..itemConfig.LootableItemBlacklist];
 
     /// <summary>
     ///     Get an HashSet of items that should never be given as a reward to player
@@ -75,11 +75,6 @@ public class ItemFilterService(ISptLogger<ItemFilterService> logger, ItemConfig 
     /// <returns>True if blacklisted</returns>
     public bool IsLootableItemBlacklisted(MongoId itemKey)
     {
-        if (!LootableItemBlacklistCache.Any())
-        {
-            LootableItemBlacklistCache.UnionWith(itemConfig.LootableItemBlacklist);
-        }
-
         return LootableItemBlacklistCache.Contains(itemKey);
     }
 
@@ -94,11 +89,6 @@ public class ItemFilterService(ISptLogger<ItemFilterService> logger, ItemConfig 
 
     public bool IsItemBlacklisted(MongoId tpl)
     {
-        if (!ItemBlacklistCache.Any())
-        {
-            ItemBlacklistCache.UnionWith(itemConfig.Blacklist);
-        }
-
         return ItemBlacklistCache.Contains(tpl);
     }
 

--- a/Libraries/SPTarkov.Server.Core/Utils/Collections/ExhaustableArray.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Collections/ExhaustableArray.cs
@@ -15,7 +15,7 @@ public record ExhaustableArray<T> : IExhaustableArray<T>
     {
         _cloner = cloner;
         _randomUtil = randomUtil;
-        pool = cloner.Clone(itemPool ?? []);
+        pool = new LinkedList<T>(itemPool ?? []);
     }
 
     public ExhaustableArray(ICollection<T>? itemPool, RandomUtil randomUtil, ICloner cloner)


### PR DESCRIPTION
Removing the clone in the constructor on the ExhausteableArray stopped the corrupted LinkedLists but caused another error to appear with the race condition in checking loot blacklists.

Without this fix you see a botgen error maybe 1 in 10? raids. It's far easier to test if you use postman and generate 50+ of each bot as you'll get the errors pretty constantly.

I did originally think it was just the race condition causing the errors upstream but I tested that fix in isolation and you'll still get index errors in the ExhaustableArray albeit much more rarely. There may be another cause somewhere or maybe an issue with FastCloner?