### PR TITLE
Hash web panel passwords with Argon2id

### DIFF
--- a/Libraries/SPTarkov.Server.Web/Pages/UserCredentialsPage.razor
+++ b/Libraries/SPTarkov.Server.Web/Pages/UserCredentialsPage.razor
@@ -271,7 +271,13 @@
     private void RefreshCredentials()
     {
         _credentials.Clear();
-        _credentials.AddRange(AuthService.Credentials.OrderBy(credential => credential.Username));
+
+        // The panel only needs the username and role. Empty the password.
+        _credentials.AddRange(
+            AuthService.Credentials
+                .OrderBy(credential => credential.Username)
+                .Select(credential => credential with { Password = string.Empty })
+        );
 
         if (_selectedUsername is not null && _credentials.All(credential => credential.Username != _selectedUsername))
         {
@@ -282,7 +288,7 @@
     private async Task CreateCredential()
     {
         var username = _newUsername.Trim();
-        var password = _newPassword.Trim();
+        var password = _newPassword;
         var isAdministrator = _newIsAdministrator;
 
         if (string.IsNullOrWhiteSpace(username))
@@ -306,7 +312,7 @@
             }
 
             _selectedUsername = username;
-            _editPassword = password;
+            _editPassword = string.Empty;
             _newUsername = string.Empty;
             _newPassword = string.Empty;
             _newIsAdministrator = true;
@@ -322,7 +328,7 @@
         }
 
         var username = SelectedCredential.Username;
-        var password = _editPassword.Trim();
+        var password = _editPassword;
 
         await RunCredentialAction(async () =>
         {
@@ -410,7 +416,7 @@
         }
 
         _selectedUsername = args.Item.Username;
-        _editPassword = args.Item.Password;
+        _editPassword = string.Empty;
         _deleteConfirmation = string.Empty;
 
         return Task.CompletedTask;

--- a/Libraries/SPTarkov.Server.Web/SPTWeb.cs
+++ b/Libraries/SPTarkov.Server.Web/SPTWeb.cs
@@ -163,14 +163,15 @@ public static class SPTWeb
         var username = form["username"].ToString();
         var password = form["password"].ToString();
 
-        if (!authService.TryValidateCredentials(username, password, context, out var principal) || principal is null)
+        var authenticatedUser = await authService.ValidateCredentialsAsync(username, password, context);
+        if (authenticatedUser is null)
         {
             return Results.Redirect(AuthService.AddLoginError(failureUrl));
         }
 
         await context.SignInAsync(
             AuthService.AuthenticationScheme,
-            principal,
+            authenticatedUser,
             new AuthenticationProperties { IsPersistent = true, AllowRefresh = true }
         );
 

--- a/Libraries/SPTarkov.Server.Web/SPTarkov.Server.Web.csproj
+++ b/Libraries/SPTarkov.Server.Web/SPTarkov.Server.Web.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SPTarkov.Server.Core\SPTarkov.Server.Core.csproj" />

--- a/Libraries/SPTarkov.Server.Web/SPTarkov.Server.Web.csproj
+++ b/Libraries/SPTarkov.Server.Web/SPTarkov.Server.Web.csproj
@@ -21,8 +21,8 @@
     <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Argon2Sharp" Version="4.0.1" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SPTarkov.Server.Core\SPTarkov.Server.Core.csproj" />

--- a/Libraries/SPTarkov.Server.Web/Services/Argon2idPasswordHasher.cs
+++ b/Libraries/SPTarkov.Server.Web/Services/Argon2idPasswordHasher.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using ScottBrady91.AspNetCore.Identity;
+using SPTarkov.DI.Annotations;
+
+namespace SPTarkov.Server.Web.Services;
+
+[Injectable(InjectionType.Singleton)]
+public class Argon2idPasswordHasher : IPasswordHasher
+{
+    private const Argon2HashStrength Strength = Argon2HashStrength.Interactive;
+
+    private static readonly object _dummyUser = new(); // Shared instance avoids per-call allocation.
+
+    private readonly Argon2PasswordHasher<object> _hasher = new(Options.Create(new Argon2PasswordHasherOptions { Strength = Strength }));
+
+    public Argon2idPasswordHasher()
+    {
+        DummyHash = Hash(Guid.NewGuid().ToString("N"));
+    }
+
+    public string DummyHash { get; }
+
+    public string Hash(string password)
+    {
+        return _hasher.HashPassword(_dummyUser, password);
+    }
+
+    public bool IsEncodedHash(string value)
+    {
+        // Argon2 hashes are always strings that start with the variant marker, e.g. "$argon2id$".
+        return !string.IsNullOrEmpty(value) && value.StartsWith("$argon2", StringComparison.Ordinal);
+    }
+
+    public bool Verify(string password, string encodedHash, out bool needsRehash)
+    {
+        needsRehash = false;
+
+        if (string.IsNullOrEmpty(encodedHash) || string.IsNullOrEmpty(password))
+        {
+            return false;
+        }
+
+        PasswordVerificationResult result;
+        try
+        {
+            result = _hasher.VerifyHashedPassword(_dummyUser, encodedHash, password);
+        }
+        catch
+        {
+            return false; // Always fail closed.
+        }
+
+        if (result == PasswordVerificationResult.Failed)
+        {
+            return false;
+        }
+
+        needsRehash = result == PasswordVerificationResult.SuccessRehashNeeded;
+        return true;
+    }
+}

--- a/Libraries/SPTarkov.Server.Web/Services/Argon2idPasswordHasher.cs
+++ b/Libraries/SPTarkov.Server.Web/Services/Argon2idPasswordHasher.cs
@@ -1,6 +1,4 @@
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Options;
-using ScottBrady91.AspNetCore.Identity;
+using Argon2Sharp;
 using SPTarkov.DI.Annotations;
 
 namespace SPTarkov.Server.Web.Services;
@@ -8,11 +6,25 @@ namespace SPTarkov.Server.Web.Services;
 [Injectable(InjectionType.Singleton)]
 public class Argon2idPasswordHasher : IPasswordHasher
 {
-    private const Argon2HashStrength Strength = Argon2HashStrength.Interactive;
+    // Cost parameters for newly created hashes. RFC 9106's memory-constrained "uniformly safe" recommendation is currently (2026-06-15)
+    // 64 MiB of memory, 3 iterations, 4 lanes, a 128-bit salt, and a 256-bit tag.
+    private const int MemorySizeKB = 65536;
+    private const int Iterations = 3;
+    private const int Parallelism = 4;
+    private const int HashLength = 32;
+    private const int SaltLength = 16;
+    private const Argon2Type Variant = Argon2Type.Argon2id;
 
-    private static readonly object _dummyUser = new(); // Shared instance avoids per-call allocation.
-
-    private readonly Argon2PasswordHasher<object> _hasher = new(Options.Create(new Argon2PasswordHasherOptions { Strength = Strength }));
+    // Immutable cost template reused across calls. The salt is a placeholder.
+    private readonly Argon2Parameters _parameters = Argon2Parameters
+        .CreateBuilder()
+        .WithType(Variant)
+        .WithMemorySizeKB(MemorySizeKB)
+        .WithIterations(Iterations)
+        .WithParallelism(Parallelism)
+        .WithHashLength(HashLength)
+        .WithRandomSalt(SaltLength)
+        .Build();
 
     public Argon2idPasswordHasher()
     {
@@ -23,7 +35,7 @@ public class Argon2idPasswordHasher : IPasswordHasher
 
     public string Hash(string password)
     {
-        return _hasher.HashPassword(_dummyUser, password);
+        return Argon2PhcFormat.HashToPhcStringWithAutoSalt(password, _parameters, SaltLength);
     }
 
     public bool IsEncodedHash(string value)
@@ -41,22 +53,30 @@ public class Argon2idPasswordHasher : IPasswordHasher
             return false;
         }
 
-        PasswordVerificationResult result;
+        bool isValid;
+        Argon2Parameters? stored;
         try
         {
-            result = _hasher.VerifyHashedPassword(_dummyUser, encodedHash, password);
+            (isValid, stored) = Argon2PhcFormat.VerifyPhcString(password, encodedHash);
         }
         catch
         {
             return false; // Always fail closed.
         }
 
-        if (result == PasswordVerificationResult.Failed)
+        if (!isValid || stored is null)
         {
             return false;
         }
 
-        needsRehash = result == PasswordVerificationResult.SuccessRehashNeeded;
+        // Flag the hash for upgrade on the next login when it was produced with cost parameters other than current.
+        needsRehash =
+            stored.MemorySizeKB != MemorySizeKB
+            || stored.Iterations != Iterations
+            || stored.Parallelism != Parallelism
+            || stored.HashLength != HashLength
+            || stored.Type != Variant;
+
         return true;
     }
 }

--- a/Libraries/SPTarkov.Server.Web/Services/AuthService.cs
+++ b/Libraries/SPTarkov.Server.Web/Services/AuthService.cs
@@ -1,7 +1,5 @@
 using System.Net;
 using System.Security.Claims;
-using System.Security.Cryptography;
-using System.Text;
 using SPTarkov.Common.Models.Logging;
 using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.DI;
@@ -11,7 +9,7 @@ using SPTarkov.Server.Core.Utils;
 namespace SPTarkov.Server.Web.Services;
 
 [Injectable(InjectionType.Singleton)]
-public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, JsonUtil jsonUtil) : IOnLoad
+public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, JsonUtil jsonUtil, IPasswordHasher passwordHasher) : IOnLoad
 {
     internal const string AuthenticationScheme = "SptWebCookie";
     internal const string AdministratorPolicy = "Administrator";
@@ -71,7 +69,7 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
             new AuthUserCredential()
             {
                 Username = username,
-                Password = password,
+                Password = passwordHasher.Hash(password),
                 IsAdministrator = isAdministrator,
             }
         );
