### PR TITLE
Add more cancellation token support & async rename

### DIFF
--- a/Libraries/SPTarkov.Common/Logger/LogFileRollManager.cs
+++ b/Libraries/SPTarkov.Common/Logger/LogFileRollManager.cs
@@ -41,12 +41,12 @@ internal sealed class LogFileRollMonitor : IAsyncDisposable
         _cleanupCancellationTokenSource = new CancellationTokenSource();
 
         _cleanupTask = Task.Factory.StartNew(
-            async () => await CleanupWorker(_cleanupCancellationTokenSource.Token).ConfigureAwait(false),
+            async () => await CleanupWorkerAsync(_cleanupCancellationTokenSource.Token).ConfigureAwait(false),
             TaskCreationOptions.LongRunning
         );
     }
 
-    private async Task CleanupWorker(CancellationToken cancellationToken)
+    private async Task CleanupWorkerAsync(CancellationToken cancellationToken)
     {
         using var timer = new PeriodicTimer(_cleanupInterval);
 

--- a/Libraries/SPTarkov.Server.Core/Callbacks/BtrDeliveryCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/BtrDeliveryCallbacks.cs
@@ -21,7 +21,7 @@ public class BtrDeliveryCallbacks(
     SaveServer saveServer
 ) : IOnUpdate
 {
-    public Task<bool> OnUpdate(CancellationToken stoppingToken, long secondsSinceLastRun)
+    public Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken stoppingToken)
     {
         if (secondsSinceLastRun < btrDeliveryConfig.RunIntervalSeconds)
         {

--- a/Libraries/SPTarkov.Server.Core/Callbacks/BtrDeliveryCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/BtrDeliveryCallbacks.cs
@@ -21,7 +21,7 @@ public class BtrDeliveryCallbacks(
     SaveServer saveServer
 ) : IOnUpdate
 {
-    public Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken stoppingToken)
+    public Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken)
     {
         if (secondsSinceLastRun < btrDeliveryConfig.RunIntervalSeconds)
         {

--- a/Libraries/SPTarkov.Server.Core/Callbacks/DialogueCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/DialogueCallbacks.cs
@@ -12,7 +12,7 @@ namespace SPTarkov.Server.Core.Callbacks;
 [Injectable(TypePriority = OnUpdateOrder.DialogueCallbacks)]
 public class DialogueCallbacks(TimeUtil timeUtil, HttpResponseUtil httpResponseUtil, DialogueController dialogueController) : IOnUpdate
 {
-    public Task<bool> OnUpdate(CancellationToken stoppingToken, long timeSinceLastRun)
+    public Task<bool> OnUpdate(long timeSinceLastRun, CancellationToken cancellationToken)
     {
         dialogueController.Update();
         return Task.FromResult(true);

--- a/Libraries/SPTarkov.Server.Core/Callbacks/GameCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/GameCallbacks.cs
@@ -22,7 +22,7 @@ public class GameCallbacks(
     TimeUtil timeUtil
 ) : IOnLoad
 {
-    public Task OnLoad(CancellationToken stoppingToken)
+    public Task OnLoad(CancellationToken cancellationToken)
     {
         gameController.Load();
         return Task.CompletedTask;
@@ -69,7 +69,7 @@ public class GameCallbacks(
         await saveServer.SaveProfileAsync(sessionID);
 
         // Backup profiles on exit
-        await backupService.Init();
+        await backupService.InitializeAsync();
 
         return httpResponseUtil.GetBody(new GameLogoutResponseData { Status = "ok" });
     }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/HandbookCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/HandbookCallbacks.cs
@@ -7,7 +7,7 @@ namespace SPTarkov.Server.Core.Callbacks;
 [Injectable(TypePriority = OnLoadOrder.HandbookCallbacks)]
 public class HandbookCallbacks(HandBookController handBookController) : IOnLoad
 {
-    public Task OnLoad(CancellationToken stoppingToken)
+    public Task OnLoad(CancellationToken cancellationToken)
     {
         handBookController.Load();
         return Task.CompletedTask;

--- a/Libraries/SPTarkov.Server.Core/Callbacks/HideoutCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/HideoutCallbacks.cs
@@ -12,7 +12,7 @@ namespace SPTarkov.Server.Core.Callbacks;
 [Injectable(TypePriority = OnUpdateOrder.HideoutCallbacks)]
 public class HideoutCallbacks(HideoutController hideoutController, HideoutConfig hideoutConfig) : IOnUpdate
 {
-    public Task<bool> OnUpdate(CancellationToken stoppingToken, long secondsSinceLastRun)
+    public Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken)
     {
         if (secondsSinceLastRun < hideoutConfig.RunIntervalSeconds)
         {

--- a/Libraries/SPTarkov.Server.Core/Callbacks/InsuranceCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/InsuranceCallbacks.cs
@@ -14,7 +14,7 @@ namespace SPTarkov.Server.Core.Callbacks;
 public class InsuranceCallbacks(InsuranceController insuranceController, HttpResponseUtil httpResponseUtil, InsuranceConfig insuranceConfig)
     : IOnUpdate
 {
-    public Task<bool> OnUpdate(CancellationToken stoppingToken, long secondsSinceLastRun)
+    public Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken)
     {
         if (secondsSinceLastRun < insuranceConfig.RunIntervalSeconds)
         {

--- a/Libraries/SPTarkov.Server.Core/Callbacks/PresetCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/PresetCallbacks.cs
@@ -7,7 +7,7 @@ namespace SPTarkov.Server.Core.Callbacks;
 [Injectable(TypePriority = OnLoadOrder.PresetCallbacks)]
 public class PresetCallbacks(PresetController presetController) : IOnLoad
 {
-    public Task OnLoad(CancellationToken stoppingToken)
+    public Task OnLoad(CancellationToken cancellationToken)
     {
         presetController.Initialize();
         return Task.CompletedTask;

--- a/Libraries/SPTarkov.Server.Core/Callbacks/RagfairCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/RagfairCallbacks.cs
@@ -30,7 +30,7 @@ public class RagfairCallbacks(
         return Task.CompletedTask;
     }
 
-    public Task<bool> OnUpdate(CancellationToken stoppingToken, long secondsSinceLastRun)
+    public Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken)
     {
         if (secondsSinceLastRun < ragfairConfig.RunIntervalSeconds)
         {

--- a/Libraries/SPTarkov.Server.Core/Callbacks/RagfairCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/RagfairCallbacks.cs
@@ -22,7 +22,7 @@ public class RagfairCallbacks(
     RagfairConfig ragfairConfig
 ) : IOnLoad, IOnUpdate
 {
-    public Task OnLoad(CancellationToken stoppingToken)
+    public Task OnLoad(CancellationToken cancellationToken)
     {
         ragfairPriceService.Load();
         ragfairServer.Load();

--- a/Libraries/SPTarkov.Server.Core/Callbacks/SaveCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/SaveCallbacks.cs
@@ -11,13 +11,13 @@ public class SaveCallbacks(SaveServer saveServer, BackupService backupService, C
 {
     public async Task OnLoad(CancellationToken stoppingToken)
     {
-        await saveServer.LoadAsync();
+        await saveServer.LoadAsync(stoppingToken);
 
         // Note: This has to happen after loading the saveServer so we don't backup corrupted profiles
-        await backupService.StartBackupSystem();
+        await backupService.StartBackupSystem(stoppingToken);
     }
 
-    public async Task<bool> OnUpdate(CancellationToken stoppingToken, long secondsSinceLastRun)
+    public async Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken)
     {
         if (secondsSinceLastRun < coreConfig.ProfileSaveIntervalInSeconds)
         {
@@ -25,7 +25,7 @@ public class SaveCallbacks(SaveServer saveServer, BackupService backupService, C
             return false;
         }
 
-        await saveServer.SaveAsync();
+        await saveServer.SaveAsync(cancellationToken);
 
         return true;
     }

--- a/Libraries/SPTarkov.Server.Core/Callbacks/SaveCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/SaveCallbacks.cs
@@ -9,12 +9,12 @@ namespace SPTarkov.Server.Core.Callbacks;
 [Injectable(TypePriority = OnLoadOrder.SaveCallbacks)]
 public class SaveCallbacks(SaveServer saveServer, BackupService backupService, CoreConfig coreConfig) : IOnLoad, IOnUpdate
 {
-    public async Task OnLoad(CancellationToken stoppingToken)
+    public async Task OnLoad(CancellationToken cancellationToken)
     {
-        await saveServer.LoadAsync(stoppingToken);
+        await saveServer.LoadAsync(cancellationToken);
 
         // Note: This has to happen after loading the saveServer so we don't backup corrupted profiles
-        await backupService.StartBackupSystem(stoppingToken);
+        await backupService.StartBackupSystem(cancellationToken);
     }
 
     public async Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken)

--- a/Libraries/SPTarkov.Server.Core/Callbacks/TraderCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/TraderCallbacks.cs
@@ -10,7 +10,7 @@ namespace SPTarkov.Server.Core.Callbacks;
 [Injectable(TypePriority = OnLoadOrder.TraderCallbacks)]
 public class TraderCallbacks(HttpResponseUtil httpResponseUtil, TraderController traderController) : IOnLoad, IOnUpdate
 {
-    public Task OnLoad(CancellationToken stoppingToken)
+    public Task OnLoad(CancellationToken cancellationToken)
     {
         traderController.Load();
         return Task.CompletedTask;

--- a/Libraries/SPTarkov.Server.Core/Callbacks/TraderCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/TraderCallbacks.cs
@@ -16,7 +16,7 @@ public class TraderCallbacks(HttpResponseUtil httpResponseUtil, TraderController
         return Task.CompletedTask;
     }
 
-    public Task<bool> OnUpdate(CancellationToken stoppingToken, long _)
+    public Task<bool> OnUpdate(long _, CancellationToken cancellationToken)
     {
         traderController.Update();
 

--- a/Libraries/SPTarkov.Server.Core/Controllers/NotifierController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/NotifierController.cs
@@ -20,31 +20,37 @@ public class NotifierController(HttpServerHelper httpServerHelper, NotifierHelpe
     ///     If no notifications are available after the timeout, use a default message.
     /// </summary>
     /// <param name="sessionId">Session/Player id</param>
-    public Task<List<WsNotificationEvent>> NotifyAsync(MongoId sessionId)
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the notification operation.
+    /// </param>
+    public Task<List<WsNotificationEvent>> NotifyAsync(MongoId sessionId, CancellationToken cancellationToken = default)
     {
-        return Task.Factory.StartNew(() =>
-        {
-            // keep track of our timeout
-            var counter = 0;
-
-            while (counter < Timeout)
+        return Task.Factory.StartNew(
+            () =>
             {
-                if (!notificationService.Has(sessionId))
-                {
-                    counter += PollInterval;
-                    Thread.Sleep(PollInterval);
-                }
-                else
-                {
-                    var messages = notificationService.Get(sessionId);
+                // keep track of our timeout
+                var counter = 0;
 
-                    notificationService.UpdateMessageOnQueue(sessionId, []);
-                    return messages;
-                }
-            }
+                while (counter < Timeout)
+                {
+                    if (!notificationService.Has(sessionId))
+                    {
+                        counter += PollInterval;
+                        Thread.Sleep(PollInterval);
+                    }
+                    else
+                    {
+                        var messages = notificationService.Get(sessionId);
 
-            return [notifierHelper.GetDefaultNotification()];
-        });
+                        notificationService.UpdateMessageOnQueue(sessionId, []);
+                        return messages;
+                    }
+                }
+
+                return [notifierHelper.GetDefaultNotification()];
+            },
+            cancellationToken
+        );
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/DI/IOnLoad.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/IOnLoad.cs
@@ -1,6 +1,29 @@
+using SPTarkov.DI.Annotations;
+
 namespace SPTarkov.Server.Core.DI;
 
 public interface IOnLoad
 {
+    /// <summary>
+    /// Called when the server is loading through its various <see cref="Injectable.TypePriority">load order</see> stages.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// A token that is cancelled when the server is shutting down gracefully, such as from Ctrl+C,
+    /// a termination signal, or another controlled shutdown request.
+    /// </param>
+    /// <returns>
+    /// A task that completes when the load operation has finished.
+    /// </returns>
+    /// <remarks>
+    /// Implementations should observe <paramref name="cancellationToken"/> and stop work as soon as
+    /// reasonably possible when cancellation is requested.
+    ///
+    /// Pass the token to any asynchronous APIs that accept one, such as file I/O, HTTP requests,
+    /// database calls, or delays. For long-running synchronous work, periodically call
+    /// <see cref="CancellationToken.ThrowIfCancellationRequested"/>.
+    ///
+    /// Do not treat cancellation as an error. If cancellation is requested, allow
+    /// <see cref="OperationCanceledException"/> to propagate unless cleanup is required.
+    /// </remarks>
     Task OnLoad(CancellationToken cancellationToken);
 }

--- a/Libraries/SPTarkov.Server.Core/DI/IOnLoad.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/IOnLoad.cs
@@ -2,5 +2,5 @@ namespace SPTarkov.Server.Core.DI;
 
 public interface IOnLoad
 {
-    Task OnLoad(CancellationToken stoppingToken);
+    Task OnLoad(CancellationToken cancellationToken);
 }

--- a/Libraries/SPTarkov.Server.Core/DI/IOnUpdate.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/IOnUpdate.cs
@@ -2,5 +2,36 @@ namespace SPTarkov.Server.Core.DI;
 
 public interface IOnUpdate
 {
+    /// <summary>
+    /// Called repeatedly while the server is running.
+    /// </summary>
+    /// <param name="secondsSinceLastRun">
+    /// The number of seconds since this component last completed successfully.
+    /// A successful update is one that returns <see langword="true"/>.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token that is cancelled when the server is shutting down gracefully, such as from Ctrl+C,
+    /// a termination signal, or another controlled shutdown request.
+    /// </param>
+    /// <returns>
+    /// A task that completes with <see langword="true"/> when the update ran successfully and the
+    /// last-run timestamp should be updated; otherwise, <see langword="false"/> to leave the
+    /// last-run timestamp unchanged.
+    /// </returns>
+    /// <remarks>
+    /// Implementations should observe <paramref name="cancellationToken"/> and stop work as soon as
+    /// reasonably possible when cancellation is requested.
+    ///
+    /// Pass the token to any asynchronous APIs that accept one, such as file I/O, HTTP requests,
+    /// database calls, or delays. For long-running synchronous work, periodically call
+    /// <see cref="CancellationToken.ThrowIfCancellationRequested"/>.
+    ///
+    /// Do not treat cancellation as an error. If cancellation is requested, allow
+    /// <see cref="OperationCanceledException"/> to propagate unless cleanup is required.
+    ///
+    /// Returning <see langword="true"/> indicates that the update completed successfully. Returning
+    /// <see langword="false"/> can be used when the update intentionally skipped work and should be
+    /// called again later with the same accumulated elapsed time.
+    /// </remarks>
     Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken);
 }

--- a/Libraries/SPTarkov.Server.Core/DI/IOnUpdate.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/IOnUpdate.cs
@@ -2,5 +2,5 @@ namespace SPTarkov.Server.Core.DI;
 
 public interface IOnUpdate
 {
-    Task<bool> OnUpdate(CancellationToken stoppingToken, long secondsSinceLastRun);
+    Task<bool> OnUpdate(long secondsSinceLastRun, CancellationToken cancellationToken);
 }

--- a/Libraries/SPTarkov.Server.Core/DI/ISerializer.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/ISerializer.cs
@@ -5,6 +5,12 @@ namespace SPTarkov.Server.Core.DI;
 
 public interface ISerializer
 {
-    public Task Serialize(MongoId sessionID, HttpRequest req, HttpResponse resp, object? body);
+    public Task SerializeAsync(
+        MongoId sessionID,
+        HttpRequest req,
+        HttpResponse resp,
+        object? body,
+        CancellationToken cancellationToken = default
+    );
     public bool CanHandle(string route);
 }

--- a/Libraries/SPTarkov.Server.Core/DI/Router.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/Router.cs
@@ -96,7 +96,7 @@ public abstract class StaticRouter(JsonUtil jsonUtil, IEnumerable<RouteAction> r
 
 public abstract class DynamicRouter(JsonUtil jsonUtil, IEnumerable<RouteAction> routes) : Router
 {
-    public async ValueTask<object> HandleDynamic(
+    public async ValueTask<object> HandleDynamicAsync(
         string url,
         string? body,
         MongoId sessionId,

--- a/Libraries/SPTarkov.Server.Core/DI/Router.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/Router.cs
@@ -65,7 +65,13 @@ public abstract class Router
 
 public abstract class StaticRouter(JsonUtil jsonUtil, IEnumerable<RouteAction> routes) : Router
 {
-    public async ValueTask<object> HandleStatic(string url, string? body, MongoId sessionId, string output)
+    public async ValueTask<object> HandleStaticAsync(
+        string url,
+        string? body,
+        MongoId sessionId,
+        string output,
+        CancellationToken cancellationToken = default
+    )
     {
         var action = routes.Single(route => route.url == url);
         var type = action.bodyType;
@@ -77,7 +83,7 @@ public abstract class StaticRouter(JsonUtil jsonUtil, IEnumerable<RouteAction> r
 
         info ??= new EmptyRequestData();
         TriggerOnBeforeAction(new StaticDynamicOnBeforeEventRequestData(url, info, sessionId, output));
-        var result = await action.action(url, info, sessionId, output);
+        var result = await action.action(url, info, sessionId, output, cancellationToken);
         TriggerOnAfterAction(new StaticDynamicOnAfterEventRequestData(url, info, sessionId, output, result));
         return result;
     }
@@ -90,7 +96,13 @@ public abstract class StaticRouter(JsonUtil jsonUtil, IEnumerable<RouteAction> r
 
 public abstract class DynamicRouter(JsonUtil jsonUtil, IEnumerable<RouteAction> routes) : Router
 {
-    public async ValueTask<object> HandleDynamic(string url, string? body, MongoId sessionId, string output)
+    public async ValueTask<object> HandleDynamic(
+        string url,
+        string? body,
+        MongoId sessionId,
+        string output,
+        CancellationToken cancellationToken = default
+    )
     {
         var action = routes.First(r => url.Contains(r.url));
         var type = action.bodyType;
@@ -102,7 +114,7 @@ public abstract class DynamicRouter(JsonUtil jsonUtil, IEnumerable<RouteAction> 
 
         info ??= new EmptyRequestData();
         TriggerOnBeforeAction(new StaticDynamicOnBeforeEventRequestData(url, info, sessionId, output));
-        var result = await action.action(url, info, sessionId, output);
+        var result = await action.action(url, info, sessionId, output, cancellationToken);
         TriggerOnAfterAction(new StaticDynamicOnAfterEventRequestData(url, info, sessionId, output, result));
         return result;
     }
@@ -179,8 +191,19 @@ public abstract class SaveLoadRouter : Router
 
 public record HandledRoute(string route, bool dynamic);
 
-public record RouteAction(string url, Func<string, IRequestData, MongoId, string?, ValueTask<object>> action, Type? bodyType = null);
+public record RouteAction(
+    string url,
+    Func<string, IRequestData, MongoId, string?, CancellationToken, ValueTask<object>> action,
+    Type? bodyType = null
+);
 
-public record RouteAction<TRequest>(string url, Func<string, TRequest, MongoId, string?, ValueTask<string>> typedAction)
-    : RouteAction(url, async (url, info, sessionId, output) => await typedAction(url, (TRequest)info, sessionId, output), typeof(TRequest))
+public record RouteAction<TRequest>(string url, Func<string, TRequest, MongoId, string?, CancellationToken, ValueTask<string>> typedAction)
+    : RouteAction(
+        url,
+        async (url, info, sessionId, output, cancellationToken) =>
+        {
+            return await typedAction(url, (TRequest)info, sessionId, output, cancellationToken);
+        },
+        typeof(TRequest)
+    )
     where TRequest : class, IRequestData;

--- a/Libraries/SPTarkov.Server.Core/DI/Router.cs
+++ b/Libraries/SPTarkov.Server.Core/DI/Router.cs
@@ -191,12 +191,43 @@ public abstract class SaveLoadRouter : Router
 
 public record HandledRoute(string route, bool dynamic);
 
+/// <summary>
+/// Describes a route and the action that should be executed when the route is invoked.
+/// </summary>
+/// <param name="url">
+/// The route URL or route pattern associated with the action.
+/// </param>
+/// <param name="action">
+/// The action to execute for the route.
+/// The parameters are, in order: the route URL, the request data, the session ID,
+/// an optional output value, and a cancellation token sourced from
+/// <c>HttpContext.RequestAborted</c>.
+/// </param>
+/// <param name="bodyType">
+/// The expected request body type for the route, or <see langword="null"/> when
+/// the route does not declare a specific body type.
+/// </param>
 public record RouteAction(
     string url,
     Func<string, IRequestData, MongoId, string?, CancellationToken, ValueTask<object>> action,
     Type? bodyType = null
 );
 
+/// <summary>
+/// Describes a route and a strongly typed action that should be executed when the route is invoked.
+/// </summary>
+/// <typeparam name="TRequest">
+/// The strongly typed request body type expected by the route.
+/// </typeparam>
+/// <param name="url">
+/// The route URL or route pattern associated with the action.
+/// </param>
+/// <param name="typedAction">
+/// The strongly typed action to execute for the route.
+/// The parameters are, in order: the route URL, the typed request data, the session ID,
+/// an optional output value, and a cancellation token sourced from
+/// <c>HttpContext.RequestAborted</c>.
+/// </param>
 public record RouteAction<TRequest>(string url, Func<string, TRequest, MongoId, string?, CancellationToken, ValueTask<string>> typedAction)
     : RouteAction(
         url,

--- a/Libraries/SPTarkov.Server.Core/Loaders/BundleLoader.cs
+++ b/Libraries/SPTarkov.Server.Core/Loaders/BundleLoader.cs
@@ -15,13 +15,14 @@ public sealed class BundleLoader(ISptLogger<BundleLoader> logger, JsonUtil jsonU
 {
     private readonly ConcurrentDictionary<string, BundleInfo> _bundles = [];
 
-    public async Task LoadBundlesAsync(SptMod mod)
+    public async Task LoadBundlesAsync(SptMod mod, CancellationToken cancellationToken = default)
     {
-        await bundleHashCacheService.HydrateCache();
+        await bundleHashCacheService.HydrateCacheAsync(cancellationToken);
 
         var modPath = mod.GetModPath();
         var modBundles = await jsonUtil.DeserializeFromFileAsync<BundleManifest>(
-            Path.Join(Directory.GetCurrentDirectory(), modPath, "bundles.json")
+            Path.Join(Directory.GetCurrentDirectory(), modPath, "bundles.json"),
+            cancellationToken
         );
 
         var relativeModPath = modPath.Replace('\\', '/');
@@ -69,7 +70,7 @@ public sealed class BundleLoader(ISptLogger<BundleLoader> logger, JsonUtil jsonU
                         }
                         else
                         {
-                            var bundleHash = await bundleHashCacheService.CalculateMatchAndStoreHash(bundleLocalPath);
+                            var bundleHash = await bundleHashCacheService.CalculateMatchAndStoreHashAsync(bundleLocalPath, ct);
                             AddBundle(
                                 bundleManifest.Key,
                                 new BundleInfo
@@ -88,11 +89,11 @@ public sealed class BundleLoader(ISptLogger<BundleLoader> logger, JsonUtil jsonU
                 );
             });
 
-        await bundleHashCacheService.WriteCache();
+        await bundleHashCacheService.WriteCacheAsync(cancellationToken);
     }
 
     /// <summary>
-    ///     Handle singleplayer/bundles
+    ///     HandleAsync singleplayer/bundles
     /// </summary>
     /// <returns> List of loaded bundles.</returns>
     public List<BundleInfo> GetBundles()

--- a/Libraries/SPTarkov.Server.Core/Loaders/ConfigLoader.cs
+++ b/Libraries/SPTarkov.Server.Core/Loaders/ConfigLoader.cs
@@ -76,7 +76,7 @@ public static class ConfigLoader
                 {
                     await using FileStream fs = new(file, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
-                    deserializedContent = await JsonSerializer.DeserializeAsync(fs, configType, options: options);
+                    deserializedContent = await JsonSerializer.DeserializeAsync(fs, configType, options);
                 }
             }
             catch (JsonException)

--- a/Libraries/SPTarkov.Server.Core/Loaders/PreSptModLoad.cs
+++ b/Libraries/SPTarkov.Server.Core/Loaders/PreSptModLoad.cs
@@ -9,14 +9,14 @@ namespace SPTarkov.Server.Core.Loaders;
 [Injectable(InjectionType.Singleton, TypePriority = OnLoadOrder.PreSptModLoader)]
 public sealed class PreSptModLoader(ISptLogger<PreSptModLoader> logger, IEnumerable<IPreSptLoadModAsync> preSptLoadMods) : IOnLoad
 {
-    public async Task OnLoad(CancellationToken stoppingToken)
+    public async Task OnLoad(CancellationToken cancellationToken)
     {
         if (ProgramStatics.MODS())
         {
             logger.Info("Loading PreSptMods...");
             foreach (var postSptLoadMod in preSptLoadMods)
             {
-                await postSptLoadMod.PreSptLoadAsync(stoppingToken);
+                await postSptLoadMod.PreSptLoadAsync(cancellationToken);
             }
 
             logger.Info("Finished loading PreSptMods...");

--- a/Libraries/SPTarkov.Server.Core/Models/External/IPreSptLoadModAsync.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/External/IPreSptLoadModAsync.cs
@@ -5,5 +5,5 @@
 /// </summary>
 public interface IPreSptLoadModAsync
 {
-    Task PreSptLoadAsync(CancellationToken stoppingToken);
+    Task PreSptLoadAsync(CancellationToken cancellationToken);
 }

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BotDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BotDynamicRouter.cs
@@ -13,23 +13,23 @@ public class BotDynamicRouter(JsonUtil jsonUtil, BotCallbacks botCallbacks)
         [
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/settings/bot/limit/",
-                async (url, info, sessionID, output) => await botCallbacks.GetBotLimit(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await botCallbacks.GetBotLimit(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/settings/bot/difficulty/",
-                async (url, info, sessionID, output) => await botCallbacks.GetBotDifficulty(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await botCallbacks.GetBotDifficulty(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/settings/bot/difficulties",
-                async (url, info, sessionID, output) => await botCallbacks.GetAllBotDifficulties(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await botCallbacks.GetAllBotDifficulties(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/settings/bot/maxCap",
-                async (url, info, sessionID, output) => await botCallbacks.GetBotCap(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await botCallbacks.GetBotCap(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/settings/bot/getBotBehaviours/",
-                async (url, info, sessionID, output) => await botCallbacks.GetBotBehaviours()
+                async (url, info, sessionID, output, cancellationToken) => await botCallbacks.GetBotBehaviours()
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BundleDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/BundleDynamicRouter.cs
@@ -13,7 +13,7 @@ public class BundleDynamicRouter(JsonUtil jsonUtil, BundleCallbacks bundleCallba
         [
             new RouteAction<EmptyRequestData>(
                 "/files/bundle",
-                async (url, info, sessionID, output) => await bundleCallbacks.GetBundle(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await bundleCallbacks.GetBundle(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/CustomizationDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/CustomizationDynamicRouter.cs
@@ -13,7 +13,7 @@ public class CustomizationDynamicRouter(JsonUtil jsonUtil, CustomizationCallback
         [
             new RouteAction<EmptyRequestData>(
                 "/client/trading/customization/",
-                async (url, info, sessionID, output) => await customizationCallbacks.GetTraderSuits(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await customizationCallbacks.GetTraderSuits(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/DataDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/DataDynamicRouter.cs
@@ -13,15 +13,15 @@ public class DataDynamicRouter(JsonUtil jsonUtil, DataCallbacks dataCallbacks)
         [
             new RouteAction<EmptyRequestData>(
                 "/client/menu/locale/",
-                async (url, info, sessionID, output) => await dataCallbacks.GetLocalesMenu(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetLocalesMenu(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/locale/",
-                async (url, info, sessionID, output) => await dataCallbacks.GetLocalesGlobal(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetLocalesGlobal(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/items/prices/",
-                async (url, info, sessionID, output) => await dataCallbacks.GetItemPrices(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetItemPrices(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/InraidDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/InraidDynamicRouter.cs
@@ -13,7 +13,7 @@ public class InraidDynamicRouter(JsonUtil jsonUtil, InraidCallbacks inraidCallba
         [
             new RouteAction<RegisterPlayerRequestData>(
                 "/client/location/getLocalloot",
-                async (url, info, sessionID, output) => await inraidCallbacks.RegisterPlayer(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await inraidCallbacks.RegisterPlayer(url, info, sessionID)
             ),
         ]
     )

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/NotifierDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/NotifierDynamicRouter.cs
@@ -13,19 +13,19 @@ public class NotifierDynamicRouter(JsonUtil jsonUtil, NotifierCallbacks notifier
         [
             new RouteAction<EmptyRequestData>(
                 "/?last_id",
-                async (url, info, sessionID, _) => await notifierCallbacks.Notify(url, info, sessionID)
+                async (url, info, sessionID, _, cancellationToken) => await notifierCallbacks.Notify(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/notifierServer",
-                async (url, info, sessionID, _) => await notifierCallbacks.Notify(url, info, sessionID)
+                async (url, info, sessionID, _, cancellationToken) => await notifierCallbacks.Notify(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/push/notifier/get/",
-                async (url, info, sessionID, _) => await notifierCallbacks.GetNotifier(url, info, sessionID)
+                async (url, info, sessionID, _, cancellationToken) => await notifierCallbacks.GetNotifier(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/push/notifier/get/",
-                async (url, info, sessionID, _) => await notifierCallbacks.GetNotifier(url, info, sessionID)
+                async (url, info, sessionID, _, cancellationToken) => await notifierCallbacks.GetNotifier(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Dynamic/TraderDynamicRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Dynamic/TraderDynamicRouter.cs
@@ -13,11 +13,11 @@ public class TraderDynamicRouter(JsonUtil jsonUtil, TraderCallbacks traderCallba
         [
             new RouteAction<EmptyRequestData>(
                 "/client/trading/api/getTrader/",
-                async (url, info, sessionID, output) => await traderCallbacks.GetTrader(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await traderCallbacks.GetTrader(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/trading/api/getTraderAssort/",
-                async (url, info, sessionID, output) => await traderCallbacks.GetAssort(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await traderCallbacks.GetAssort(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/HttpRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/HttpRouter.cs
@@ -14,25 +14,31 @@ public class HttpRouter(IEnumerable<StaticRouter> staticRouters, IEnumerable<Dyn
             || dynamicRoutes.Any(dr => dr.CanHandle(context.Request.Path.Value, true));
     }
 
-    public async ValueTask<string?> GetResponse(HttpRequest req, MongoId sessionID, string? body)
+    public async ValueTask<string?> GetResponseAsync(
+        HttpRequest req,
+        MongoId sessionID,
+        string? body,
+        CancellationToken cancellationToken = default
+    )
     {
         var wrapper = new ResponseWrapper("");
-        var handled = await HandleRoute(req, sessionID, wrapper, staticRouters, false, body);
+        var handled = await HandleRouteAsync(req, sessionID, wrapper, staticRouters, false, body, cancellationToken);
         if (!handled)
         {
-            await HandleRoute(req, sessionID, wrapper, dynamicRoutes, true, body);
+            await HandleRouteAsync(req, sessionID, wrapper, dynamicRoutes, true, body, cancellationToken);
         }
 
         return wrapper.Output;
     }
 
-    protected async ValueTask<bool> HandleRoute(
+    protected async ValueTask<bool> HandleRouteAsync(
         HttpRequest request,
         MongoId sessionID,
         ResponseWrapper wrapper,
         IEnumerable<Router> routers,
         bool dynamic,
-        string? body
+        string? body,
+        CancellationToken cancellationToken = default
     )
     {
         var url = request.Path.Value;
@@ -54,7 +60,7 @@ public class HttpRouter(IEnumerable<StaticRouter> staticRouters, IEnumerable<Dyn
                 }
                 else
                 {
-                    wrapper.Output = await (route as StaticRouter).HandleStatic(url, body, sessionID, wrapper.Output) as string;
+                    wrapper.Output = await (route as StaticRouter).HandleStaticAsync(url, body, sessionID, wrapper.Output) as string;
                 }
 
                 matched = true;

--- a/Libraries/SPTarkov.Server.Core/Routers/HttpRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/HttpRouter.cs
@@ -56,11 +56,14 @@ public class HttpRouter(IEnumerable<StaticRouter> staticRouters, IEnumerable<Dyn
             {
                 if (dynamic)
                 {
-                    wrapper.Output = await (route as DynamicRouter).HandleDynamic(url, body, sessionID, wrapper.Output) as string;
+                    wrapper.Output =
+                        await (route as DynamicRouter).HandleDynamicAsync(url, body, sessionID, wrapper.Output, cancellationToken)
+                        as string;
                 }
                 else
                 {
-                    wrapper.Output = await (route as StaticRouter).HandleStaticAsync(url, body, sessionID, wrapper.Output) as string;
+                    wrapper.Output =
+                        await (route as StaticRouter).HandleStaticAsync(url, body, sessionID, wrapper.Output, cancellationToken) as string;
                 }
 
                 matched = true;

--- a/Libraries/SPTarkov.Server.Core/Routers/ImageRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/ImageRouter.cs
@@ -34,7 +34,7 @@ public class ImageRouter(
         return false;
     }
 
-    public async Task Handle(MongoId sessionId, HttpContext context)
+    public async Task HandleAsync(MongoId sessionId, HttpContext context, CancellationToken cancellationToken = default)
     {
         // remove file extension
         var url = fileUtil.StripExtension(context.Request.Path, true);
@@ -43,7 +43,7 @@ public class ImageRouter(
         var urlKeyLower = url.ToLowerInvariant();
         if (imageRouterService.ExistsByKey(urlKeyLower))
         {
-            await httpFileUtil.SendFile(context.Response, imageRouterService.GetByKey(urlKeyLower));
+            await httpFileUtil.SendFileAsync(context.Response, imageRouterService.GetByKey(urlKeyLower), cancellationToken);
             return;
         }
     }

--- a/Libraries/SPTarkov.Server.Core/Routers/Serializers/BundleSerializer.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Serializers/BundleSerializer.cs
@@ -11,7 +11,13 @@ namespace SPTarkov.Server.Core.Routers.Serializers;
 [Injectable]
 public class BundleSerializer(ISptLogger<BundleSerializer> logger, BundleLoader bundleLoader, HttpFileUtil httpFileUtil) : ISerializer
 {
-    public async Task Serialize(MongoId sessionID, HttpRequest req, HttpResponse resp, object? body)
+    public async Task SerializeAsync(
+        MongoId sessionID,
+        HttpRequest req,
+        HttpResponse resp,
+        object? body,
+        CancellationToken cancellationToken = default
+    )
     {
         var key = req.Path.Value.Split("/bundle/")[1];
         var bundle = bundleLoader.GetBundle(key);
@@ -28,7 +34,7 @@ public class BundleSerializer(ISptLogger<BundleSerializer> logger, BundleLoader 
         }
 
         var bundlePath = Path.Join(bundle.ModPath, "/bundles/", bundle.FileName);
-        await httpFileUtil.SendFile(resp, bundlePath);
+        await httpFileUtil.SendFileAsync(resp, bundlePath, cancellationToken);
     }
 
     public bool CanHandle(string route)

--- a/Libraries/SPTarkov.Server.Core/Routers/Serializers/NotifySerializer.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Serializers/NotifySerializer.cs
@@ -11,7 +11,13 @@ namespace SPTarkov.Server.Core.Routers.Serializers;
 [Injectable]
 public class NotifySerializer(NotifierController notifierController, JsonUtil jsonUtil, HttpServerHelper httpServerHelper) : ISerializer
 {
-    public async Task Serialize(MongoId sessionID, HttpRequest req, HttpResponse resp, object? body)
+    public async Task SerializeAsync(
+        MongoId sessionID,
+        HttpRequest req,
+        HttpResponse resp,
+        object? body,
+        CancellationToken cancellationToken = default
+    )
     {
         var splittedUrl = req.Path.Value.Split("/");
         var tmpSessionID = splittedUrl[^1].Split("?last_id")[0];
@@ -21,9 +27,9 @@ public class NotifySerializer(NotifierController notifierController, JsonUtil js
          *  be sent to client as NEWLINE separated strings... yup.
          */
         await notifierController
-            .NotifyAsync(tmpSessionID)
+            .NotifyAsync(tmpSessionID, cancellationToken)
             .ContinueWith(messages => messages.Result.Select(message => string.Join("\n", jsonUtil.Serialize(message))))
-            .ContinueWith(text => httpServerHelper.SendTextJson(resp, text));
+            .ContinueWith(text => httpServerHelper.SendTextJson(resp, text), cancellationToken);
     }
 
     public bool CanHandle(string route)

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/AchievementStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/AchievementStaticRouter.cs
@@ -14,11 +14,11 @@ public class AchievementStaticRouter(JsonUtil jsonUtil, AchievementCallbacks ach
         [
             new RouteAction<GetAchievementListRequest>(
                 "/client/achievement/list",
-                async (url, info, sessionID, output) => await achievementCallbacks.GetAchievements(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await achievementCallbacks.GetAchievements(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/achievement/statistic",
-                async (url, info, sessionID, output) => await achievementCallbacks.Statistic(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await achievementCallbacks.Statistic(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/BotStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/BotStaticRouter.cs
@@ -13,7 +13,7 @@ public class BotStaticRouter(JsonUtil jsonUtil, BotCallbacks botCallbacks)
         [
             new RouteAction<GenerateBotsRequestData>(
                 "/client/game/bot/generate",
-                async (url, info, sessionID, outout) => await botCallbacks.GenerateBots(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await botCallbacks.GenerateBots(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/BuildStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/BuildStaticRouter.cs
@@ -15,23 +15,24 @@ public class BuildStaticRouter(JsonUtil jsonUtil, BuildsCallbacks buildsCallback
         [
             new RouteAction<EmptyRequestData>(
                 "/client/builds/list",
-                async (url, info, sessionID, output) => await buildsCallbacks.GetBuilds(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await buildsCallbacks.GetBuilds(url, info, sessionID)
             ),
             new RouteAction<SetMagazineRequest>(
                 "/client/builds/magazine/save",
-                async (url, info, sessionID, output) => await buildsCallbacks.CreateMagazineTemplate(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await buildsCallbacks.CreateMagazineTemplate(url, info, sessionID)
             ),
             new RouteAction<PresetBuildActionRequestData>(
                 "/client/builds/weapon/save",
-                async (url, info, sessionID, output) => await buildsCallbacks.SetWeapon(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await buildsCallbacks.SetWeapon(url, info, sessionID)
             ),
             new RouteAction<PresetBuildActionRequestData>(
                 "/client/builds/equipment/save",
-                async (url, info, sessionID, output) => await buildsCallbacks.SetEquipment(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await buildsCallbacks.SetEquipment(url, info, sessionID)
             ),
             new RouteAction<RemoveBuildRequestData>(
                 "/client/builds/delete",
-                async (url, info, sessionID, output) => await buildsCallbacks.DeleteBuild(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await buildsCallbacks.DeleteBuild(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/BundleStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/BundleStaticRouter.cs
@@ -13,7 +13,7 @@ public class BundleStaticRouter(JsonUtil jsonUtil, BundleCallbacks bundleCallbac
         [
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/bundles",
-                async (url, info, sessionID, output) => await bundleCallbacks.GetBundles(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await bundleCallbacks.GetBundles(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/ClientLogStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/ClientLogStaticRouter.cs
@@ -14,15 +14,15 @@ public class ClientLogStaticRouter(JsonUtil jsonUtil, ClientLogCallbacks clientL
         [
             new RouteAction<ClientLogRequest>(
                 "/singleplayer/log",
-                async (url, info, sessionID, output) => await clientLogCallbacks.ClientLog(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await clientLogCallbacks.ClientLog(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/release",
-                async (url, info, sessionID, output) => await clientLogCallbacks.ReleaseNotes()
+                async (url, info, sessionID, output, cancellationToken) => await clientLogCallbacks.ReleaseNotes()
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/enableBSGlogging",
-                async (url, info, sessionID, output) => await clientLogCallbacks.BsgLogging()
+                async (url, info, sessionID, output, cancellationToken) => await clientLogCallbacks.BsgLogging()
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/CustomizationStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/CustomizationStaticRouter.cs
@@ -13,15 +13,17 @@ public class CustomizationStaticRouter(JsonUtil jsonUtil, CustomizationCallbacks
         [
             new RouteAction<EmptyRequestData>(
                 "/client/trading/customization/storage",
-                async (url, info, sessionID, output) => await customizationCallbacks.GetCustomisationUnlocks(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await customizationCallbacks.GetCustomisationUnlocks(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/hideout/customization/offer/list",
-                async (url, info, sessionID, output) => await customizationCallbacks.GetHideoutCustomisation(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await customizationCallbacks.GetHideoutCustomisation(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/customization/storage",
-                async (url, info, sessionID, output) => await customizationCallbacks.GetStorage(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await customizationCallbacks.GetStorage(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/DataStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/DataStaticRouter.cs
@@ -14,51 +14,51 @@ public class DataStaticRouter(JsonUtil jsonUtil, DataCallbacks dataCallbacks)
         [
             new RouteAction<EmptyRequestData>(
                 "/client/settings",
-                async (url, info, sessionID, output) => await dataCallbacks.GetSettings(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetSettings(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/globals",
-                async (url, info, sessionID, output) => await dataCallbacks.GetGlobals(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetGlobals(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/items",
-                async (url, info, sessionID, output) => await dataCallbacks.GetTemplateItems(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetTemplateItems(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/handbook/templates",
-                async (url, info, sessionID, output) => await dataCallbacks.GetTemplateHandbook(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetTemplateHandbook(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/customization",
-                async (url, info, sessionID, output) => await dataCallbacks.GetTemplateSuits(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetTemplateSuits(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/account/customization",
-                async (url, info, sessionID, output) => await dataCallbacks.GetTemplateCharacter(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetTemplateCharacter(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/hideout/production/recipes",
-                async (url, info, sessionID, output) => await dataCallbacks.GetHideoutProduction(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetHideoutProduction(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/hideout/settings",
-                async (url, info, sessionID, output) => await dataCallbacks.GetHideoutSettings(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetHideoutSettings(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/hideout/areas",
-                async (url, info, sessionID, output) => await dataCallbacks.GetHideoutAreas(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetHideoutAreas(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/languages",
-                async (url, info, sessionID, output) => await dataCallbacks.GetLocalesLanguages(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetLocalesLanguages(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/hideout/qte/list",
-                async (url, info, sessionID, output) => await dataCallbacks.GetQteList(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetQteList(url, info, sessionID)
             ),
             new RouteAction<GetClientDialogueRequestData>(
                 "/client/dialogue",
-                async (url, info, sessionID, output) => await dataCallbacks.GetDialogue(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dataCallbacks.GetDialogue(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/DialogStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/DialogStaticRouter.cs
@@ -15,107 +15,110 @@ public class DialogStaticRouter(JsonUtil jsonUtil, DialogueCallbacks dialogueCal
         [
             new RouteAction<GetChatServerListRequestData>(
                 "/client/chatServer/list",
-                async (url, info, sessionID, output) => await dialogueCallbacks.GetChatServerList(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.GetChatServerList(url, info, sessionID)
             ),
             new RouteAction<GetMailDialogListRequestData>(
                 "/client/mail/dialog/list",
-                async (url, info, sessionID, output) => await dialogueCallbacks.GetMailDialogList(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.GetMailDialogList(url, info, sessionID)
             ),
             new RouteAction<GetMailDialogViewRequestData>(
                 "/client/mail/dialog/view",
-                async (url, info, sessionID, output) => await dialogueCallbacks.GetMailDialogView(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.GetMailDialogView(url, info, sessionID)
             ),
             new RouteAction<GetMailDialogInfoRequestData>(
                 "/client/mail/dialog/info",
-                async (url, info, sessionID, output) => await dialogueCallbacks.GetMailDialogInfo(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.GetMailDialogInfo(url, info, sessionID)
             ),
             new RouteAction<RemoveDialogRequestData>(
                 "/client/mail/dialog/remove",
-                async (url, info, sessionID, output) => await dialogueCallbacks.RemoveDialog(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.RemoveDialog(url, info, sessionID)
             ),
             new RouteAction<PinDialogRequestData>(
                 "/client/mail/dialog/pin",
-                async (url, info, sessionID, output) => await dialogueCallbacks.PinDialog(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.PinDialog(url, info, sessionID)
             ),
             new RouteAction<PinDialogRequestData>(
                 "/client/mail/dialog/unpin",
-                async (url, info, sessionID, output) => await dialogueCallbacks.UnpinDialog(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.UnpinDialog(url, info, sessionID)
             ),
             new RouteAction<SetDialogReadRequestData>(
                 "/client/mail/dialog/read",
-                async (url, info, sessionID, output) => await dialogueCallbacks.SetRead(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.SetRead(url, info, sessionID)
             ),
             new RouteAction<GetAllAttachmentsRequestData>(
                 "/client/mail/dialog/getAllAttachments",
-                async (url, info, sessionID, output) => await dialogueCallbacks.GetAllAttachments(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.GetAllAttachments(url, info, sessionID)
             ),
             new RouteAction<SendMessageRequest>(
                 "/client/mail/msg/send",
-                async (url, info, sessionID, output) => await dialogueCallbacks.SendMessage(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.SendMessage(url, info, sessionID)
             ),
             new RouteAction<ClearMailMessageRequest>(
                 "/client/mail/dialog/clear",
-                async (url, info, sessionID, output) => await dialogueCallbacks.ClearMail(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.ClearMail(url, info, sessionID)
             ),
             new RouteAction<CreateGroupMailRequest>(
                 "/client/mail/dialog/group/create",
-                async (url, info, sessionID, output) => await dialogueCallbacks.CreateGroupMail(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.CreateGroupMail(url, info, sessionID)
             ),
             new RouteAction<ChangeGroupMailOwnerRequest>(
                 "/client/mail/dialog/group/owner/change",
-                async (url, info, sessionID, output) => await dialogueCallbacks.ChangeMailGroupOwner(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await dialogueCallbacks.ChangeMailGroupOwner(url, info, sessionID)
             ),
             new RouteAction<AddUserGroupMailRequest>(
                 "/client/mail/dialog/group/users/add",
-                async (url, info, sessionID, output) => await dialogueCallbacks.AddUserToMail(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.AddUserToMail(url, info, sessionID)
             ),
             new RouteAction<RemoveUserGroupMailRequest>(
                 "/client/mail/dialog/group/users/remove",
-                async (url, info, sessionID, output) => await dialogueCallbacks.RemoveUserFromMail(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.RemoveUserFromMail(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/friend/list",
-                async (url, info, sessionID, output) => await dialogueCallbacks.GetFriendList(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.GetFriendList(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/friend/request/list/outbox",
-                async (url, info, sessionID, output) => await dialogueCallbacks.ListOutbox(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.ListOutbox(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/friend/request/list/inbox",
-                async (url, info, sessionID, output) => await dialogueCallbacks.ListInbox(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.ListInbox(url, info, sessionID)
             ),
             new RouteAction<FriendRequestData>(
                 "/client/friend/request/send",
-                async (url, info, sessionID, output) => await dialogueCallbacks.SendFriendRequest(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.SendFriendRequest(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/friend/request/accept-all",
-                async (url, info, sessionID, output) => await dialogueCallbacks.AcceptAllFriendRequests(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await dialogueCallbacks.AcceptAllFriendRequests(url, info, sessionID)
             ),
             new RouteAction<AcceptFriendRequestData>(
                 "/client/friend/request/accept",
-                async (url, info, sessionID, output) => await dialogueCallbacks.AcceptFriendRequest(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.AcceptFriendRequest(url, info, sessionID)
             ),
             new RouteAction<DeclineFriendRequestData>(
                 "/client/friend/request/decline",
-                async (url, info, sessionID, output) => await dialogueCallbacks.DeclineFriendRequest(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await dialogueCallbacks.DeclineFriendRequest(url, info, sessionID)
             ),
             new RouteAction<CancelFriendRequestData>(
                 "/client/friend/request/cancel",
-                async (url, info, sessionID, output) => await dialogueCallbacks.CancelFriendRequest(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.CancelFriendRequest(url, info, sessionID)
             ),
             new RouteAction<DeleteFriendRequest>(
                 "/client/friend/delete",
-                async (url, info, sessionID, output) => await dialogueCallbacks.DeleteFriend(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.DeleteFriend(url, info, sessionID)
             ),
             new RouteAction<UIDRequestData>(
                 "/client/friend/ignore/set",
-                async (url, info, sessionID, output) => await dialogueCallbacks.IgnoreFriend(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.IgnoreFriend(url, info, sessionID)
             ),
             new RouteAction<UIDRequestData>(
                 "/client/friend/ignore/remove",
-                async (url, info, sessionID, output) => await dialogueCallbacks.UnIgnoreFriend(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await dialogueCallbacks.UnIgnoreFriend(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/GameStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/GameStaticRouter.cs
@@ -15,75 +15,75 @@ public class GameStaticRouter(JsonUtil jsonUtil, GameCallbacks gameCallbacks)
         [
             new RouteAction<EmptyRequestData>(
                 "/client/game/config",
-                async (url, info, sessionID, output) => await gameCallbacks.GetGameConfig(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetGameConfig(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/putHWMetrics",
-                async (url, info, sessionID, output) => await gameCallbacks.PutHwMetrics(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.PutHwMetrics(url, info, sessionID)
             ),
             new RouteAction<GameModeRequestData>(
                 "/client/game/mode",
-                async (url, info, sessionID, output) => await gameCallbacks.GetGameMode(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetGameMode(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/server/list",
-                async (url, info, sessionID, output) => await gameCallbacks.GetServer(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetServer(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/current",
-                async (url, info, sessionID, output) => await gameCallbacks.GetCurrentGroup(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetCurrentGroup(url, info, sessionID)
             ),
             new RouteAction<VersionValidateRequestData>(
                 "/client/game/version/validate",
-                async (url, info, sessionID, output) => await gameCallbacks.VersionValidate(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.VersionValidate(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/game/start",
-                async (url, info, sessionID, output) => await gameCallbacks.GameStart(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GameStart(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/game/logout",
-                async (url, info, sessionID, output) => await gameCallbacks.GameLogout(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GameLogout(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/checkVersion",
-                async (url, info, sessionID, output) => await gameCallbacks.ValidateGameVersion(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.ValidateGameVersion(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/game/keepalive",
-                async (url, info, sessionID, output) => await gameCallbacks.GameKeepalive(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GameKeepalive(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/settings/version",
-                async (url, info, sessionID, output) => await gameCallbacks.GetVersion(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetVersion(url, info, sessionID)
             ),
             new RouteAction<UIDRequestData>(
                 "/client/reports/lobby/send",
-                async (url, info, sessionID, output) => await gameCallbacks.ReportNickname(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.ReportNickname(url, info, sessionID)
             ),
             new RouteAction<UIDRequestData>(
                 "/client/report/send",
-                async (url, info, sessionID, output) => await gameCallbacks.ReportNickname(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.ReportNickname(url, info, sessionID)
             ),
             new RouteAction<GetRaidTimeRequest>(
                 "/singleplayer/settings/getRaidTime",
-                async (url, info, sessionID, output) => await gameCallbacks.GetRaidTime(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetRaidTime(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/survey",
-                async (url, info, sessionID, output) => await gameCallbacks.GetSurvey(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetSurvey(url, info, sessionID)
             ),
             new RouteAction<SendSurveyOpinionRequest>(
                 "/client/survey/view",
-                async (url, info, sessionID, output) => await gameCallbacks.GetSurveyView(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.GetSurveyView(url, info, sessionID)
             ),
             new RouteAction<SendSurveyOpinionRequest>(
                 "/client/survey/opinion",
-                async (url, info, sessionID, output) => await gameCallbacks.SendSurveyOpinion(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.SendSurveyOpinion(url, info, sessionID)
             ),
             new RouteAction<SendClientModsRequest>(
                 "/singleplayer/clientmods",
-                async (url, info, sessionID, output) => await gameCallbacks.ReceiveClientMods(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await gameCallbacks.ReceiveClientMods(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/HealthStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/HealthStaticRouter.cs
@@ -13,7 +13,7 @@ public class HealthStaticRouter(JsonUtil jsonUtil, HealthCallbacks healthCallbac
         [
             new RouteAction<WorkoutData>(
                 "/client/hideout/workout",
-                async (url, info, sessionID, output) => await healthCallbacks.HandleWorkoutEffects(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await healthCallbacks.HandleWorkoutEffects(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/InraidStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/InraidStaticRouter.cs
@@ -14,19 +14,20 @@ public class InraidStaticRouter(InraidCallbacks inRaidCallbacks, JsonUtil jsonUt
         [
             new RouteAction<ScavSaveRequestData>(
                 "/raid/profile/scavsave",
-                async (url, info, sessionID, output) => await inRaidCallbacks.SaveProgress(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await inRaidCallbacks.SaveProgress(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/settings/raid/menu",
-                async (url, info, sessionID, output) => await inRaidCallbacks.GetRaidMenuSettings()
+                async (url, info, sessionID, output, cancellationToken) => await inRaidCallbacks.GetRaidMenuSettings()
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/scav/traitorscavhostile",
-                async (url, info, sessionID, output) => await inRaidCallbacks.GetTraitorScavHostileChance(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await inRaidCallbacks.GetTraitorScavHostileChance(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/bosstypes",
-                async (url, info, sessionID, output) => await inRaidCallbacks.GetBossTypes(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await inRaidCallbacks.GetBossTypes(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/InsuranceStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/InsuranceStaticRouter.cs
@@ -13,7 +13,7 @@ public class InsuranceStaticRouter(JsonUtil jsonUtil, InsuranceCallbacks insuran
         [
             new RouteAction<GetInsuranceCostRequestData>(
                 "/client/insurance/items/list/cost",
-                async (url, info, sessionID, output) => await insuranceCallbacks.GetInsuranceCost(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await insuranceCallbacks.GetInsuranceCost(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/ItemEventStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/ItemEventStaticRouter.cs
@@ -13,7 +13,7 @@ public class ItemEventStaticRouter(JsonUtil jsonUtil, ItemEventCallbacks itemEve
         [
             new RouteAction<ItemEventRouterRequest>(
                 "/client/game/profile/items/moving",
-                async (url, info, sessionID, output) => await itemEventCallbacks.HandleEvents(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await itemEventCallbacks.HandleEvents(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherStaticRouter.cs
@@ -14,45 +14,48 @@ public class LauncherStaticRouter(LauncherCallbacks launcherCallbacks, JsonUtil 
         [
             new RouteAction<EmptyRequestData>(
                 "/launcher/ping",
-                async (url, info, sessionID, _) => await launcherCallbacks.Ping(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.Ping(url, info, sessionID)
             ),
-            new RouteAction<EmptyRequestData>("/launcher/server/connect", async (_, _, _, _) => await launcherCallbacks.Connect()),
+            new RouteAction<EmptyRequestData>("/launcher/server/connect", async (_, _, _, _, _) => await launcherCallbacks.Connect()),
             new RouteAction<LoginRequestData>(
                 "/launcher/profile/login",
-                async (url, info, sessionID, _) => await launcherCallbacks.Login(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.Login(url, info, sessionID)
             ),
             new RouteAction<RegisterData>(
                 "/launcher/profile/register",
-                async (url, info, sessionID, _) => await launcherCallbacks.Register(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.Register(url, info, sessionID)
             ),
             new RouteAction<LoginRequestData>(
                 "/launcher/profile/get",
-                async (url, info, sessionID, _) => await launcherCallbacks.Get(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.Get(url, info, sessionID)
             ),
             new RouteAction<ChangeRequestData>(
                 "/launcher/profile/change/username",
-                async (url, info, sessionID, _) => await launcherCallbacks.ChangeUsername(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.ChangeUsername(url, info, sessionID)
             ),
             new RouteAction<RegisterData>(
                 "/launcher/profile/change/wipe",
-                async (url, info, sessionID, _) => await launcherCallbacks.Wipe(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.Wipe(url, info, sessionID)
             ),
             new RouteAction<RemoveProfileData>(
                 "/launcher/profile/remove",
-                async (url, info, sessionID, _) => await launcherCallbacks.RemoveProfile(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.RemoveProfile(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/launcher/profile/compatibleTarkovVersion",
-                async (_, _, _, _) => await launcherCallbacks.GetCompatibleTarkovVersion()
+                async (_, _, _, _, _) => await launcherCallbacks.GetCompatibleTarkovVersion()
             ),
-            new RouteAction<EmptyRequestData>("/launcher/server/version", async (_, _, _, _) => await launcherCallbacks.GetServerVersion()),
+            new RouteAction<EmptyRequestData>(
+                "/launcher/server/version",
+                async (_, _, _, _, _) => await launcherCallbacks.GetServerVersion()
+            ),
             new RouteAction<EmptyRequestData>(
                 "/launcher/server/loadedServerMods",
-                async (_, _, _, _) => await launcherCallbacks.GetLoadedServerMods()
+                async (_, _, _, _, _) => await launcherCallbacks.GetLoadedServerMods()
             ),
             new RouteAction<EmptyRequestData>(
                 "/launcher/server/serverModsUsedByProfile",
-                async (url, info, sessionID, _) => await launcherCallbacks.GetServerModsProfileUsed(url, info, sessionID)
+                async (url, info, sessionID, _, _) => await launcherCallbacks.GetServerModsProfileUsed(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherV2StaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/LauncherV2StaticRouter.cs
@@ -12,15 +12,18 @@ public class LauncherV2StaticRouter(LauncherV2Callbacks launcherV2Callbacks, Jso
     : StaticRouter(
         jsonUtil,
         [
-            new RouteAction<EmptyRequestData>("/launcher/v2/ping", async (_, _, _, _) => await launcherV2Callbacks.Ping()),
-            new RouteAction<EmptyRequestData>("/launcher/v2/types", async (_, _, _, _) => await launcherV2Callbacks.Types()),
-            new RouteAction<LoginRequestData>("/launcher/v2/login", async (_, info, _, _) => await launcherV2Callbacks.Login(info)),
-            new RouteAction<RegisterData>("/launcher/v2/register", async (_, info, _, _) => await launcherV2Callbacks.Register(info)),
-            new RouteAction<LoginRequestData>("/launcher/v2/remove", async (_, info, _, _) => await launcherV2Callbacks.Remove(info)),
-            new RouteAction<EmptyRequestData>("/launcher/v2/version", async (_, _, _, _) => await launcherV2Callbacks.CompatibleVersion()),
-            new RouteAction<EmptyRequestData>("/launcher/v2/mods", async (_, _, _, _) => await launcherV2Callbacks.Mods()),
-            new RouteAction<EmptyRequestData>("/launcher/v2/profiles", async (_, _, _, _) => await launcherV2Callbacks.Profiles()),
-            new RouteAction<LoginRequestData>("/launcher/v2/profile", async (_, info, _, _) => await launcherV2Callbacks.Profile(info)),
-            new RouteAction<RegisterData>("/launcher/v2/wipe", async (_, info, _, _) => await launcherV2Callbacks.Wipe(info)),
+            new RouteAction<EmptyRequestData>("/launcher/v2/ping", async (_, _, _, _, _) => await launcherV2Callbacks.Ping()),
+            new RouteAction<EmptyRequestData>("/launcher/v2/types", async (_, _, _, _, _) => await launcherV2Callbacks.Types()),
+            new RouteAction<LoginRequestData>("/launcher/v2/login", async (_, info, _, _, _) => await launcherV2Callbacks.Login(info)),
+            new RouteAction<RegisterData>("/launcher/v2/register", async (_, info, _, _, _) => await launcherV2Callbacks.Register(info)),
+            new RouteAction<LoginRequestData>("/launcher/v2/remove", async (_, info, _, _, _) => await launcherV2Callbacks.Remove(info)),
+            new RouteAction<EmptyRequestData>(
+                "/launcher/v2/version",
+                async (_, _, _, _, _) => await launcherV2Callbacks.CompatibleVersion()
+            ),
+            new RouteAction<EmptyRequestData>("/launcher/v2/mods", async (_, _, _, _, _) => await launcherV2Callbacks.Mods()),
+            new RouteAction<EmptyRequestData>("/launcher/v2/profiles", async (_, _, _, _, _) => await launcherV2Callbacks.Profiles()),
+            new RouteAction<LoginRequestData>("/launcher/v2/profile", async (_, info, _, _, _) => await launcherV2Callbacks.Profile(info)),
+            new RouteAction<RegisterData>("/launcher/v2/wipe", async (_, info, _, _, _) => await launcherV2Callbacks.Wipe(info)),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/LocationStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/LocationStaticRouter.cs
@@ -14,13 +14,13 @@ public class LocationStaticRouter(JsonUtil jsonUtil, LocationCallbacks locationC
         [
             new RouteAction<EmptyRequestData>(
                 "/client/locations",
-                async (url, info, sessionID, output) => await locationCallbacks.GetLocationData(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await locationCallbacks.GetLocationData(url, info, sessionID)
             ),
             // For this route it's necessary to not set a specific type for this route
             // As 'sometimes' this route can have the loot request and other times not.
             new RouteAction(
                 "/client/airdrop/loot",
-                async (url, info, sessionID, output) =>
+                async (url, info, sessionID, output, cancellationToken) =>
                     await locationCallbacks.GetAirdropLoot(url, info as GetAirdropLootRequest, sessionID)
             ),
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/MatchStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/MatchStaticRouter.cs
@@ -15,115 +15,116 @@ public class MatchStaticRouter(JsonUtil jsonUtil, MatchCallbacks matchCallbacks)
         [
             new RouteAction<EmptyRequestData>(
                 "/client/match/available",
-                async (url, info, sessionID, output) => await matchCallbacks.ServerAvailable(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.ServerAvailable(url, info, sessionID)
             ),
             new RouteAction<UpdatePingRequestData>(
                 "/client/match/updatePing",
-                async (url, info, sessionID, output) => await matchCallbacks.UpdatePing(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.UpdatePing(url, info, sessionID)
             ),
             new RouteAction<MatchGroupJoinRequest>(
                 "/client/match/join",
-                async (url, info, sessionID, output) => await matchCallbacks.JoinMatch(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.JoinMatch(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/exit",
-                async (url, info, sessionID, output) => await matchCallbacks.ExitMatch(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.ExitMatch(url, info, sessionID)
             ),
             new RouteAction<DeleteGroupRequest>(
                 "/client/match/group/delete",
-                async (url, info, sessionID, output) => await matchCallbacks.DeleteGroup(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.DeleteGroup(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/leave",
-                async (url, info, sessionID, output) => await matchCallbacks.LeaveGroup(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.LeaveGroup(url, info, sessionID)
             ),
             new RouteAction<MatchGroupStatusRequest>(
                 "/client/match/group/status",
-                async (url, info, sessionID, output) => await matchCallbacks.GetGroupStatus(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.GetGroupStatus(url, info, sessionID)
             ),
             new RouteAction<MatchGroupStartGameRequest>(
                 "/client/match/group/start_game",
-                async (url, info, sessionID, output) => await matchCallbacks.StartGameAsGroupLeader(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.StartGameAsGroupLeader(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/exit_from_menu",
-                async (url, info, sessionID, output) => await matchCallbacks.ExitFromMenu(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.ExitFromMenu(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/current",
-                async (url, info, sessionID, output) => await matchCallbacks.GroupCurrent(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.GroupCurrent(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/looking/start",
-                async (url, info, sessionID, output) => await matchCallbacks.StartGroupSearch(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.StartGroupSearch(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/looking/stop",
-                async (url, info, sessionID, output) => await matchCallbacks.StopGroupSearch(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.StopGroupSearch(url, info, sessionID)
             ),
             new RouteAction<MatchGroupInviteSendRequest>(
                 "/client/match/group/invite/send",
-                async (url, info, sessionID, output) => await matchCallbacks.SendGroupInvite(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.SendGroupInvite(url, info, sessionID)
             ),
             new RouteAction<RequestIdRequest>(
                 "/client/match/group/invite/accept",
-                async (url, info, sessionID, output) => await matchCallbacks.AcceptGroupInvite(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.AcceptGroupInvite(url, info, sessionID)
             ),
             new RouteAction<RequestIdRequest>(
                 "/client/match/group/invite/decline",
-                async (url, info, sessionID, output) => await matchCallbacks.DeclineGroupInvite(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.DeclineGroupInvite(url, info, sessionID)
             ),
             new RouteAction<RequestIdRequest>(
                 "/client/match/group/invite/cancel",
-                async (url, info, sessionID, output) => await matchCallbacks.CancelGroupInvite(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.CancelGroupInvite(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/invite/cancel-all",
-                async (url, info, sessionID, output) => await matchCallbacks.CancelAllGroupInvite(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.CancelAllGroupInvite(url, info, sessionID)
             ),
             new RouteAction<MatchGroupTransferRequest>(
                 "/client/match/group/transfer",
-                async (url, info, sessionID, output) => await matchCallbacks.TransferGroup(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.TransferGroup(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/raid/ready",
-                async (url, info, sessionID, output) => await matchCallbacks.RaidReady(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.RaidReady(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/match/group/raid/not-ready",
-                async (url, info, sessionID, output) => await matchCallbacks.NotRaidReady(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.NotRaidReady(url, info, sessionID)
             ),
             new RouteAction<PutMetricsRequestData>(
                 "/client/putMetrics",
-                async (url, info, sessionID, output) => await matchCallbacks.PutMetrics(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.PutMetrics(url, info, sessionID)
             ),
             new RouteAction<PutMetricsRequestData>(
                 "/client/analytics/event-disconnect",
-                async (url, info, sessionID, output) => await matchCallbacks.EventDisconnect(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.EventDisconnect(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/getMetricsConfig",
-                async (url, info, sessionID, output) => await matchCallbacks.GetMetrics(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.GetMetrics(url, info, sessionID)
             ),
             new RouteAction<GetRaidConfigurationRequestData>(
                 "/client/raid/configuration",
-                async (url, info, sessionID, output) => await matchCallbacks.GetRaidConfiguration(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.GetRaidConfiguration(url, info, sessionID)
             ),
             new RouteAction<GetRaidConfigurationRequestData>(
                 "/client/raid/configuration-by-profile",
-                async (url, info, sessionID, output) => await matchCallbacks.GetConfigurationByProfile(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await matchCallbacks.GetConfigurationByProfile(url, info, sessionID)
             ),
             new RouteAction<MatchGroupPlayerRemoveRequest>(
                 "/client/match/group/player/remove",
-                async (url, info, sessionID, output) => await matchCallbacks.RemovePlayerFromGroup(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.RemovePlayerFromGroup(url, info, sessionID)
             ),
             new RouteAction<StartLocalRaidRequestData>(
                 "/client/match/local/start",
-                async (url, info, sessionID, output) => await matchCallbacks.StartLocalRaid(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.StartLocalRaid(url, info, sessionID)
             ),
             new RouteAction<EndLocalRaidRequestData>(
                 "/client/match/local/end",
-                async (url, info, sessionID, output) => await matchCallbacks.EndLocalRaid(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await matchCallbacks.EndLocalRaid(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/ModdedTraderCustomizationRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/ModdedTraderCustomizationRouter.cs
@@ -13,7 +13,7 @@ public class ModdedTraderCustomizationRouter(JsonUtil jsonUtil, ModdedTraderCust
         [
             new RouteAction<EmptyRequestData>(
                 "/singleplayer/moddedTraders",
-                async (url, info, sessionID, output) =>
+                async (url, info, sessionID, output, cancellationToken) =>
                     await moddedTraderCustomizationCallbacks.GetCustomizationTraders(url, info, sessionID)
             ),
         ]

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/NotifierStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/NotifierStaticRouter.cs
@@ -14,11 +14,12 @@ public class NotifierStaticRouter(JsonUtil jsonUtil, NotifierCallbacks notifierC
         [
             new RouteAction<EmptyRequestData>(
                 "/client/notifier/channel/create",
-                async (url, info, sessionID, output) => await notifierCallbacks.CreateNotifierChannel(url, info, sessionID)
+                async (url, info, sessionID, output, canellationToken) =>
+                    await notifierCallbacks.CreateNotifierChannel(url, info, sessionID)
             ),
             new RouteAction<UIDRequestData>(
                 "/client/game/profile/select",
-                async (url, info, sessionID, output) => await notifierCallbacks.SelectProfile(url, info, sessionID)
+                async (url, info, sessionID, output, canellationToken) => await notifierCallbacks.SelectProfile(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/PrestigeStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/PrestigeStaticRouter.cs
@@ -14,11 +14,11 @@ public class PrestigeStaticRouter(JsonUtil jsonUtil, PrestigeCallbacks prestigeC
         [
             new RouteAction<EmptyRequestData>(
                 "/client/prestige/list",
-                async (url, info, sessionID, output) => await prestigeCallbacks.GetPrestige(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await prestigeCallbacks.GetPrestige(url, info, sessionID)
             ),
             new RouteAction<ObtainPrestigeRequestList>(
                 "/client/prestige/obtain",
-                async (url, info, sessionID, output) => await prestigeCallbacks.ObtainPrestige(url, info, sessionID)
+                async (url, info, sessionID, output, canellationToken) => await prestigeCallbacks.ObtainPrestige(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/ProfileStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/ProfileStaticRouter.cs
@@ -15,55 +15,55 @@ public class ProfileStaticRouter(ProfileCallbacks profileCallbacks, JsonUtil jso
         [
             new RouteAction<ProfileCreateRequestData>(
                 "/client/game/profile/create",
-                async (url, info, sessionID, output) => await profileCallbacks.CreateProfile(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.CreateProfile(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/game/profile/list",
-                async (url, info, sessionID, output) => await profileCallbacks.GetProfileData(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.GetProfileData(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/game/profile/savage/regenerate",
-                async (url, info, sessionID, output) => await profileCallbacks.RegenerateScav(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.RegenerateScav(url, info, sessionID)
             ),
             new RouteAction<ProfileChangeVoiceRequestData>(
                 "/client/game/profile/voice/change",
-                async (url, info, sessionID, output) => await profileCallbacks.ChangeVoice(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.ChangeVoice(url, info, sessionID)
             ),
             new RouteAction<ProfileChangeNicknameRequestData>(
                 "/client/game/profile/nickname/change",
-                async (url, info, sessionID, output) => await profileCallbacks.ChangeNickname(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.ChangeNickname(url, info, sessionID)
             ),
             new RouteAction<ValidateNicknameRequestData>(
                 "/client/game/profile/nickname/validate",
-                async (url, info, sessionID, output) => await profileCallbacks.ValidateNickname(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.ValidateNickname(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/game/profile/nickname/reserved",
-                async (url, info, sessionID, output) => await profileCallbacks.GetReservedNickname(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.GetReservedNickname(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/profile/status",
-                async (url, info, sessionID, output) => await profileCallbacks.GetProfileStatus(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.GetProfileStatus(url, info, sessionID)
             ),
             new RouteAction<GetOtherProfileRequest>(
                 "/client/profile/view",
-                async (url, info, sessionID, output) => await profileCallbacks.GetOtherProfile(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.GetOtherProfile(url, info, sessionID)
             ),
             new RouteAction<GetProfileSettingsRequest>(
                 "/client/profile/settings",
-                async (url, info, sessionID, output) => await profileCallbacks.GetProfileSettings(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.GetProfileSettings(url, info, sessionID)
             ),
             new RouteAction<SearchProfilesRequestData>(
                 "/client/game/profile/search",
-                async (url, info, sessionID, output) => await profileCallbacks.SearchProfiles(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.SearchProfiles(url, info, sessionID)
             ),
             new RouteAction<GetMiniProfileRequestData>(
                 "/launcher/profile/info",
-                async (url, info, sessionID, output) => await profileCallbacks.GetMiniProfile(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.GetMiniProfile(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/launcher/profiles",
-                async (url, info, sessionID, output) => await profileCallbacks.GetAllMiniProfiles(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await profileCallbacks.GetAllMiniProfiles(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/QuestStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/QuestStaticRouter.cs
@@ -14,11 +14,11 @@ public class QuestStaticRouter(JsonUtil jsonUtil, QuestCallbacks questCallbacks)
         [
             new RouteAction<ListQuestsRequestData>(
                 "/client/quest/list",
-                async (url, info, sessionID, output) => await questCallbacks.ListQuests(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await questCallbacks.ListQuests(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/repeatalbeQuests/activityPeriods",
-                async (url, info, sessionID, output) => await questCallbacks.ActivityPeriods(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await questCallbacks.ActivityPeriods(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/RagfairStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/RagfairStaticRouter.cs
@@ -14,31 +14,32 @@ public class RagfairStaticRouter(JsonUtil jsonUtil, RagfairCallbacks ragfairCall
         [
             new RouteAction<SearchRequestData>(
                 "/client/ragfair/search",
-                async (url, info, sessionID, output) => await ragfairCallbacks.Search(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await ragfairCallbacks.Search(url, info, sessionID)
             ),
             new RouteAction<SearchRequestData>(
                 "/client/ragfair/find",
-                async (url, info, sessionID, output) => await ragfairCallbacks.Search(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await ragfairCallbacks.Search(url, info, sessionID)
             ),
             new RouteAction<GetMarketPriceRequestData>(
                 "/client/ragfair/itemMarketPrice",
-                async (url, info, sessionID, output) => await ragfairCallbacks.GetMarketPrice(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await ragfairCallbacks.GetMarketPrice(url, info, sessionID)
             ),
             new RouteAction<StorePlayerOfferTaxAmountRequestData>(
                 "/client/ragfair/offerfees",
-                async (url, info, sessionID, output) => await ragfairCallbacks.StorePlayerOfferTaxAmount(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) =>
+                    await ragfairCallbacks.StorePlayerOfferTaxAmount(url, info, sessionID)
             ),
             new RouteAction<SendRagfairReportRequestData>(
                 "/client/reports/ragfair/send",
-                async (url, info, sessionID, output) => await ragfairCallbacks.SendReport(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await ragfairCallbacks.SendReport(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/items/prices",
-                async (url, info, sessionID, output) => await ragfairCallbacks.GetFleaPrices(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await ragfairCallbacks.GetFleaPrices(url, info, sessionID)
             ),
             new RouteAction<GetRagfairOfferByIdRequest>(
                 "/client/ragfair/offer/findbyid",
-                async (url, info, sessionID, output) => await ragfairCallbacks.GetFleaOfferById(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await ragfairCallbacks.GetFleaOfferById(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/TraderStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/TraderStaticRouter.cs
@@ -13,7 +13,7 @@ public class TraderStaticRouter(JsonUtil jsonUtil, TraderCallbacks traderCallbac
         [
             new RouteAction<EmptyRequestData>(
                 "/client/trading/api/traderSettings",
-                async (url, info, sessionID, output) => await traderCallbacks.GetTraderSettings(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await traderCallbacks.GetTraderSettings(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/WeatherStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/WeatherStaticRouter.cs
@@ -13,11 +13,11 @@ public class WeatherStaticRouter(JsonUtil jsonUtil, WeatherCallbacks weatherCall
         [
             new RouteAction<EmptyRequestData>(
                 "/client/weather",
-                async (url, info, sessionID, output) => await weatherCallbacks.GetWeather(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await weatherCallbacks.GetWeather(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
                 "/client/localGame/weather",
-                async (url, info, sessionID, output) => await weatherCallbacks.GetLocalWeather(url, info, sessionID)
+                async (url, info, sessionID, output, cancellationToken) => await weatherCallbacks.GetLocalWeather(url, info, sessionID)
             ),
         ]
     ) { }

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/IHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/IHttpListener.cs
@@ -6,5 +6,5 @@ namespace SPTarkov.Server.Core.Servers.Http;
 public interface IHttpListener
 {
     bool CanHandle(MongoId sessionId, HttpContext context);
-    Task Handle(MongoId sessionId, HttpContext context);
+    Task HandleAsync(MongoId sessionId, HttpContext context, CancellationToken cancellationToken = default);
 }

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -30,13 +30,13 @@ public class SptHttpListener(
         return SupportedMethods.Contains(context.Request.Method) && httpRouter.CanHandle(context);
     }
 
-    public async Task Handle(MongoId sessionId, HttpContext context)
+    public async Task HandleAsync(MongoId sessionId, HttpContext context, CancellationToken cancellationToken = default)
     {
         switch (context.Request.Method)
         {
             case "GET":
             {
-                var response = await GetResponse(sessionId, context, null);
+                var response = await GetResponseAsync(sessionId, context, null, cancellationToken);
 
                 // Another handler is already handling this, or no handler was found.
                 if (response is null)
@@ -44,7 +44,7 @@ public class SptHttpListener(
                     return;
                 }
 
-                await SendResponse(sessionId, context.Request, context.Response, null, response);
+                await SendResponseAsync(sessionId, context.Request, context.Response, null, response, cancellationToken);
                 break;
             }
             // these are handled almost identically.
@@ -65,12 +65,12 @@ public class SptHttpListener(
                 {
                     await using var deflateStream = new ZLibStream(context.Request.Body, CompressionMode.Decompress);
                     using var reader = new StreamReader(deflateStream, Encoding.UTF8);
-                    body = await reader.ReadToEndAsync();
+                    body = await reader.ReadToEndAsync(cancellationToken);
                 }
                 else
                 {
                     using var reader = new StreamReader(context.Request.Body, Encoding.UTF8);
-                    body = await reader.ReadToEndAsync();
+                    body = await reader.ReadToEndAsync(cancellationToken);
                 }
 
                 if (!requestIsCompressed)
@@ -81,7 +81,7 @@ public class SptHttpListener(
                     }
                 }
 
-                var response = await GetResponse(sessionId, context, body);
+                var response = await GetResponseAsync(sessionId, context, body, cancellationToken);
 
                 // Another handler is already handling this, or no handler was found.
                 if (response is null)
@@ -89,7 +89,7 @@ public class SptHttpListener(
                     return;
                 }
 
-                await SendResponse(sessionId, context.Request, context.Response, body, response);
+                await SendResponseAsync(sessionId, context.Request, context.Response, body, response, cancellationToken);
                 break;
             }
         }
@@ -103,7 +103,14 @@ public class SptHttpListener(
     /// <param name="resp"> Outgoing response </param>
     /// <param name="body"> Buffer </param>
     /// <param name="output"> Server generated response data</param>
-    public async Task SendResponse(MongoId sessionID, HttpRequest req, HttpResponse resp, object? body, string output)
+    public async Task SendResponseAsync(
+        MongoId sessionID,
+        HttpRequest req,
+        HttpResponse resp,
+        object? body,
+        string output,
+        CancellationToken cancellationToken = default
+    )
     {
         body ??= new object();
 
@@ -112,7 +119,7 @@ public class SptHttpListener(
         if (IsDebugRequest(req))
         {
             // Send only raw response without transformation
-            await SendJson(resp, output, sessionID);
+            await SendJsonAsync(resp, output, sessionID, cancellationToken);
             if (logger.IsLogEnabled(LogLevel.Debug))
             {
                 logger.Debug($"Response: {output}");
@@ -126,12 +133,12 @@ public class SptHttpListener(
         var serialiser = serializers.FirstOrDefault(x => x.CanHandle(output));
         if (serialiser != null)
         {
-            await serialiser.Serialize(sessionID, req, resp, bodyInfo);
+            await serialiser.SerializeAsync(sessionID, req, resp, bodyInfo, cancellationToken);
         }
         else
         // No serializer can handle the request (majority of requests don't), zlib the output and send response back
         {
-            await SendZlibJson(resp, output, sessionID);
+            await SendZlibJsonAsync(resp, output, sessionID, cancellationToken);
         }
 
         LogRequest(req, output);
@@ -161,9 +168,14 @@ public class SptHttpListener(
         }
     }
 
-    public async ValueTask<string> GetResponse(MongoId sessionId, HttpContext context, string? body)
+    public async ValueTask<string> GetResponseAsync(
+        MongoId sessionId,
+        HttpContext context,
+        string? body,
+        CancellationToken cancellationToken = default
+    )
     {
-        var output = await httpRouter.GetResponse(context.Request, sessionId, body);
+        var output = await httpRouter.GetResponseAsync(context.Request, sessionId, body, cancellationToken);
 
         // Route doesn't exist or response is not properly set up
         if (string.IsNullOrEmpty(output))
@@ -185,7 +197,7 @@ public class SptHttpListener(
         return output;
     }
 
-    public async Task SendJson(HttpResponse resp, string? output, MongoId sessionID)
+    public async Task SendJsonAsync(HttpResponse resp, string? output, MongoId sessionID, CancellationToken cancellationToken = default)
     {
         resp.StatusCode = 200;
         resp.ContentType = "application/json";
@@ -193,11 +205,11 @@ public class SptHttpListener(
 
         if (!string.IsNullOrEmpty(output))
         {
-            await resp.WriteAsync(output);
+            await resp.WriteAsync(output, cancellationToken: cancellationToken);
         }
     }
 
-    public async Task SendZlibJson(HttpResponse resp, string output, MongoId sessionID)
+    public async Task SendZlibJsonAsync(HttpResponse resp, string output, MongoId sessionID, CancellationToken cancellationToken = default)
     {
         resp.StatusCode = 200;
         resp.ContentType = "application/json";
@@ -205,7 +217,7 @@ public class SptHttpListener(
 
         await using (var deflateStream = new ZLibStream(resp.Body, CompressionLevel.SmallestSize))
         {
-            await deflateStream.WriteAsync(Encoding.UTF8.GetBytes(output));
+            await deflateStream.WriteAsync(Encoding.UTF8.GetBytes(output), cancellationToken);
         }
     }
 

--- a/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Http/SptHttpListener.cs
@@ -103,6 +103,9 @@ public class SptHttpListener(
     /// <param name="resp"> Outgoing response </param>
     /// <param name="body"> Buffer </param>
     /// <param name="output"> Server generated response data</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the response operation.
+    /// </param>
     public async Task SendResponseAsync(
         MongoId sessionID,
         HttpRequest req,

--- a/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/HttpServer.cs
@@ -15,7 +15,7 @@ public sealed class HttpServer(
     IEnumerable<IHttpListener> httpListeners
 )
 {
-    public async Task HandleRequest(HttpContext context, RequestDelegate next)
+    public async Task HandleRequestAsync(HttpContext context, RequestDelegate next, CancellationToken cancellationToken = default)
     {
         if (context.WebSockets.IsWebSocketRequest && webSocketServer.CanHandle(context))
         {
@@ -37,7 +37,7 @@ public sealed class HttpServer(
 
         if (listener != null)
         {
-            await listener.Handle(sessionId, context);
+            await listener.HandleAsync(sessionId, context, cancellationToken);
         }
         else
         {

--- a/Libraries/SPTarkov.Server.Core/Servers/SaveServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/SaveServer.cs
@@ -36,7 +36,7 @@ public sealed class SaveServer(
     /// <summary>
     ///     Load all profiles in /user/profiles folder into memory (this.profiles)
     /// </summary>
-    public async Task LoadAsync()
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
     {
         // get files to load
         if (!fileUtil.DirectoryExists(profileFilepath))
@@ -54,7 +54,7 @@ public sealed class SaveServer(
             var filename = Path.GetFileNameWithoutExtension(file);
             if (MongoId.IsValidMongoId(filename))
             {
-                await LoadProfileAsync(fileUtil.StripExtension(file));
+                await LoadProfileAsync(fileUtil.StripExtension(file), cancellationToken);
             }
         }
 
@@ -68,13 +68,13 @@ public sealed class SaveServer(
     /// <summary>
     ///     Save changes for each profile from memory into user/profiles json
     /// </summary>
-    public async Task SaveAsync()
+    public async Task SaveAsync(CancellationToken cancellationToken = default)
     {
         // Save every profile
         var totalTime = 0L;
         foreach (var sessionID in profiles)
         {
-            totalTime += await SaveProfileAsync(sessionID.Key);
+            totalTime += await SaveProfileAsync(sessionID.Key, cancellationToken);
         }
 
         if (!profiles.IsEmpty && logger.IsLogEnabled(LogLevel.Debug))
@@ -184,7 +184,7 @@ public sealed class SaveServer(
     ///     Execute saveLoadRouters callbacks after being loaded into memory.
     /// </summary>
     /// <param name="sessionID"> ID of profile to store in memory </param>
-    public async Task LoadProfileAsync(MongoId sessionID)
+    public async Task LoadProfileAsync(MongoId sessionID, CancellationToken cancellationToken = default)
     {
         var filePath = Path.Combine(profileFilepath, $"{sessionID}.json");
         if (fileUtil.FileExists(filePath))
@@ -194,7 +194,7 @@ public sealed class SaveServer(
 
             try
             {
-                profile = await jsonUtil.DeserializeFromFileAsync<JsonObject>(filePath);
+                profile = await jsonUtil.DeserializeFromFileAsync<JsonObject>(filePath, cancellationToken);
             }
             catch (JsonException e)
             {
@@ -207,7 +207,7 @@ public sealed class SaveServer(
 
                 if (backupService.RestoreProfile(sessionID))
                 {
-                    profile = await jsonUtil.DeserializeFromFileAsync<JsonObject>(filePath);
+                    profile = await jsonUtil.DeserializeFromFileAsync<JsonObject>(filePath, cancellationToken);
                     logger.Success("Profile restored from backup!");
                 }
                 else
@@ -249,7 +249,7 @@ public sealed class SaveServer(
     /// </summary>
     /// <param name="sessionID"> Profile id (user/profiles/id.json) </param>
     /// <returns> Time taken to save the profile in seconds </returns>
-    public async Task<long> SaveProfileAsync(MongoId sessionID)
+    public async Task<long> SaveProfileAsync(MongoId sessionID, CancellationToken cancellationToken = default)
     {
         // No need to save profiles that have been marked as invalid
         if (IsProfileInvalidOrUnloadable(sessionID))
@@ -259,8 +259,8 @@ public sealed class SaveServer(
 
         // Lock based on sessionID so we don't attempt to write to the same save file
         // multiple times at the same time, leading to file access contention
-        SemaphoreSlim saveLock = saveLocks.GetOrAdd(sessionID, _ => new SemaphoreSlim(1, 1));
-        await saveLock.WaitAsync();
+        var saveLock = saveLocks.GetOrAdd(sessionID, _ => new SemaphoreSlim(1, 1));
+        await saveLock.WaitAsync(cancellationToken);
 
         Stopwatch start;
         try
@@ -271,12 +271,12 @@ public sealed class SaveServer(
             var jsonProfile =
                 jsonUtil.Serialize(profiles[sessionID], !coreConfig.Features.CompressProfile)
                 ?? throw new InvalidOperationException("Could not serialize profile for saving!");
-            var fmd5 = await hashUtil.GenerateHashForDataAsync(HashingAlgorithm.MD5, jsonProfile);
+            var fmd5 = await hashUtil.GenerateHashForDataAsync(HashingAlgorithm.MD5, jsonProfile, cancellationToken);
             if (!saveMd5.TryGetValue(sessionID, out var currentMd5) || currentMd5 != fmd5)
             {
                 saveMd5[sessionID] = fmd5;
                 // save profile to disk
-                await fileUtil.WriteFileAsync(filePath, jsonProfile);
+                await fileUtil.WriteFileAsync(filePath, jsonProfile, cancellationToken);
             }
 
             start.Stop();

--- a/Libraries/SPTarkov.Server.Core/Services/BackupService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BackupService.cs
@@ -151,7 +151,8 @@ public sealed class BackupService(
                 await fileUtil.WriteFileAsync(
                     Path.Combine(targetDir, ActiveModsFilename),
                     jsonUtil.Serialize(GetActiveServerMods())
-                        ?? throw new InvalidOperationException("Could not serialize active server mods!")
+                        ?? throw new InvalidOperationException("Could not serialize active server mods!"),
+                    cancellationToken
                 );
 
                 if (logger.IsLogEnabled(LogLevel.Debug))

--- a/Libraries/SPTarkov.Server.Core/Services/BackupService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BackupService.cs
@@ -23,7 +23,7 @@ public sealed class BackupService(
 
     private readonly BackupConfig _backupConfig = backupConfig;
 
-    // Runs Init() every x minutes
+    // Runs InitializeAsync() every x minutes
     private Timer? _backupIntervalTimer;
 
     private readonly SemaphoreSlim _backupLock = new(1, 1);
@@ -52,7 +52,7 @@ public sealed class BackupService(
         if (!_backupConfig.BackupInterval.Enabled)
         {
             // Not backing up at regular intervals, run once and exit
-            await Init(cancellationToken);
+            await InitializeAsync(cancellationToken);
 
             return;
         }
@@ -62,8 +62,9 @@ public sealed class BackupService(
             {
                 try
                 {
-                    await Init();
+                    await InitializeAsync(cancellationToken);
                 }
+                catch (OperationCanceledException) { }
                 catch (Exception ex)
                 {
                     logger.Error($"Profile backup failed: {ex.Message}, {ex.StackTrace}");
@@ -73,6 +74,12 @@ public sealed class BackupService(
             TimeSpan.Zero,
             TimeSpan.FromMinutes(_backupConfig.BackupInterval.IntervalMinutes)
         );
+
+        cancellationToken.Register(() =>
+        {
+            _backupIntervalTimer?.Dispose();
+            _backupIntervalTimer = null;
+        });
     }
 
     /// <summary>
@@ -80,7 +87,7 @@ public sealed class BackupService(
     ///     This method orchestrates the profile backup service. Handles copying profiles to a backup directory and cleaning
     ///     up old backups if the number exceeds the configured maximum.
     /// </summary>
-    public async Task Init(CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         if (!IsEnabled())
         {

--- a/Libraries/SPTarkov.Server.Core/Services/BundleHashCacheService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BundleHashCacheService.cs
@@ -13,7 +13,7 @@ public class BundleHashCacheService(ISptLogger<BundleHashCacheService> logger, J
     protected ConcurrentDictionary<string, uint> _bundleHashes = [];
     private readonly SemaphoreSlim _writeLock = new(1, 1);
 
-    public async Task HydrateCache()
+    public async Task HydrateCacheAsync(CancellationToken cancellationToken = default)
     {
         if (!Directory.Exists(_bundleHashCachePath))
         {
@@ -28,12 +28,12 @@ public class BundleHashCacheService(ISptLogger<BundleHashCacheService> logger, J
             return;
         }
 
-        _bundleHashes = await jsonUtil.DeserializeFromFileAsync<ConcurrentDictionary<string, uint>>(fullCachePath) ?? [];
+        _bundleHashes = await jsonUtil.DeserializeFromFileAsync<ConcurrentDictionary<string, uint>>(fullCachePath, cancellationToken) ?? [];
     }
 
-    public async Task WriteCache()
+    public async Task WriteCacheAsync(CancellationToken cancellationToken = default)
     {
-        await _writeLock.WaitAsync();
+        await _writeLock.WaitAsync(cancellationToken);
 
         try
         {
@@ -44,7 +44,7 @@ public class BundleHashCacheService(ISptLogger<BundleHashCacheService> logger, J
                 return;
             }
 
-            await fileUtil.WriteFileAsync(Path.Join(_bundleHashCachePath, _cacheName), bundleHashesSerialized);
+            await fileUtil.WriteFileAsync(Path.Join(_bundleHashCachePath, _cacheName), bundleHashesSerialized, cancellationToken);
         }
         finally
         {
@@ -71,9 +71,12 @@ public class BundleHashCacheService(ISptLogger<BundleHashCacheService> logger, J
     /// Calculate, match the current hash and store the correct hash of the bundle
     /// </summary>
     /// <param name="BundlePath">The path to the bundle</param>
-    public async Task<uint> CalculateMatchAndStoreHash(string BundlePath)
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the hashing operation.
+    /// </param>
+    public async Task<uint> CalculateMatchAndStoreHashAsync(string BundlePath, CancellationToken cancellationToken = default)
     {
-        var hash = await CalculateHash(BundlePath);
+        var hash = await CalculateHashAsync(BundlePath, cancellationToken);
 
         if (!MatchWithStoredHash(BundlePath, hash))
         {
@@ -83,9 +86,9 @@ public class BundleHashCacheService(ISptLogger<BundleHashCacheService> logger, J
         return hash;
     }
 
-    protected async Task<uint> CalculateHash(string BundlePath)
+    protected async Task<uint> CalculateHashAsync(string BundlePath, CancellationToken cancellationToken = default)
     {
-        return await hashUtil.GenerateCrc32ForFileAsync(BundlePath);
+        return await hashUtil.GenerateCrc32ForFileAsync(BundlePath, cancellationToken);
     }
 
     protected bool MatchWithStoredHash(string BundlePath, uint hash)

--- a/Libraries/SPTarkov.Server.Core/Services/BundleHashCacheService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/BundleHashCacheService.cs
@@ -62,7 +62,7 @@ public class BundleHashCacheService(ISptLogger<BundleHashCacheService> logger, J
         return value;
     }
 
-    protected async Task StoreValue(string bundlePath, uint hash)
+    protected void StoreValue(string bundlePath, uint hash)
     {
         _bundleHashes.TryAdd(bundlePath, hash);
     }
@@ -80,7 +80,7 @@ public class BundleHashCacheService(ISptLogger<BundleHashCacheService> logger, J
 
         if (!MatchWithStoredHash(BundlePath, hash))
         {
-            await StoreValue(BundlePath, hash);
+            StoreValue(BundlePath, hash);
         }
 
         return hash;

--- a/Libraries/SPTarkov.Server.Core/Services/Hosted/SPTStartupHostedService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Hosted/SPTStartupHostedService.cs
@@ -26,7 +26,7 @@ public sealed class SPTStartupHostedService(
 {
     private readonly Dictionary<string, long> _onUpdateLastRun = [];
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -36,7 +36,7 @@ public sealed class SPTStartupHostedService(
                 {
                     if (File.Exists(Path.Join(Directory.GetCurrentDirectory(), mod.GetModPath(), "bundles.json")))
                     {
-                        await bundleLoader.LoadBundlesAsync(mod, stoppingToken).ConfigureAwait(false);
+                        await bundleLoader.LoadBundlesAsync(mod, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -81,7 +81,7 @@ public sealed class SPTStartupHostedService(
             logger.Info(serverLocalisationService.GetText("executing_startup_callbacks"));
             foreach (var onLoad in onLoadComponents)
             {
-                await onLoad.OnLoad(stoppingToken).ConfigureAwait(false);
+                await onLoad.OnLoad(cancellationToken).ConfigureAwait(false);
             }
 
             logger.Success(serverLocalisationService.GetText("started_webserver_success", httpServer.ListeningUrl()));
@@ -91,7 +91,7 @@ public sealed class SPTStartupHostedService(
 
             using var timer = new PeriodicTimer(TimeSpan.FromSeconds(5));
 
-            while (!stoppingToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 foreach (var updateable in onUpdateComponents)
                 {
@@ -106,7 +106,7 @@ public sealed class SPTStartupHostedService(
 
                     try
                     {
-                        if (await updateable.OnUpdate(secondsSinceLastRun, stoppingToken).ConfigureAwait(false))
+                        if (await updateable.OnUpdate(secondsSinceLastRun, cancellationToken).ConfigureAwait(false))
                         {
                             _onUpdateLastRun[updateableName] = timeUtil.GetTimeStamp();
                         }
@@ -117,7 +117,7 @@ public sealed class SPTStartupHostedService(
                     }
                 }
 
-                await timer.WaitForNextTickAsync(stoppingToken);
+                await timer.WaitForNextTickAsync(cancellationToken);
             }
         }
         catch (Exception ex)

--- a/Libraries/SPTarkov.Server.Core/Services/Hosted/SPTStartupHostedService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Hosted/SPTStartupHostedService.cs
@@ -111,6 +111,10 @@ public sealed class SPTStartupHostedService(
                             _onUpdateLastRun[updateableName] = timeUtil.GetTimeStamp();
                         }
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
                     catch (Exception err)
                     {
                         LogUpdateException(err, updateable);

--- a/Libraries/SPTarkov.Server.Core/Services/Hosted/SPTStartupHostedService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Hosted/SPTStartupHostedService.cs
@@ -36,7 +36,7 @@ public sealed class SPTStartupHostedService(
                 {
                     if (File.Exists(Path.Join(Directory.GetCurrentDirectory(), mod.GetModPath(), "bundles.json")))
                     {
-                        await bundleLoader.LoadBundlesAsync(mod).ConfigureAwait(false);
+                        await bundleLoader.LoadBundlesAsync(mod, stoppingToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -106,7 +106,7 @@ public sealed class SPTStartupHostedService(
 
                     try
                     {
-                        if (await updateable.OnUpdate(stoppingToken, secondsSinceLastRun).ConfigureAwait(false))
+                        if (await updateable.OnUpdate(secondsSinceLastRun, stoppingToken).ConfigureAwait(false))
                         {
                             _onUpdateLastRun[updateableName] = timeUtil.GetTimeStamp();
                         }

--- a/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/LocationLifecycleService.cs
@@ -81,7 +81,7 @@ public class LocationLifecycleService(
     public virtual StartLocalRaidResponseData StartLocalRaid(MongoId sessionId, StartLocalRaidRequestData request)
     {
         // Backup the profile on raid start
-        backupService.Init().GetAwaiter().GetResult();
+        backupService.InitializeAsync().GetAwaiter().GetResult();
 
         logger.Debug($"Starting: {request.Location}");
 
@@ -536,7 +536,7 @@ public class LocationLifecycleService(
 
         // Save and backup the profile on raid end
         saveServer.SaveProfileAsync(sessionId).GetAwaiter().GetResult();
-        backupService.Init().GetAwaiter().GetResult();
+        backupService.InitializeAsync().GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/Modding/ProfileDataService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Modding/ProfileDataService.cs
@@ -26,7 +26,7 @@ public sealed class ProfileDataService(FileUtil fileUtil, JsonUtil jsonUtil)
     /// </summary>
     /// <param name="profileId">The profile to look up</param>
     /// <returns>A dictionary containing all of the profile data</returns>
-    public async Task<Dictionary<string, object>> GetAllProfileData(MongoId profileId)
+    public async Task<Dictionary<string, object>> GetAllProfileDataAsync(MongoId profileId, CancellationToken cancellationToken = default)
     {
         var profileDataPath = Path.Combine(ProfileDataFilepath, profileId.ToString());
         var profileData = new Dictionary<string, object>();
@@ -60,7 +60,7 @@ public sealed class ProfileDataService(FileUtil fileUtil, JsonUtil jsonUtil)
                 continue;
             }
 
-            var deserializedData = await jsonUtil.DeserializeFromFileAsync<object>(filePath);
+            var deserializedData = await jsonUtil.DeserializeFromFileAsync<object>(filePath, cancellationToken);
 
             if (deserializedData == null)
             {
@@ -73,14 +73,17 @@ public sealed class ProfileDataService(FileUtil fileUtil, JsonUtil jsonUtil)
         return profileData;
     }
 
-    public async Task<T?> GetProfileData<T>(MongoId profileId, string modKey)
+    public async Task<T?> GetProfileDataAsync<T>(MongoId profileId, string modKey, CancellationToken cancellationToken = default)
     {
         var profileDataKey = GetCacheKey(profileId, modKey);
         if (!_profileDataCache.TryGetValue(profileDataKey, out var value))
         {
             if (ProfileDataExists(profileId, modKey))
             {
-                value = await jsonUtil.DeserializeFromFileAsync<T>(Path.Combine(ProfileDataFilepath, profileId, $"{modKey}.json"));
+                value = await jsonUtil.DeserializeFromFileAsync<T>(
+                    Path.Combine(ProfileDataFilepath, profileId, $"{modKey}.json"),
+                    cancellationToken
+                );
 
                 if (value != null)
                 {
@@ -96,7 +99,12 @@ public sealed class ProfileDataService(FileUtil fileUtil, JsonUtil jsonUtil)
         return (T?)value;
     }
 
-    public async Task SaveProfileData<T>(MongoId profileId, string modKey, T profileData)
+    public async Task SaveProfileDataAsync<T>(
+        MongoId profileId,
+        string modKey,
+        T profileData,
+        CancellationToken cancellationToken = default
+    )
     {
         ArgumentNullException.ThrowIfNull(profileData);
 
@@ -106,7 +114,7 @@ public sealed class ProfileDataService(FileUtil fileUtil, JsonUtil jsonUtil)
 
         _profileDataCache[GetCacheKey(profileId, modKey)] = profileData;
 
-        await fileUtil.WriteFileAsync(Path.Combine(ProfileDataFilepath, profileId, $"{modKey}.json"), data);
+        await fileUtil.WriteFileAsync(Path.Combine(ProfileDataFilepath, profileId, $"{modKey}.json"), data, cancellationToken);
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/ReleaseCheckService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/ReleaseCheckService.cs
@@ -15,10 +15,10 @@ namespace SPTarkov.Server.Core.Services;
 [Injectable(TypePriority = int.MaxValue)]
 internal sealed class ReleaseCheckService(ISptLogger<ReleaseCheckService> logger, IHttpClientFactory httpClientFactory) : IOnLoad
 {
-    public Task OnLoad(CancellationToken stoppingToken)
+    public Task OnLoad(CancellationToken cancellationToken)
     {
         // Run in a new task so we don't hold the main thread at all, this isn't super critical
-        _ = Task.Run(CheckForUpdate, stoppingToken);
+        _ = Task.Run(CheckForUpdate, cancellationToken);
 
         return Task.CompletedTask;
     }

--- a/Libraries/SPTarkov.Server.Core/Utils/DatabaseImporter.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/DatabaseImporter.cs
@@ -25,16 +25,16 @@ public class DatabaseImporter(
     private const string SptDataPath = "./SPT_Data/";
     protected readonly Dictionary<string, string> DatabaseHashes = [];
 
-    public async Task OnLoad(CancellationToken stoppingToken)
+    public async Task OnLoad(CancellationToken cancellationToken)
     {
         var shouldVerify = !ProgramStatics.DEBUG();
 
         if (shouldVerify)
         {
-            await LoadHashesAsync(stoppingToken);
+            await LoadHashesAsync(cancellationToken);
         }
 
-        await HydrateDatabaseAsync(SptDataPath, shouldVerify, stoppingToken);
+        await HydrateDatabaseAsync(SptDataPath, shouldVerify, cancellationToken);
 
         var imageFilePath = $"{SptDataPath}images/";
         CreateRouteMapping(imageFilePath, "files");
@@ -63,7 +63,7 @@ public class DatabaseImporter(
         }
     }
 
-    protected async Task LoadHashesAsync(CancellationToken cancellationToken)
+    protected async Task LoadHashesAsync(CancellationToken cancellationToken = default)
     {
         var checksFilePath = Path.Combine(SptDataPath, "checks.dat");
 
@@ -103,27 +103,39 @@ public class DatabaseImporter(
     /// </summary>
     /// <param name="filePath">path to database folder</param>
     /// <param name="shouldVerifyDatabase">if the database should be verified after deserialization</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the database hydration operation.
+    /// </param>
     /// <returns></returns>
     protected async Task HydrateDatabaseAsync(string filePath, bool shouldVerifyDatabase, CancellationToken cancellationToken = default)
     {
-        logger.Info(serverLocalisationService.GetText("importing_database"));
-        Stopwatch timer = new();
-        timer.Start();
+        try
+        {
+            logger.Info(serverLocalisationService.GetText("importing_database"));
+            Stopwatch timer = new();
+            timer.Start();
 
-        var dataToImport = await importerUtil.LoadRecursiveAsync<DatabaseTables>(
-            $"{filePath}database/",
-            shouldVerifyDatabase ? VerifyDatabase : null,
-            cancellationToken: cancellationToken
-        );
+            var dataToImport = await importerUtil.LoadRecursiveAsync<DatabaseTables>(
+                $"{filePath}database/",
+                shouldVerifyDatabase ? VerifyDatabaseAsync : null,
+                cancellationToken: cancellationToken
+            );
 
-        timer.Stop();
+            timer.Stop();
 
-        logger.Info(serverLocalisationService.GetText("importing_database_finish"));
-        logger.Debug($"Database import took {timer.ElapsedMilliseconds}ms");
-        databaseServer.SetTables(dataToImport);
+            logger.Info(serverLocalisationService.GetText("importing_database_finish"));
+            logger.Debug($"Database import took {timer.ElapsedMilliseconds}ms");
+            databaseServer.SetTables(dataToImport);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            logger.Warning("Database import was cancelled.");
+
+            throw;
+        }
     }
 
-    protected async Task VerifyDatabase(string fileName)
+    protected async Task VerifyDatabaseAsync(string fileName, CancellationToken cancellationToken)
     {
         var relativePath = fileName.StartsWith(SptDataPath, StringComparison.OrdinalIgnoreCase)
             ? fileName.Substring(SptDataPath.Length)
@@ -133,7 +145,7 @@ public class DatabaseImporter(
         {
             await using (var stream = File.OpenRead(fileName))
             {
-                var hashBytes = await md5.ComputeHashAsync(stream);
+                var hashBytes = await md5.ComputeHashAsync(stream, cancellationToken);
                 var hashString = Convert.ToHexString(hashBytes);
 
                 if (DatabaseHashes.TryGetValue(relativePath, out var expectedHash))

--- a/Libraries/SPTarkov.Server.Core/Utils/DatabaseImporter.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/DatabaseImporter.cs
@@ -31,10 +31,10 @@ public class DatabaseImporter(
 
         if (shouldVerify)
         {
-            await LoadHashes(stoppingToken);
+            await LoadHashesAsync(stoppingToken);
         }
 
-        await HydrateDatabase(SptDataPath, shouldVerify);
+        await HydrateDatabaseAsync(SptDataPath, shouldVerify, stoppingToken);
 
         var imageFilePath = $"{SptDataPath}images/";
         CreateRouteMapping(imageFilePath, "files");
@@ -63,7 +63,7 @@ public class DatabaseImporter(
         }
     }
 
-    protected async Task LoadHashes(CancellationToken stoppingToken)
+    protected async Task LoadHashesAsync(CancellationToken cancellationToken)
     {
         var checksFilePath = Path.Combine(SptDataPath, "checks.dat");
 
@@ -74,13 +74,13 @@ public class DatabaseImporter(
                 await using var fs = File.OpenRead(checksFilePath);
 
                 using var reader = new StreamReader(fs, Encoding.ASCII);
-                var base64Content = await reader.ReadToEndAsync(stoppingToken);
+                var base64Content = await reader.ReadToEndAsync(cancellationToken);
 
                 var jsonBytes = Convert.FromBase64String(base64Content);
 
                 await using var ms = new MemoryStream(jsonBytes);
 
-                var FileHashes = await jsonUtil.DeserializeFromMemoryStreamAsync<List<FileHash>>(ms) ?? [];
+                var FileHashes = await jsonUtil.DeserializeFromMemoryStreamAsync<List<FileHash>>(ms, cancellationToken) ?? [];
 
                 foreach (var hash in FileHashes)
                 {
@@ -104,7 +104,7 @@ public class DatabaseImporter(
     /// <param name="filePath">path to database folder</param>
     /// <param name="shouldVerifyDatabase">if the database should be verified after deserialization</param>
     /// <returns></returns>
-    protected async Task HydrateDatabase(string filePath, bool shouldVerifyDatabase)
+    protected async Task HydrateDatabaseAsync(string filePath, bool shouldVerifyDatabase, CancellationToken cancellationToken = default)
     {
         logger.Info(serverLocalisationService.GetText("importing_database"));
         Stopwatch timer = new();
@@ -112,7 +112,8 @@ public class DatabaseImporter(
 
         var dataToImport = await importerUtil.LoadRecursiveAsync<DatabaseTables>(
             $"{filePath}database/",
-            shouldVerifyDatabase ? VerifyDatabase : null
+            shouldVerifyDatabase ? VerifyDatabase : null,
+            cancellationToken: cancellationToken
         );
 
         timer.Stop();

--- a/Libraries/SPTarkov.Server.Core/Utils/FileUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/FileUtil.cs
@@ -6,7 +6,7 @@ namespace SPTarkov.Server.Core.Utils;
 [Injectable]
 public sealed class FileUtil
 {
-    private const string _modBasePath = "user/mods/";
+    private const string ModBasePath = "user/mods/";
 
     public List<string> GetFiles(string path, bool recursive = false, string searchPattern = "*")
     {
@@ -65,14 +65,14 @@ public sealed class FileUtil
         return File.ReadAllText(path);
     }
 
-    public async Task<string> ReadFileAsync(string path)
+    public async Task<string> ReadFileAsync(string path, CancellationToken cancellationToken = default)
     {
-        return await File.ReadAllTextAsync(path);
+        return await File.ReadAllTextAsync(path, cancellationToken);
     }
 
-    public async Task<byte[]> ReadFileAsBytesAsync(string path)
+    public async Task<byte[]> ReadFileAsBytesAsync(string path, CancellationToken cancellationToken = default)
     {
-        return await File.ReadAllBytesAsync(path);
+        return await File.ReadAllBytesAsync(path, cancellationToken);
     }
 
     public void WriteFile(string filePath, string fileContent)
@@ -100,17 +100,17 @@ public sealed class FileUtil
         File.WriteAllBytes(filePath, fileContent);
     }
 
-    public async Task WriteFileAsync(string filePath, string fileContent)
+    public async Task WriteFileAsync(string filePath, string fileContent, CancellationToken cancellationToken = default)
     {
         var bytes = Encoding.UTF8.GetBytes(fileContent);
-        await WriteFileAsync(filePath, bytes);
+        await WriteFileAsync(filePath, bytes, cancellationToken);
     }
 
     /// <summary>
     /// Writes a file atomically by first writing to a temporary file, then replacing the original.
     /// This prevents corruption if the write operation fails or is interrupted.
     /// </summary>
-    public async Task WriteFileAsync(string filePath, byte[] fileContent)
+    public async Task WriteFileAsync(string filePath, byte[] fileContent, CancellationToken cancellationToken = default)
     {
         var directoryPath = Path.GetDirectoryName(filePath);
 
@@ -127,10 +127,10 @@ public sealed class FileUtil
                 var fs = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true)
             )
             {
-                await fs.WriteAsync(fileContent);
+                await fs.WriteAsync(fileContent, cancellationToken);
 
                 // We flush here so we can be sure it's immediately committed to disk
-                await fs.FlushAsync();
+                await fs.FlushAsync(cancellationToken);
                 fs.Flush(true);
             }
 
@@ -202,6 +202,6 @@ public sealed class FileUtil
 
     public string GetModPath(string modName)
     {
-        return Path.Combine(_modBasePath, modName);
+        return Path.Combine(ModBasePath, modName);
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Utils/HashUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/HashUtil.cs
@@ -23,8 +23,11 @@ public sealed class HashUtil(RandomUtil _randomUtil)
     /// Generates a CRC32 hash for a file, reading in chunks using a pooled buffer to reduce allocations.
     /// </summary>
     /// <param name="filePath">The path to the file</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the read operation.
+    /// </param>
     /// <returns>The CRC32 hash as a uint</returns>
-    public async Task<uint> GenerateCrc32ForFileAsync(string filePath)
+    public async Task<uint> GenerateCrc32ForFileAsync(string filePath, CancellationToken cancellationToken = default)
     {
         var crc = new Crc32();
         await using var stream = File.OpenRead(filePath);
@@ -34,7 +37,7 @@ public sealed class HashUtil(RandomUtil _randomUtil)
         try
         {
             int bytesRead;
-            while ((bytesRead = await stream.ReadAsync(buffer)) > 0)
+            while ((bytesRead = await stream.ReadAsync(buffer, cancellationToken)) > 0)
             {
                 crc.Append(buffer.AsSpan(0, bytesRead));
             }
@@ -76,24 +79,31 @@ public sealed class HashUtil(RandomUtil _randomUtil)
     /// </summary>
     /// <param name="algorithm">algorithm to use to hash</param>
     /// <param name="data">data to be hashed</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the read operation.
+    /// </param>
     /// <returns>A task which contains the hash value</returns>
     /// <exception cref="NotImplementedException">thrown if the provided algorithm is not implemented</exception>
     /// >
-    public async Task<string> GenerateHashForDataAsync(HashingAlgorithm algorithm, string data)
+    public async Task<string> GenerateHashForDataAsync(
+        HashingAlgorithm algorithm,
+        string data,
+        CancellationToken cancellationToken = default
+    )
     {
         switch (algorithm)
         {
             case HashingAlgorithm.MD5:
             {
                 await using var ms = new MemoryStream(Encoding.UTF8.GetBytes(data));
-                var md5HashData = await MD5.HashDataAsync(ms);
+                var md5HashData = await MD5.HashDataAsync(ms, cancellationToken);
                 return Convert.ToHexString(md5HashData).Replace("-", string.Empty);
             }
 
             case HashingAlgorithm.SHA1:
             {
                 await using var ms = new MemoryStream(Encoding.UTF8.GetBytes(data));
-                var sha1HashData = await SHA1.HashDataAsync(ms);
+                var sha1HashData = await SHA1.HashDataAsync(ms, cancellationToken);
                 return Convert.ToHexString(sha1HashData).Replace("-", string.Empty);
             }
         }

--- a/Libraries/SPTarkov.Server.Core/Utils/HashUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/HashUtil.cs
@@ -24,7 +24,7 @@ public sealed class HashUtil(RandomUtil _randomUtil)
     /// </summary>
     /// <param name="filePath">The path to the file</param>
     /// <param name="cancellationToken">
-    /// The <see cref="CancellationToken"/> that can be used to cancel the read operation.
+    /// The <see cref="CancellationToken"/> that can be used to cancel the hashing operation.
     /// </param>
     /// <returns>The CRC32 hash as a uint</returns>
     public async Task<uint> GenerateCrc32ForFileAsync(string filePath, CancellationToken cancellationToken = default)
@@ -80,7 +80,7 @@ public sealed class HashUtil(RandomUtil _randomUtil)
     /// <param name="algorithm">algorithm to use to hash</param>
     /// <param name="data">data to be hashed</param>
     /// <param name="cancellationToken">
-    /// The <see cref="CancellationToken"/> that can be used to cancel the read operation.
+    /// The <see cref="CancellationToken"/> that can be used to cancel the hashing operation.
     /// </param>
     /// <returns>A task which contains the hash value</returns>
     /// <exception cref="NotImplementedException">thrown if the provided algorithm is not implemented</exception>

--- a/Libraries/SPTarkov.Server.Core/Utils/HttpFileUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/HttpFileUtil.cs
@@ -7,7 +7,7 @@ namespace SPTarkov.Server.Core.Utils;
 [Injectable]
 public sealed class HttpFileUtil(HttpServerHelper httpServerHelper)
 {
-    public async Task SendFile(HttpResponse resp, string filePath)
+    public async Task SendFileAsync(HttpResponse resp, string filePath, CancellationToken cancellationToken = default)
     {
         var pathSlice = filePath.Split("/");
         var mimePath = httpServerHelper.GetMimeText(pathSlice[^1].Split(".")[^1]);
@@ -16,6 +16,6 @@ public sealed class HttpFileUtil(HttpServerHelper httpServerHelper)
         resp.Headers.Append("Content-Type", type);
         resp.Headers.Append("Content-Length", fileInfo.Length.ToString());
 
-        await resp.SendFileAsync(filePath, CancellationToken.None);
+        await resp.SendFileAsync(filePath, cancellationToken);
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Utils/ImporterUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/ImporterUtil.cs
@@ -17,8 +17,8 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
 
     public async Task<T> LoadRecursiveAsync<T>(
         string filePath,
-        Func<string, Task>? onReadCallback = null,
-        Func<string, object, Task>? onObjectDeserialized = null,
+        Func<string, CancellationToken, Task>? onReadCallback = null,
+        Func<string, object, CancellationToken, Task>? onObjectDeserialized = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -41,11 +41,13 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
     private async Task<object> LoadRecursiveAsync(
         string filePath,
         Type loadedType,
-        Func<string, Task>? onReadCallback = null,
-        Func<string, object, Task>? onObjectDeserialized = null,
+        Func<string, CancellationToken, Task>? onReadCallback = null,
+        Func<string, object, CancellationToken, Task>? onObjectDeserialized = null,
         CancellationToken cancellationToken = default
     )
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var tasks = new List<Task>();
         var dictionaryLock = new Lock();
         var result = Activator.CreateInstance(loadedType);
@@ -57,6 +59,8 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
         // Process files
         foreach (var file in files)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (
                 fileUtil.GetFileExtension(file) != "json"
                 || _filesToIgnore.Contains(fileUtil.GetFileNameAndExtension(file).ToLowerInvariant())
@@ -71,6 +75,8 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
         // Process directories
         foreach (var directory in directories)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (_directoriesToIgnore.Contains(directory))
             {
                 continue;
@@ -98,19 +104,23 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
     private async Task ProcessFileAsync(
         string file,
         Type loadedType,
-        Func<string, Task>? onReadCallback,
-        Func<string, object, Task>? onObjectDeserialized,
+        Func<string, CancellationToken, Task>? onReadCallback,
+        Func<string, object, CancellationToken, Task>? onObjectDeserialized,
         object result,
         Lock dictionaryLock,
         CancellationToken cancellationToken = default
     )
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         try
         {
             if (onReadCallback != null)
             {
-                await onReadCallback(file);
+                await onReadCallback(file, cancellationToken);
             }
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Get the set method to update the object
             var setMethod = GetSetMethod(
@@ -124,13 +134,17 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
 
             if (onObjectDeserialized != null)
             {
-                await onObjectDeserialized(file, fileDeserialized);
+                await onObjectDeserialized(file, fileDeserialized, cancellationToken);
             }
 
             lock (dictionaryLock)
             {
                 setMethod.Invoke(result, isDictionary ? [fileUtil.StripExtension(file), fileDeserialized] : [fileDeserialized]);
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -143,12 +157,14 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
         string directory,
         Type loadedType,
         object result,
-        Func<string, Task>? onReadCallback,
-        Func<string, object, Task>? onObjectDeserialized,
+        Func<string, CancellationToken, Task>? onReadCallback,
+        Func<string, object, CancellationToken, Task>? onObjectDeserialized,
         Lock dictionaryLock,
         CancellationToken cancellationToken = default
     )
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         try
         {
             var directoryName = directory.Split("/").Last().Replace("_", "");
@@ -168,6 +184,8 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
                     onObjectDeserialized,
                     cancellationToken
                 );
+
+                cancellationToken.ThrowIfCancellationRequested();
 
                 lock (dictionaryLock)
                 {
@@ -195,6 +213,10 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
                     setMethod.Invoke(result, isDictionary ? [directory, loadedData] : [loadedData]);
                 }
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/Libraries/SPTarkov.Server.Core/Utils/ImporterUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/ImporterUtil.cs
@@ -18,10 +18,11 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
     public async Task<T> LoadRecursiveAsync<T>(
         string filePath,
         Func<string, Task>? onReadCallback = null,
-        Func<string, object, Task>? onObjectDeserialized = null
+        Func<string, object, Task>? onObjectDeserialized = null,
+        CancellationToken cancellationToken = default
     )
     {
-        var result = await LoadRecursiveAsync(filePath, typeof(T), onReadCallback, onObjectDeserialized);
+        var result = await LoadRecursiveAsync(filePath, typeof(T), onReadCallback, onObjectDeserialized, cancellationToken);
 
         return (T)result;
     }
@@ -33,12 +34,16 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
     /// <param name="loadedType"></param>
     /// <param name="onReadCallback"></param>
     /// <param name="onObjectDeserialized"></param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the loading operation.
+    /// </param>
     /// <returns>Task</returns>
     private async Task<object> LoadRecursiveAsync(
         string filePath,
         Type loadedType,
         Func<string, Task>? onReadCallback = null,
-        Func<string, object, Task>? onObjectDeserialized = null
+        Func<string, object, Task>? onObjectDeserialized = null,
+        CancellationToken cancellationToken = default
     )
     {
         var tasks = new List<Task>();
@@ -60,7 +65,7 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
                 continue;
             }
 
-            tasks.Add(ProcessFileAsync(file, loadedType, onReadCallback, onObjectDeserialized, result, dictionaryLock));
+            tasks.Add(ProcessFileAsync(file, loadedType, onReadCallback, onObjectDeserialized, result, dictionaryLock, cancellationToken));
         }
 
         // Process directories
@@ -71,7 +76,17 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
                 continue;
             }
 
-            tasks.Add(ProcessDirectoryAsync(directory, loadedType, result, onReadCallback, onObjectDeserialized, dictionaryLock));
+            tasks.Add(
+                ProcessDirectoryAsync(
+                    directory,
+                    loadedType,
+                    result,
+                    onReadCallback,
+                    onObjectDeserialized,
+                    dictionaryLock,
+                    cancellationToken
+                )
+            );
         }
 
         // Wait for all tasks to finish
@@ -86,7 +101,8 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
         Func<string, Task>? onReadCallback,
         Func<string, object, Task>? onObjectDeserialized,
         object result,
-        Lock dictionaryLock
+        Lock dictionaryLock,
+        CancellationToken cancellationToken = default
     )
     {
         try
@@ -104,7 +120,7 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
                 out var isDictionary
             );
 
-            var fileDeserialized = await DeserializeFileAsync(file, propertyType);
+            var fileDeserialized = await DeserializeFileAsync(file, propertyType, cancellationToken);
 
             if (onObjectDeserialized != null)
             {
@@ -129,7 +145,8 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
         object result,
         Func<string, Task>? onReadCallback,
         Func<string, object, Task>? onObjectDeserialized,
-        Lock dictionaryLock
+        Lock dictionaryLock,
+        CancellationToken cancellationToken = default
     )
     {
         try
@@ -144,7 +161,13 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
 
                 GetSetMethod(parentName, loadedType, out var matchedProperty, out _);
 
-                var loadedData = await LoadRecursiveAsync($"{directory}/", matchedProperty, onReadCallback, onObjectDeserialized);
+                var loadedData = await LoadRecursiveAsync(
+                    $"{directory}/",
+                    matchedProperty,
+                    onReadCallback,
+                    onObjectDeserialized,
+                    cancellationToken
+                );
 
                 lock (dictionaryLock)
                 {
@@ -159,7 +182,13 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
             {
                 var setMethod = GetSetMethod(directoryName, loadedType, out var matchedProperty, out var isDictionary);
 
-                var loadedData = await LoadRecursiveAsync($"{directory}/", matchedProperty, onReadCallback, onObjectDeserialized);
+                var loadedData = await LoadRecursiveAsync(
+                    $"{directory}/",
+                    matchedProperty,
+                    onReadCallback,
+                    onObjectDeserialized,
+                    cancellationToken
+                );
 
                 lock (dictionaryLock)
                 {
@@ -173,14 +202,14 @@ public sealed class ImporterUtil(ISptLogger<ImporterUtil> logger, FileUtil fileU
         }
     }
 
-    private async Task<object> DeserializeFileAsync(string file, Type propertyType)
+    private async Task<object> DeserializeFileAsync(string file, Type propertyType, CancellationToken cancellationToken = default)
     {
         if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(LazyLoad<>))
         {
             return CreateLazyLoadDeserialization(file, propertyType);
         }
 
-        return await jsonUtil.DeserializeFromFileAsync(file, propertyType);
+        return await jsonUtil.DeserializeFromFileAsync(file, propertyType, cancellationToken);
     }
 
     private object CreateLazyLoadDeserialization(string file, Type propertyType)

--- a/Libraries/SPTarkov.Server.Core/Utils/JsonUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/JsonUtil.cs
@@ -82,8 +82,11 @@ public class JsonUtil
     ///     Convert JSON into an object from a file asynchronously
     /// </summary>
     /// <param name="file">The JSON File to read</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the read operation.
+    /// </param>
     /// <returns>T</returns>
-    public async Task<T?> DeserializeFromFileAsync<T>(string file)
+    public async Task<T?> DeserializeFromFileAsync<T>(string file, CancellationToken cancellationToken = default)
     {
         if (!File.Exists(file))
         {
@@ -92,7 +95,7 @@ public class JsonUtil
 
         await using FileStream fs = new(file, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
-        return await JsonSerializer.DeserializeAsync<T>(fs, JsonSerializerOptionsNoIndent);
+        return await JsonSerializer.DeserializeAsync<T>(fs, JsonSerializerOptionsNoIndent, cancellationToken);
     }
 
     /// <summary>
@@ -119,8 +122,11 @@ public class JsonUtil
     /// </summary>
     /// <param name="file">The JSON File to read</param>
     /// <param name="type">The type of the object to deserialize to</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the deserialization operation.
+    /// </param>
     /// <returns>object</returns>
-    public async Task<object?> DeserializeFromFileAsync(string file, Type type)
+    public async Task<object?> DeserializeFromFileAsync(string file, Type type, CancellationToken cancellationToken = default)
     {
         if (!File.Exists(file))
         {
@@ -129,7 +135,7 @@ public class JsonUtil
 
         await using FileStream fs = new(file, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
-        return await JsonSerializer.DeserializeAsync(fs, type, JsonSerializerOptionsNoIndent);
+        return await JsonSerializer.DeserializeAsync(fs, type, JsonSerializerOptionsNoIndent, cancellationToken);
     }
 
     /// <summary>
@@ -148,20 +154,26 @@ public class JsonUtil
     /// </summary>
     /// <param name="fs">The file stream to deserialize</param>
     /// <param name="type">The type of the object to deserialize to</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the deserialization operation.
+    /// </param>
     /// <returns></returns>
-    public async Task<object?> DeserializeFromFileStreamAsync(FileStream fs, Type type)
+    public async Task<object?> DeserializeFromFileStreamAsync(FileStream fs, Type type, CancellationToken cancellationToken = default)
     {
-        return await JsonSerializer.DeserializeAsync(fs, type, JsonSerializerOptionsNoIndent);
+        return await JsonSerializer.DeserializeAsync(fs, type, JsonSerializerOptionsNoIndent, cancellationToken);
     }
 
     /// <summary>
     ///     Convert JSON into an object from a MemoryStream asynchronously
     /// </summary>
     /// <param name="ms">The memory stream to deserialize</param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> that can be used to cancel the deserialization operation.
+    /// </param>
     /// <returns>T</returns>
-    public async Task<T?> DeserializeFromMemoryStreamAsync<T>(MemoryStream ms)
+    public async Task<T?> DeserializeFromMemoryStreamAsync<T>(MemoryStream ms, CancellationToken cancellationToken = default)
     {
-        return await JsonSerializer.DeserializeAsync<T>(ms, JsonSerializerOptionsNoIndent);
+        return await JsonSerializer.DeserializeAsync<T>(ms, JsonSerializerOptionsNoIndent, cancellationToken);
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Utils/JsonUtil.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/JsonUtil.cs
@@ -83,7 +83,7 @@ public class JsonUtil
     /// </summary>
     /// <param name="file">The JSON File to read</param>
     /// <param name="cancellationToken">
-    /// The <see cref="CancellationToken"/> that can be used to cancel the read operation.
+    /// The <see cref="CancellationToken"/> that can be used to cancel the deserialization operation.
     /// </param>
     /// <returns>T</returns>
     public async Task<T?> DeserializeFromFileAsync<T>(string file, CancellationToken cancellationToken = default)

--- a/Libraries/SPTarkov.Server.Core/Utils/Watermark.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Watermark.cs
@@ -50,7 +50,7 @@ public class Watermark(
     protected readonly List<string> text = [];
     protected string versionLabel = string.Empty;
 
-    public virtual Task OnLoad(CancellationToken stoppingToken)
+    public virtual Task OnLoad(CancellationToken cancellationToken)
     {
         var versionTag = GetVersionTag();
 

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -194,7 +194,10 @@ public static class Program
 
         app.UseNoGCRegions();
 
-        app.Use(async (context, next) => await context.RequestServices.GetRequiredService<HttpServer>().HandleRequest(context, next));
+        app.Use(
+            async (context, next) =>
+                await context.RequestServices.GetRequiredService<HttpServer>().HandleRequestAsync(context, next, context.RequestAborted)
+        );
 
         app.UseSptBlazor();
     }

--- a/Testing/TestMod/TestMod.cs
+++ b/Testing/TestMod/TestMod.cs
@@ -28,7 +28,7 @@ public record TestModMetadata : AbstractModMetadata, IModWebMetadata
 [Injectable(TypePriority = OnLoadOrder.PostDBModLoader + 1)]
 public class TestMod(ISptLogger<TestMod> logger) : IOnLoad
 {
-    public async Task OnLoad(CancellationToken stoppingToken)
+    public async Task OnLoad(CancellationToken cancellationToken)
     {
         logger.Info("Test mod loading!");
 

--- a/Testing/TestMod2/TestMod2.cs
+++ b/Testing/TestMod2/TestMod2.cs
@@ -28,7 +28,7 @@ public record TestMod2Metadata : AbstractModMetadata, IModWebMetadata
 [Injectable(TypePriority = OnLoadOrder.PostDBModLoader + 1)]
 public class TestMod2(ISptLogger<TestMod2> logger) : IOnLoad
 {
-    public async Task OnLoad(CancellationToken stoppingToken)
+    public async Task OnLoad(CancellationToken cancellationToken)
     {
         logger.Info("Test mod 2 loading!");
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/sp-tarkov/server-csharp/commit/49dfcedbeda2647abb528b4badbd5ca6440d0d4c

- It gives every async method a cancellationToken, allowing for graceful cancellation of operations
- It modifies the router to pass a cancellation through from `HttpContext.RequestAborted` so that if an HTTP request closes it's connection, operations can be cancelled
- Fixes inconsistent async method naming by ensuring async methods use the Async suffix
- It adds docs to `IOnLoad` and `IOnUpdate`

