### PR TITLE
Extend `MongoId` to construct from `ReadOnlySpan`

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Generators/Bot/BotWeaponGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/Bot/BotWeaponGenerator.cs
@@ -710,7 +710,7 @@ public class BotWeaponGenerator(
         }
 
         var magazineTemplate = itemHelper.GetItem(
-            magazineSlot.Properties?.Filters.FirstOrDefault()?.Filter?.FirstOrDefault() ?? new MongoId(null)
+            magazineSlot.Properties?.Filters.FirstOrDefault()?.Filter?.FirstOrDefault() ?? MongoId.Empty()
         );
         if (!magazineTemplate.Key)
         {

--- a/Libraries/SPTarkov.Server.Core/Helpers/Bot/BotWeaponGeneratorHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Bot/BotWeaponGeneratorHelper.cs
@@ -38,7 +38,7 @@ public class BotWeaponGeneratorHelper(
         {
             var firstSlotAmmoTpl =
                 magTemplate.Properties?.Cartridges?.FirstOrDefault()?.Properties?.Filters?.First().Filter?.FirstOrDefault()
-                ?? new MongoId(null);
+                ?? MongoId.Empty();
             var ammoMaxStackSize = itemHelper.GetItem(firstSlotAmmoTpl).Value?.Properties?.StackMaxSize ?? 1;
             chamberBulletCount =
                 ammoMaxStackSize == 1

--- a/Libraries/SPTarkov.Server.Core/Models/Common/MongoId.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Common/MongoId.cs
@@ -1,5 +1,6 @@
 ﻿using System.Buffers.Binary;
 using System.Security.Cryptography;
+using System.Text;
 using SPTarkov.Server.Core.Extensions;
 
 namespace SPTarkov.Server.Core.Models.Common;
@@ -88,7 +89,10 @@ public readonly struct MongoId : IEquatable<MongoId>, IComparable<MongoId>
 
         if (hex.Length != 24)
         {
-            throw new ArgumentException("ObjectId must be a 24-character hex string.", nameof(hex));
+            throw new ArgumentException(
+                $"ObjectId must be a 24-character hex string, but got \"{hex}\" (length {hex.Length}).",
+                nameof(hex)
+            );
         }
 
         Span<byte> bytes = stackalloc byte[12];
@@ -119,7 +123,10 @@ public readonly struct MongoId : IEquatable<MongoId>, IComparable<MongoId>
 
         if (hex.Length != 24)
         {
-            throw new ArgumentException("ObjectId must be a 24-character hex string.", nameof(hex));
+            throw new ArgumentException(
+                $"ObjectId must be a 24-character hex string, but got \"{Encoding.UTF8.GetString(hex)}\" (length {hex.Length}).",
+                nameof(hex)
+            );
         }
 
         Span<byte> bytes = stackalloc byte[12];

--- a/Libraries/SPTarkov.Server.Core/Models/Common/MongoId.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Common/MongoId.cs
@@ -78,9 +78,9 @@ public readonly struct MongoId : IEquatable<MongoId>, IComparable<MongoId>
         _pidAndIncrement = BitConverter.ToInt32(bytes[8..]);
     }
 
-    public MongoId(string? hex)
+    public MongoId(ReadOnlySpan<char> hex)
     {
-        if (string.IsNullOrEmpty(hex) || hex == "000000000000000000000000")
+        if (hex.IsEmpty)
         {
             this = default;
             return;
@@ -88,7 +88,7 @@ public readonly struct MongoId : IEquatable<MongoId>, IComparable<MongoId>
 
         if (hex.Length != 24)
         {
-            throw new ArgumentException("ObjectId must be a 24-character hex string.", hex);
+            throw new ArgumentException("ObjectId must be a 24-character hex string.", nameof(hex));
         }
 
         Span<byte> bytes = stackalloc byte[12];
@@ -108,6 +108,40 @@ public readonly struct MongoId : IEquatable<MongoId>, IComparable<MongoId>
         _timestampAndMachine = BitConverter.ToInt64(bytes);
         _pidAndIncrement = BitConverter.ToInt32(bytes[8..]);
     }
+
+    public MongoId(ReadOnlySpan<byte> hex)
+    {
+        if (hex.IsEmpty)
+        {
+            this = default;
+            return;
+        }
+
+        if (hex.Length != 24)
+        {
+            throw new ArgumentException("ObjectId must be a 24-character hex string.", nameof(hex));
+        }
+
+        Span<byte> bytes = stackalloc byte[12];
+        for (var i = 0; i < 12; i++)
+        {
+            var hi = HexCharToValue((char)hex[2 * i]);
+            var lo = HexCharToValue((char)hex[(2 * i) + 1]);
+
+            if (hi == -1 || lo == -1)
+            {
+                throw new FormatException("ObjectId contains invalid hex characters.");
+            }
+
+            bytes[i] = (byte)((hi << 4) | lo);
+        }
+
+        _timestampAndMachine = BitConverter.ToInt64(bytes);
+        _pidAndIncrement = BitConverter.ToInt32(bytes[8..]);
+    }
+
+    public MongoId(string? hex)
+        : this(hex.AsSpan()) { }
 
     /// <summary>
     /// Converts a hexadecimal character into its corresponding integer nibble value.

--- a/Libraries/SPTarkov.Server.Core/Services/Ragfair/RagfairLinkedItemService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Ragfair/RagfairLinkedItemService.cs
@@ -123,7 +123,7 @@ public class RagfairLinkedItemService(TemplateTable templateTable, ItemHelper it
         }
 
         // Get the first cylinder filter tpl
-        var cylinderTpl = cylinderMod.Properties?.Filters?.First().Filter?.FirstOrDefault() ?? new MongoId(null);
+        var cylinderTpl = cylinderMod.Properties?.Filters?.First().Filter?.FirstOrDefault() ?? MongoId.Empty();
 
         if (!cylinderTpl.IsValidMongoId())
         {

--- a/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/StringToMongoIdConverter.cs
+++ b/Libraries/SPTarkov.Server.Core/Utils/Json/Converters/StringToMongoIdConverter.cs
@@ -8,12 +8,30 @@ public sealed class StringToMongoIdConverter : JsonConverter<MongoId>
 {
     public override MongoId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TokenType == JsonTokenType.String)
+        if (reader.TokenType is not JsonTokenType.String)
         {
-            return new MongoId(reader.GetString());
+            throw new JsonException($"The JsonTokenType was not of type string, it was: {reader.TokenType}");
         }
 
-        throw new JsonException($"The JsonTokenType was not of type string, it was: {reader.TokenType}");
+        return Read(ref reader);
+    }
+
+    // Deserialize MongoId as a dictionary key
+    public override MongoId ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return Read(ref reader);
+    }
+
+    private static MongoId Read(ref Utf8JsonReader reader)
+    {
+        if (!reader.HasValueSequence && !reader.ValueIsEscaped)
+        {
+            return new MongoId(reader.ValueSpan);
+        }
+
+        Span<char> buffer = stackalloc char[24];
+        var written = reader.CopyString(buffer);
+        return new MongoId(buffer[..written]);
     }
 
     public override void Write(Utf8JsonWriter writer, MongoId mongoId, JsonSerializerOptions options)
@@ -27,12 +45,6 @@ public sealed class StringToMongoIdConverter : JsonConverter<MongoId>
         {
             throw new JsonException("Failed to format MongoId to stack buffer.");
         }
-    }
-
-    // Deserialize MongoId as a dictionary key
-    public override MongoId ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        return new MongoId(reader.GetString());
     }
 
     // Serialize MongoId as a dictionary key

--- a/Testing/UnitTests/Tests/MongoIDTests.cs
+++ b/Testing/UnitTests/Tests/MongoIDTests.cs
@@ -56,7 +56,7 @@ public class MongoIDTests
     public void Constructor_EmptyAndNull_ReturnsDefaultInstance()
     {
         // Arrange & Act
-        var fromNull = new MongoId(null);
+        var fromNull = MongoId.Empty();
         var fromEmpty = new MongoId(string.Empty);
         var fromZeroes = new MongoId(ZeroHexZeroHex);
         var defaultInstance = default(MongoId);


### PR DESCRIPTION
Allows `MongoId` to construct from span's for non allocation purposes

Tests seem to pass and going in-game is fine even while using `MongoId.Empty()` rather than `new MongoId(null)`