@@ -87,7 +85,7 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
             return false;
         }
 
-        credential.Password = password;
+        credential.Password = passwordHasher.Hash(password);
         await SaveCredentials();
 
         return true;
@@ -122,15 +120,13 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
         return true;
     }
 
-    internal bool TryValidateCredentials(string username, string password, HttpContext httpContext, out ClaimsPrincipal? principal)
+    internal async Task<ClaimsPrincipal?> ValidateCredentialsAsync(string username, string password, HttpContext httpContext)
     {
-        principal = null;
         var authenticationConfig = httpConfig.WebAuthenticationConfig;
 
         if (!authenticationConfig.Enabled)
         {
-            principal = CreateDefaultPrincipal();
-            return true;
+            return CreateDefaultPrincipal();
         }
 
         var defaultUser = authenticationConfig.DefaultUser;
@@ -138,30 +134,45 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
         {
             if (!authenticationConfig.EnableDefaultUser)
             {
-                return false;
+                return null;
             }
 
             if (!authenticationConfig.AllowDefaultUserFromAnyIp && !IsLocalRequest(httpContext))
             {
-                return false;
+                return null;
             }
         }
 
         if (!TryGetCredentials(username, out var credentials) || credentials is null)
         {
-            return false;
+            // Spend the same work on a missing user as a real verification.
+            _ = passwordHasher.Verify(password, passwordHasher.DummyHash, out _);
+
+            return null;
         }
 
-        var usernameMatches = SecureEquals(username, credentials.Username);
-        var passwordMatches = SecureEquals(password, credentials.Password);
-
-        if (!(usernameMatches & passwordMatches))
+        if (!passwordHasher.Verify(password, credentials.Password, out var needsRehash))
         {
-            return false;
+            return null;
         }
 
-        principal = CreatePrincipal(credentials.Username, credentials.IsAdministrator);
-        return true;
+        // Upgrade hashes created with out-of-date parameters on the next successful login.
+        // ReSharper disable once InvertIf
+        if (needsRehash)
+        {
+            credentials.Password = passwordHasher.Hash(password);
+
+            try
+            {
+                await SaveCredentials();
+            }
+            catch (Exception exception)
+            {
+                logger.Warning($"Failed to persist rehashed web credential for '{credentials.Username}': {exception.Message}");
+            }
+        }
+
+        return CreatePrincipal(credentials.Username, credentials.IsAdministrator);
     }
 
     internal static string GetSafeReturnUrl(string? returnUrl)
