### PR TITLE
SIC fix: home button tooltip breaking cursor behaviour due to viewport

### DIFF
--- a/Libraries/SPTarkov.Server.Web/Layout/BaseMudBlazorLayout.razor
+++ b/Libraries/SPTarkov.Server.Web/Layout/BaseMudBlazorLayout.razor
@@ -9,7 +9,7 @@
 <main>
 @if (!IsLandingPage)
 {
-    <MudTooltip Text="Return to landing page">
+    <MudTooltip Text="Return to landing page" Placement="Placement.Right">
         <MudIconButton Icon="@Icons.Material.Filled.Home"
                        Href="/"
                        Variant="Variant.Outlined"

--- a/Libraries/SPTarkov.Server.Web/wwwroot/css/spt-theme.css
+++ b/Libraries/SPTarkov.Server.Web/wwwroot/css/spt-theme.css
@@ -37,7 +37,7 @@ main {
 }
 
 .spt-home-button {
-    position: fixed;
+    position: absolute;
     top: 16px;
     left: 16px;
     z-index: 1200;


### PR DESCRIPTION
moves tooltip to the right
makes home button absolute instead of fixed for viewport behaviour with blazor