@@ -229,14 +240,6 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
         return localIpAddress is not null && remoteIpAddress.Equals(localIpAddress);
     }
 
-    private static bool SecureEquals(string suppliedValue, string expectedValue)
-    {
-        var suppliedBytes = Encoding.UTF8.GetBytes(suppliedValue);
-        var expectedBytes = Encoding.UTF8.GetBytes(expectedValue);
-
-        return CryptographicOperations.FixedTimeEquals(suppliedBytes, expectedBytes);
-    }
-
     private async Task CreateOrLoadUserCredentials()
     {
         var fullPath = Path.GetFullPath(UserCredentialsPath);
@@ -253,11 +256,46 @@ public class AuthService(ISptLogger<AuthService> logger, HttpConfig httpConfig, 
                 await jsonUtil.DeserializeFromFileAsync<List<AuthUserCredential>>(credentialsPath)
                 ?? throw new NullReferenceException("Could not deserialize credentials.json");
 
+            await MigratePlaintextCredentials();
+
             return;
         }
 
-        _credentials = new List<AuthUserCredential>([httpConfig.WebAuthenticationConfig.DefaultUser]);
+        // Seed from the config default user, hashing its plaintext password before it touches disk.
+        var defaultUser = httpConfig.WebAuthenticationConfig.DefaultUser;
+        _credentials =
+        [
+            new AuthUserCredential
+            {
+                Username = defaultUser.Username,
+                Password = passwordHasher.Hash(defaultUser.Password),
+                IsAdministrator = defaultUser.IsAdministrator,
+            },
+        ];
         await SaveCredentials();
+    }
+
+    private async Task MigratePlaintextCredentials()
+    {
+        // Unhashed, plaintext passwords are hashed in place. This allows server administrators to manually set account passwords and have
+        // them hashed on next server reload. Empty entries are left alone as they cannot be meaningfully hashed.
+        var migratedCount = 0;
+        foreach (var credential in _credentials)
+        {
+            if (string.IsNullOrEmpty(credential.Password) || passwordHasher.IsEncodedHash(credential.Password))
+            {
+                continue;
+            }
+
+            credential.Password = passwordHasher.Hash(credential.Password);
+            migratedCount++;
+        }
+
+        if (migratedCount > 0)
+        {
+            await SaveCredentials();
+            logger.Warning($"Migrated {migratedCount} plaintext web credentials to hashes.");
+        }
     }
 
     private async Task SaveCredentials(List<AuthUserCredential>? credentials = null)

--- a/Libraries/SPTarkov.Server.Web/Services/IPasswordHasher.cs
+++ b/Libraries/SPTarkov.Server.Web/Services/IPasswordHasher.cs
@@ -1,0 +1,36 @@
+namespace SPTarkov.Server.Web.Services;
+
+/// <summary>
+/// Hashes and verifies web-panel account passwords.
+/// </summary>
+public interface IPasswordHasher
+{
+    /// <summary>
+    /// Hashes a plaintext password into a hash suitable for storage.
+    /// </summary>
+    string Hash(string password);
+
+    /// <summary>
+    /// Verifies a plaintext password against a previously stored encoded hash. Returns false for a malformed or
+    /// corrupted hash.
+    /// </summary>
+    /// <param name="password">The plaintext password supplied at login.</param>
+    /// <param name="encodedHash">The stored encoded hash to verify against.</param>
+    /// <param name="needsRehash">
+    /// True when the password was correct but the stored hash was produced with cost parameters that differ from the
+    /// current ones, so the caller should re-hash and persist it. Always false on a failed verification.
+    /// </param>
+    bool Verify(string password, string encodedHash, out bool needsRehash);
+
+    /// <summary>
+    /// Returns true when the supplied value is already one of this hasher's encoded hashes, rather than a plaintext
+    /// secret. Used to detect pre-hashing credentials that still need migrating.
+    /// </summary>
+    bool IsEncodedHash(string value);
+
+    /// <summary>
+    /// A throwaway hash whose verification cost matches a real one. Verify a failed login against this so response
+    /// timing is the same whether the supplied username exists.
+    /// </summary>
+    string DummyHash { get; }
+}

--- a/Testing/UnitTests/Tests/Services/Argon2idPasswordHasherTests.cs
+++ b/Testing/UnitTests/Tests/Services/Argon2idPasswordHasherTests.cs
@@ -1,6 +1,5 @@
-using Microsoft.Extensions.Options;
+using Argon2Sharp;
 using NUnit.Framework;
-using ScottBrady91.AspNetCore.Identity;
 using SPTarkov.Server.Web.Services;
 
 namespace UnitTests.Tests.Services;
@@ -57,12 +56,8 @@ public class Argon2idPasswordHasherTests
     {
         const string password = "correct horse battery staple";
 
-        // A hash produced with a different strength than the hasher's current setting should verify but also be flagged
-        // for upgrade.
-        var staleHasher = new Argon2PasswordHasher<object>(
-            Options.Create(new Argon2PasswordHasherOptions { Strength = Argon2HashStrength.Medium })
-        );
-        var staleHash = staleHasher.HashPassword(new object(), password);
+        // A hash produced with weaker cost parameters than the hasher's current settings should verify but also be flagged for upgrade.
+        var staleHash = Argon2PhcFormat.HashToPhcStringWithAutoSalt(password);
 
         var ok = _hasher.Verify(password, staleHash, out var needsRehash);
 

--- a/Testing/UnitTests/Tests/Services/Argon2idPasswordHasherTests.cs
+++ b/Testing/UnitTests/Tests/Services/Argon2idPasswordHasherTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using ScottBrady91.AspNetCore.Identity;
+using SPTarkov.Server.Web.Services;
+
+namespace UnitTests.Tests.Services;
+
+[TestFixture]
+public class Argon2idPasswordHasherTests
+{
+    private Argon2idPasswordHasher _hasher;
+
+    [OneTimeSetUp]
+    public void Initialize()
+    {
+        _hasher = new Argon2idPasswordHasher();
+    }
+
+    [Test]
+    public void HashProducesArgon2idEncodedString()
+    {
+        var hash = _hasher.Hash("correct horse battery staple");
+
+        Assert.That(hash, Does.StartWith("$argon2id$"));
+    }
+
+    [Test]
+    public void VerifyReturnsTrueForCorrectPassword()
+    {
+        const string password = "correct horse battery staple";
+        var hash = _hasher.Hash(password);
+
+        Assert.That(_hasher.Verify(password, hash, out _), Is.True);
+    }
+
+    [Test]
+    public void VerifyReturnsFalseForWrongPassword()
+    {
+        var hash = _hasher.Hash("correct horse battery staple");
+
+        Assert.That(_hasher.Verify("staple battery horse correct", hash, out _), Is.False);
+    }
+
+    [Test]
+    public void VerifyDoesNotFlagRehashForCurrentParameters()
+    {
+        const string password = "correct horse battery staple";
+        var hash = _hasher.Hash(password);
+        var ok = _hasher.Verify(password, hash, out var needsRehash);
+
+        Assert.That(ok, Is.True);
+        Assert.That(needsRehash, Is.False);
+    }
+
+    [Test]
+    public void VerifyFlagsRehashWhenStoredParametersDiffer()
+    {
+        const string password = "correct horse battery staple";
+
+        // A hash produced with a different strength than the hasher's current setting should verify but also be flagged
+        // for upgrade.
+        var staleHasher = new Argon2PasswordHasher<object>(
+            Options.Create(new Argon2PasswordHasherOptions { Strength = Argon2HashStrength.Medium })
+        );
+        var staleHash = staleHasher.HashPassword(new object(), password);
+
+        var ok = _hasher.Verify(password, staleHash, out var needsRehash);
+
+        Assert.That(ok, Is.True);
+        Assert.That(needsRehash, Is.True);
+    }
+
+    [Test]
+    public void HashUsesRandomSaltSoEqualPasswordsHashDifferently()
+    {
+        const string password = "correct horse battery staple";
+
+        Assert.That(_hasher.Hash(password), Is.Not.EqualTo(_hasher.Hash(password)));
+    }
+
+    [Test]
+    public void VerifyFailsClosedOnMalformedHash()
+    {
+        Assert.That(_hasher.Verify("correct horse battery staple", "not a hash", out _), Is.False);
+        Assert.That(_hasher.Verify("correct horse battery staple", string.Empty, out _), Is.False);
+    }
+
+    [Test]
+    public void DummyHashIsAValidArgon2idHash()
+    {
+        Assert.That(_hasher.DummyHash, Does.StartWith("$argon2id$"));
+    }
+
+    [Test]
+    public void IsEncodedHashRecognizesOwnOutput()
+    {
+        Assert.That(_hasher.IsEncodedHash(_hasher.Hash("correct horse battery staple")), Is.True);
+    }
+
+    [Test]
+    public void IsEncodedHashRejectsPlaintextAndEmpty()
+    {
+        Assert.That(_hasher.IsEncodedHash("correct horse battery staple"), Is.False);
+        Assert.That(_hasher.IsEncodedHash(string.Empty), Is.False);
+    }
+}


### PR DESCRIPTION
- Add `IPasswordHasher` and Argon2id implementation
- Hash passwords on create/update instead of storing plaintext
- Passwords are no longer trimmed
- Verify logins against stored hashes
- Rehash credentials when cost parameters change
- Migrate existing plaintext credentials to hashes on startup
- Seed config default user with a hashed password
- Verify failed logins against a dummy hash to keep timing constant
- Stop exposing/editing stored passwords in the credentials UI panel
- Adds some tests for the hasher