### PR TITLE
fix: WebSocket sync-over-async + dead connection detection

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Controllers/DialogueController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/DialogueController.cs
@@ -657,7 +657,9 @@ public class DialogueController(
                     EventType = NotificationEventType.friendListRequestAccept,
                     Profile = profileHelper.GetChatRoomMemberFromPmcProfile(friendProfile.CharacterData.PmcData),
                 };
-                notificationSendHelper.SendMessage(sessionID, notification);
+#pragma warning disable CS4014
+                _ = notificationSendHelper.SendMessageAsync(sessionID, notification); // TODO(debt): Timer callback can't be async
+#pragma warning restore CS4014
             },
             null,
             TimeSpan.FromMicroseconds(1000),

--- a/Libraries/SPTarkov.Server.Core/Controllers/NotifierController.cs
+++ b/Libraries/SPTarkov.Server.Core/Controllers/NotifierController.cs
@@ -20,31 +20,28 @@ public class NotifierController(HttpServerHelper httpServerHelper, NotifierHelpe
     ///     If no notifications are available after the timeout, use a default message.
     /// </summary>
     /// <param name="sessionId">Session/Player id</param>
-    public Task<List<WsNotificationEvent>> NotifyAsync(MongoId sessionId)
+    public async Task<List<WsNotificationEvent>> NotifyAsync(MongoId sessionId)
     {
-        return Task.Factory.StartNew(() =>
+        // keep track of our timeout
+        var counter = 0;
+
+        while (counter < Timeout)
         {
-            // keep track of our timeout
-            var counter = 0;
-
-            while (counter < Timeout)
+            if (!notificationService.Has(sessionId))
             {
-                if (!notificationService.Has(sessionId))
-                {
-                    counter += PollInterval;
-                    Thread.Sleep(PollInterval);
-                }
-                else
-                {
-                    var messages = notificationService.Get(sessionId);
-
-                    notificationService.UpdateMessageOnQueue(sessionId, []);
-                    return messages;
-                }
+                counter += PollInterval;
+                await Task.Delay(PollInterval);
             }
+            else
+            {
+                var messages = notificationService.Get(sessionId);
 
-            return [notifierHelper.GetDefaultNotification()];
-        });
+                notificationService.UpdateMessageOnQueue(sessionId, []);
+                return messages;
+            }
+        }
+
+        return [notifierHelper.GetDefaultNotification()];
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/SPTFriend/Commands/GiveMeSpaceMessageHandler.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Dialogue/SPTFriend/Commands/GiveMeSpaceMessageHandler.cs
@@ -51,7 +51,8 @@ public class GiveMeSpaceMessageHandler(
             const int rowsToAdd = 2;
             var bonusId = profileHelper.AddStashRowsBonusToProfile(sessionId, rowsToAdd);
 
-            notificationSendHelper.SendMessage(
+#pragma warning disable CS4014
+            _ = notificationSendHelper.SendMessageAsync( // TODO(debt): convert Process to async to properly await
                 sessionId,
                 new WsProfileChangeEvent
                 {
@@ -60,6 +61,7 @@ public class GiveMeSpaceMessageHandler(
                     Changes = new Dictionary<string, double?> { { bonusId, rowsToAdd } },
                 }
             );
+#pragma warning restore CS4014
 
             mailSendService.SendUserMessageToPlayer(
                 sessionId,

--- a/Libraries/SPTarkov.Server.Core/Helpers/NotificationSendHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/NotificationSendHelper.cs
@@ -27,7 +27,7 @@ public class NotificationSendHelper(
     /// </summary>
     /// <param name="sessionId">Session/player id</param>
     /// <param name="notificationMessage"></param>
-    public void SendMessage(MongoId sessionId, WsNotificationEvent notificationMessage)
+    public async Task SendMessageAsync(MongoId sessionId, WsNotificationEvent notificationMessage)
     {
         if (logger.IsLogEnabled(LogLevel.Debug))
         {
@@ -40,7 +40,7 @@ public class NotificationSendHelper(
             {
                 logger.Debug($"Send message for {sessionId} websocket available, message being sent");
             }
-            sptWebSocketConnectionHandler.SendMessage(sessionId, notificationMessage);
+            await sptWebSocketConnectionHandler.SendMessageAsync(sessionId, notificationMessage);
             return;
         }
 
@@ -59,48 +59,55 @@ public class NotificationSendHelper(
     /// <param name="senderDetails">Who is sending the message to player</param>
     /// <param name="messageText">Text to send player</param>
     /// <param name="messageType">Underlying type of message being sent</param>
-    public void SendMessageToPlayer(MongoId sessionId, UserDialogInfo senderDetails, string messageText, MessageType messageType)
+    public async Task SendMessageToPlayerAsync(MongoId sessionId, UserDialogInfo senderDetails, string messageText, MessageType messageType)
     {
-        var dialog = GetDialog(sessionId, messageType, senderDetails);
-        if (dialog is null)
+        try
         {
-            // Error is logged in GetDialog
-            return;
-        }
+            var dialog = GetDialog(sessionId, messageType, senderDetails);
+            if (dialog is null)
+            {
+                // Error is logged in GetDialog
+                return;
+            }
 
-        dialog.New += 1;
-        var message = new Message
-        {
-            Id = new MongoId(),
-            UserId = dialog.Id,
-            MessageType = messageType,
-            DateTime = timeUtil.GetTimeStamp(),
-            Text = messageText,
-            HasRewards = null,
-            RewardCollected = null,
-            Items = null,
-        };
+            dialog.New += 1;
+            var message = new Message
+            {
+                Id = new MongoId(),
+                UserId = dialog.Id,
+                MessageType = messageType,
+                DateTime = timeUtil.GetTimeStamp(),
+                Text = messageText,
+                HasRewards = null,
+                RewardCollected = null,
+                Items = null,
+            };
 
-        if (dialog.Messages != null)
-        {
-            dialog.Messages.Add(message);
-        }
-        else
-        {
-            logger.Error(
-                $"Could not add message Id: {message.Id.ToString()} to dialogue for player Id: {sessionId.ToString()}. dialog.Messages is null. Message was not sent."
-            );
-            return;
-        }
+            if (dialog.Messages != null)
+            {
+                dialog.Messages.Add(message);
+            }
+            else
+            {
+                logger.Error(
+                    $"Could not add message Id: {message.Id.ToString()} to dialogue for player Id: {sessionId.ToString()}. dialog.Messages is null. Message was not sent."
+                );
+                return;
+            }
 
-        var notification = new WsChatMessageReceived
+            var notification = new WsChatMessageReceived
+            {
+                EventType = NotificationEventType.new_message,
+                EventIdentifier = message.Id,
+                DialogId = message.UserId,
+                Message = message,
+            };
+            await SendMessageAsync(sessionId, notification);
+        }
+        catch (Exception err)
         {
-            EventType = NotificationEventType.new_message,
-            EventIdentifier = message.Id,
-            DialogId = message.UserId,
-            Message = message,
-        };
-        SendMessage(sessionId, notification);
+            logger.Error($"Failed to send message to player {sessionId}: {err.Message}", err);
+        }
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
@@ -104,7 +104,6 @@ public class RewardHelper(
                     break;
                 case RewardType.StashRows:
                     var bonusId = profileHelper.AddStashRowsBonusToProfile(sessionId.Value, (int)reward.Value); // Add specified stash rows from reward - requires client restart
-
 #pragma warning disable CS4014
                     _ = notificationSendHelper.SendMessageAsync( // TODO(debt): convert ApplyRewards to async to properly await
                         sessionId.Value,

--- a/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/RewardHelper.cs
@@ -105,7 +105,8 @@ public class RewardHelper(
                 case RewardType.StashRows:
                     var bonusId = profileHelper.AddStashRowsBonusToProfile(sessionId.Value, (int)reward.Value); // Add specified stash rows from reward - requires client restart
 
-                    notificationSendHelper.SendMessage(
+#pragma warning disable CS4014
+                    _ = notificationSendHelper.SendMessageAsync( // TODO(debt): convert ApplyRewards to async to properly await
                         sessionId.Value,
                         new WsProfileChangeEvent
                         {
@@ -114,6 +115,7 @@ public class RewardHelper(
                             Changes = new Dictionary<string, double?> { { bonusId, reward.Value } },
                         }
                     );
+#pragma warning restore CS4014
 
                     break;
                 case RewardType.ProductionScheme:
@@ -124,7 +126,8 @@ public class RewardHelper(
                     break;
                 case RewardType.CustomizationDirect:
                     profileHelper.AddHideoutCustomisationUnlock(fullProfile, reward, rewardSource);
-                    notificationSendHelper.SendMessage(
+#pragma warning disable CS4014
+                    _ = notificationSendHelper.SendMessageAsync( // TODO(debt): convert ApplyRewards to async to properly await
                         sessionId.Value,
                         new WsNotificationEvent
                         {
@@ -132,11 +135,14 @@ public class RewardHelper(
                             EventType = NotificationEventType.CustomizationUpdateRequired,
                         }
                     );
+#pragma warning restore CS4014
 
                     break;
                 case RewardType.NotificationPopup:
                     var notification = notifierHelper.CreateNotificationPopup(reward.IllustrationConfig, reward.Message.Value);
-                    notificationSendHelper.SendMessage(sessionId.Value, notification);
+#pragma warning disable CS4014
+                    _ = notificationSendHelper.SendMessageAsync(sessionId.Value, notification); // TODO(debt): convert ApplyRewards to async to properly await
+#pragma warning restore CS4014
                     break;
                 case RewardType.WebPromoCode:
                     // TODO: ??? (Free arena trial from Balancing - Part 1)

--- a/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
@@ -52,120 +52,94 @@ public class WebSocketServer(IEnumerable<IWebSocketConnectionHandler> webSocketC
             logger.Debug($"[WS] Starting read loop for websocket reference {webSocketIdContext}");
         }
 
-        var thread = Task.Factory.StartNew(
-            async () =>
+        try
+        {
+            var messageBuffer = new List<byte>();
+            var receiveBuffer = new byte[1024 * 4];
+
+            while (!wsToken.IsCancellationRequested && webSocket.State == WebSocketState.Open)
             {
-                var messageBuffer = new List<byte>();
-                var receiveBuffer = new byte[1024 * 4];
-                var socketClosing = false;
+                var segment = new ArraySegment<byte>(receiveBuffer);
 
-                while (!wsToken.IsCancellationRequested && !socketClosing)
+                WebSocketReceiveResult? result = null;
+
+                try
                 {
-                    var segment = new ArraySegment<byte>(receiveBuffer);
-
-                    WebSocketReceiveResult? result = null;
-
-                    try
+                    result = await webSocket.ReceiveAsync(segment, wsToken);
+                }
+                catch (WebSocketException wsException)
+                {
+                    if (
+                        wsException.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely
+                        || webSocket.State == WebSocketState.Aborted
+                        || webSocket.State == WebSocketState.Closed
+                    )
                     {
-                        result = await webSocket.ReceiveAsync(segment, wsToken);
-                    }
-                    catch (WebSocketException wsException)
-                    {
-                        if (
-                            wsException.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely
-                            || webSocket.State == WebSocketState.Aborted
-                            || webSocket.State == WebSocketState.Closed
-                        )
-                        {
-                            socketClosing = true;
-                            break;
-                        }
-                    }
-
-                    // Continue handling here, the WebSocket is not closed so we should be good despite being null here
-                    if (result == null)
-                    {
-                        continue;
-                    }
-
-                    // Handle graceful close of the WebSocket
-                    // WebsocketSharp requires this as when Close() is called it will send a message to the WS server that it's about to close.
-                    // If this is not handled an exception is thrown on the client
-                    if (result.MessageType == WebSocketMessageType.Close)
-                    {
-                        logger.Debug($"[WS] WebSocket reference {webSocketIdContext} sent close frame, stopping.");
-                        await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Closing..", wsToken);
-                        socketClosing = true;
                         break;
                     }
-
-                    messageBuffer.AddRange(segment.Take(result.Count));
-
-                    if (result.EndOfMessage)
-                    {
-                        if (logger.IsLogEnabled(LogLevel.Debug))
-                        {
-                            logger.Debug(
-                                $"[WS] Read loop for websocket reference {webSocketIdContext} received new message. Notifying socket handlers."
-                            );
-                        }
-
-                        var message = messageBuffer.ToArray();
-
-                        foreach (var wsh in socketHandlers)
-                        {
-                            await wsh.OnMessage(message, WebSocketMessageType.Text, webSocket, context);
-                        }
-
-                        messageBuffer.Clear();
-                    }
                 }
-            },
-            wsToken,
-            TaskCreationOptions.LongRunning,
-            TaskScheduler.Default
-        );
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
 
-        var counter = 0;
-        while (webSocket.State == WebSocketState.Open)
-        {
-            if (counter == 30 && logger.IsLogEnabled(LogLevel.Debug))
-            {
-                logger.Debug(
-                    $"[WS] Websocket keep alive for reference {webSocketIdContext}. Thread state {thread.Status}. Websocket state {webSocket.State}"
-                );
-                counter = 0;
+                if (result == null)
+                {
+                    continue;
+                }
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    logger.Debug($"[WS] WebSocket reference {webSocketIdContext} sent close frame, stopping.");
+                    await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Closing..", CancellationToken.None);
+                    break;
+                }
+
+                messageBuffer.AddRange(segment.Take(result.Count));
+
+                if (result.EndOfMessage)
+                {
+                    if (logger.IsLogEnabled(LogLevel.Debug))
+                    {
+                        logger.Debug(
+                            $"[WS] Read loop for websocket reference {webSocketIdContext} received new message. Notifying socket handlers."
+                        );
+                    }
+
+                    var message = messageBuffer.ToArray();
+
+                    foreach (var wsh in socketHandlers)
+                    {
+                        await wsh.OnMessage(message, WebSocketMessageType.Text, webSocket, context);
+                    }
+
+                    messageBuffer.Clear();
+                }
             }
-            else
+        }
+        finally
+        {
+            if (logger.IsLogEnabled(LogLevel.Debug))
             {
-                counter++;
+                logger.Debug($"[WS] State for websocket reference {webSocketIdContext} is now {webSocket.State}, closing");
             }
 
-            // Keep this thread sleeping unless this status changes.
-            Thread.Sleep(1000);
-        }
-
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"[WS] State for websocket reference {webSocketIdContext} is now {webSocket.State}, closing");
-        }
-
-        // Disconnect has been received, cancel the token and send OnClose to the relevant WebSockets.
-        foreach (var wsh in socketHandlers)
-        {
             await cts.CancelAsync();
+
+            foreach (var wsh in socketHandlers)
+            {
+                if (logger.IsLogEnabled(LogLevel.Debug))
+                {
+                    logger.Debug($"[WS] OnClose for websocket reference {webSocketIdContext} requested");
+                }
+
+                await wsh.OnClose(webSocket, context, webSocketIdContext);
+            }
 
             if (logger.IsLogEnabled(LogLevel.Debug))
             {
-                logger.Debug($"[WS] OnClose for websocket reference {webSocketIdContext} requested");
+                logger.Debug($"[WS] Websocket reference {webSocketIdContext} fully closed.");
             }
-
-            await wsh.OnClose(webSocket, context, webSocketIdContext);
-        }
-
-        if (logger.IsLogEnabled(LogLevel.Debug))
-        {
-            logger.Debug($"[WS] Websocket reference {webSocketIdContext} fully closed.");
         }
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/WebSocketServer.cs
@@ -25,7 +25,7 @@ public class WebSocketServer(IEnumerable<IWebSocketConnectionHandler> webSocketC
     {
         var socketHandlers = webSocketConnectionHandler.Where(wsh => context.Request.Path.Value.Contains(wsh.GetHookUrl()));
 
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         var wsToken = cts.Token;
         var webSocketIdContext = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
 

--- a/Libraries/SPTarkov.Server.Core/Servers/Ws/SptWebSocketConnectionHandler.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Ws/SptWebSocketConnectionHandler.cs
@@ -149,24 +149,28 @@ public class SptWebSocketConnectionHandler(
         return Task.CompletedTask;
     }
 
-    public void SendMessageToAll(WsNotificationEvent output)
+    public async Task SendMessageToAllAsync(WsNotificationEvent output)
     {
+        MongoId[] sessionIds;
         lock (_socketsLock)
         {
-            foreach (var sessionID in _sockets.Keys)
-            {
-                SendMessage(sessionID, output); // this currently serializes for every socket, might want to separate into sending already serialized data
-            }
+            sessionIds = _sockets.Keys.ToArray();
+        }
+
+        foreach (var sessionID in sessionIds)
+        {
+            await SendMessageAsync(sessionID, output);
         }
     }
 
-    public void SendMessage(MongoId sessionID, WsNotificationEvent output)
+    public async Task SendMessageAsync(MongoId sessionID, WsNotificationEvent output)
     {
         try
         {
             if (IsWebSocketConnected(sessionID))
             {
                 var webSockets = GetSessionWebSocket(sessionID);
+                var payload = Encoding.UTF8.GetBytes(jsonUtil.Serialize(output, output.GetType()));
 
                 if (logger.IsLogEnabled(LogLevel.Debug))
                 {
@@ -175,18 +179,18 @@ public class SptWebSocketConnectionHandler(
 
                 foreach (var webSocket in webSockets)
                 {
-                    var sendTask = webSocket.SendAsync(
-                        Encoding.UTF8.GetBytes(jsonUtil.Serialize(output, output.GetType())),
-                        WebSocketMessageType.Text,
-                        true,
-                        CancellationToken.None
-                    );
                     if (logger.IsLogEnabled(LogLevel.Debug))
                     {
                         logger.Debug($"Send message for {sessionID} on websocket async started");
                     }
 
-                    sendTask.Wait();
+                    await webSocket.SendAsync(
+                        payload,
+                        WebSocketMessageType.Text,
+                        true,
+                        CancellationToken.None
+                    );
+
                     if (logger.IsLogEnabled(LogLevel.Debug))
                     {
                         logger.Debug($"Send message for {sessionID} on websocket async finished");
@@ -224,7 +228,7 @@ public class SptWebSocketConnectionHandler(
     {
         lock (_socketsLock)
         {
-            return _sockets.GetValueOrDefault(sessionID)?.Values.Where(s => s.State == WebSocketState.Open) ?? [];
+            return _sockets.GetValueOrDefault(sessionID)?.Values.Where(s => s.State == WebSocketState.Open).ToList() ?? [];
         }
     }
 }

--- a/Libraries/SPTarkov.Server.Core/Servers/Ws/SptWebSocketConnectionHandler.cs
+++ b/Libraries/SPTarkov.Server.Core/Servers/Ws/SptWebSocketConnectionHandler.cs
@@ -184,12 +184,7 @@ public class SptWebSocketConnectionHandler(
                         logger.Debug($"Send message for {sessionID} on websocket async started");
                     }
 
-                    await webSocket.SendAsync(
-                        payload,
-                        WebSocketMessageType.Text,
-                        true,
-                        CancellationToken.None
-                    );
+                    await webSocket.SendAsync(payload, WebSocketMessageType.Text, true, CancellationToken.None);
 
                     if (logger.IsLogEnabled(LogLevel.Debug))
                     {

--- a/Libraries/SPTarkov.Server.Core/Services/MailSendService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/MailSendService.cs
@@ -308,13 +308,17 @@ public class MailSendService(
         if (_messageTypes.Contains(senderDialog.Type ?? MessageType.SystemMessage) && messageDetails?.RagfairDetails is not null)
         {
             var offerSoldMessage = notifierHelper.CreateRagfairOfferSoldNotification(message, messageDetails.RagfairDetails);
-            notificationSendHelper.SendMessage(messageDetails.RecipientId, offerSoldMessage);
+#pragma warning disable CS4014
+            _ = notificationSendHelper.SendMessageAsync(messageDetails.RecipientId, offerSoldMessage); // TODO(debt): convert SendMessageToPlayer to async to properly await
+#pragma warning restore CS4014
             message.MessageType = MessageType.MessageWithItems; // Should prevent getting the same notification popup twice
         }
 
         // Send notification to player informing them of mail delivery
         var notificationMessage = notifierHelper.CreateNewMessageNotification(message);
-        notificationSendHelper.SendMessage(messageDetails.RecipientId, notificationMessage);
+#pragma warning disable CS4014
+        _ = notificationSendHelper.SendMessageAsync(messageDetails.RecipientId, notificationMessage); // TODO(debt): convert SendMessageToPlayer to async to properly await
+#pragma warning restore CS4014
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/PmcChatResponseService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/PmcChatResponseService.cs
@@ -54,7 +54,9 @@ public class PmcChatResponseService(
             var message = ChooseMessage(true, pmcData, victim);
             if (message is not null)
             {
-                notificationSendHelper.SendMessageToPlayer(sessionId, victimDetails, message, MessageType.UserMessage);
+#pragma warning disable CS4014
+                _ = notificationSendHelper.SendMessageToPlayerAsync(sessionId, victimDetails, message, MessageType.UserMessage); // TODO(debt): convert caller to async to properly await
+#pragma warning restore CS4014
             }
         }
     }
@@ -102,7 +104,9 @@ public class PmcChatResponseService(
             return;
         }
 
-        notificationSendHelper.SendMessageToPlayer(sessionId, killerDetails, message, MessageType.UserMessage);
+#pragma warning disable CS4014
+        _ = notificationSendHelper.SendMessageToPlayerAsync(sessionId, killerDetails, message, MessageType.UserMessage); // TODO(debt): convert caller to async to properly await
+#pragma warning restore CS4014
     }
 
     /// <summary>

--- a/Libraries/SPTarkov.Server.Core/Services/RagfairOfferService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/RagfairOfferService.cs
@@ -289,7 +289,9 @@ public class RagfairOfferService(
             offerCreatorProfile.RagfairInfo.Rating.Value,
             offerCreatorProfile.RagfairInfo.IsRatingGrowing.GetValueOrDefault(false)
         );
-        notificationSendHelper.SendMessage(offerCreatorId, notificationMessage);
+#pragma warning disable CS4014
+        _ = notificationSendHelper.SendMessageAsync(offerCreatorId, notificationMessage); // TODO(debt): convert ReturnUnsoldPlayerOffer to async to properly await
+#pragma warning restore CS4014
 
         ragfairServerHelper.ReturnItems(offerCreatorProfile.SessionId.Value, unstackedItems);
         offerCreatorProfile.RagfairInfo.Offers.Splice(indexOfOfferInProfile, 1);

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -178,8 +178,8 @@ public static class Program
         app.UseWebSockets(
             new WebSocketOptions
             {
-                // Every minute a heartbeat is sent to keep the connection alive.
-                KeepAliveInterval = TimeSpan.FromSeconds(60),
+                KeepAliveInterval = TimeSpan.FromSeconds(30),
+                KeepAliveTimeout = TimeSpan.FromSeconds(30),
             }
         );
 

--- a/SPTarkov.Server/Program.cs
+++ b/SPTarkov.Server/Program.cs
@@ -176,11 +176,7 @@ public static class Program
     private static void ConfigureWebApp(WebApplication app)
     {
         app.UseWebSockets(
-            new WebSocketOptions
-            {
-                KeepAliveInterval = TimeSpan.FromSeconds(30),
-                KeepAliveTimeout = TimeSpan.FromSeconds(30),
-            }
+            new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30), KeepAliveTimeout = TimeSpan.FromSeconds(30) }
         );
 
         app.UseMiddleware<SptLoggerMiddleware>();


### PR DESCRIPTION
## Fix WebSocket sync-over-async patterns and enable dead connection detection

### Problem

SPT's WebSocket notifier (`/notifierServer/getwebsocket/`) fails under L7 reverse proxies (Caddy, nginx, actix-web). The handshake succeeds (101 Switching Protocols) but the connection dies during active use — profile loading hangs, then "Backend error: Cannot connect to destination host." Idle test clients work fine; failure occurs only under real game client load.

**This PR fixes the server-side issues that prevent WebSocket connections from working through L7 reverse proxies**, enabling SPT to be deployed behind standard reverse proxy infrastructure (Caddy, nginx, etc.) without requiring TCP passthrough workarounds for the WebSocket notifier.

Root cause: three server-side sync-over-async patterns that cause .NET ThreadPool starvation, compounded by missing dead connection detection.

### What's wrong (current code)

**1. `WebSocketServer.HandleWebSocket()` blocks 2 threads per connection**

The read loop is dispatched to `Task.Factory.StartNew(async ..., LongRunning)` and the middleware pipeline is held alive with a `Thread.Sleep(1000)` polling loop. This:
- Blocks a ThreadPool thread doing nothing (the sleep-poll loop)
- Creates an unobserved `Task<Task>` — `StartNew` with an async lambda returns `Task<Task>`, the outer completes immediately, the inner (actual read loop) is never unwrapped — exceptions are silently swallowed
- `thread.Status` in the keepalive log always shows `RanToCompletion` regardless of whether the read loop is actually running

**2. `SptWebSocketConnectionHandler.SendMessage()` uses `sendTask.Wait()`**

Every WebSocket message send blocks a ThreadPool thread. During profile loading with quest rewards, multiple `SendMessage` calls fire in rapid succession — each blocking a thread. The .NET ThreadPool's hill-climbing algorithm injects only ~1-2 threads/second, far too slow to compensate.

**3. `KeepAliveTimeout` not configured**

SPT targets net9.0 which supports `KeepAliveTimeout`, but only configures `KeepAliveInterval = 60s` without setting `KeepAliveTimeout`. Without it, ASP.NET Core sends unsolicited Pong frames (not Ping) that nobody checks — dead connections are never detected via the keepalive mechanism. [dotnet/aspnetcore#17201](https://github.com/dotnet/aspnetcore/issues/17201) confirmed this: *"Generally, both the client and server WebSocket implementations have not used the keep-alive feature to detect disconnected clients."*

**4. `GetSessionWebSocket()` returns lazy `IEnumerable` enumerated outside its lock**

`Values.Where(...)` is a deferred LINQ query. The lock is released when the method returns, but enumeration happens in the caller's `foreach` — outside any lock. A concurrent `OnClose` calling `sessionSockets.Remove()` modifies the dictionary during iteration → `InvalidOperationException`.

**5. `NotifierController.NotifyAsync()` blocks ThreadPool for up to 15 seconds**

Uses `Task.Factory.StartNew(() => { ... Thread.Sleep(300) })` without `LongRunning`, stealing a ThreadPool thread and blocking it for up to 15 seconds per HTTP long-poll request.

### Fixes

| Commit | Change | Impact |
|---|---|---|
| `41a86159` | Replace `StartNew` + `Thread.Sleep` with directly awaited async read loop wrapped in `try/finally` | Eliminates 2 blocked threads per connection; guarantees `OnClose` cleanup on any exception |
| `dfd166fb` | Add `KeepAliveTimeout = 30s`, reduce `KeepAliveInterval` to 30s | Enables Ping/Pong-based dead connection detection through proxies; 30s stays below nginx's default 60s `proxy_read_timeout` |
| `ddc5eaae` | `SendMessage` → `async Task SendMessageAsync` with `await` instead of `.Wait()`; fix `GetSessionWebSocket` with `.ToList()`; hoist serialization above per-socket loop | Eliminates ThreadPool starvation during sends; fixes lazy enumeration race condition; avoids redundant serialization |
| `dd7f13cf` | `NotifierController.NotifyAsync`: `Thread.Sleep` → `await Task.Delay` | Frees ThreadPool thread during long-poll wait |
| `62483170` | `using var cts` for `CancellationTokenSource` | Proper disposal |
| `24f969af` | Update all 10 caller sites to use async methods | Fire-and-forget with `#pragma CS4014` suppression and `// TODO(debt):` markers at sync callsites; `SendMessageToPlayerAsync` wrapped in `try/catch` to prevent silent exception loss |

### How callers are handled

`NotificationSendHelper.SendMessageAsync` and `SendMessageToPlayerAsync` are properly async. Callers in sync contexts (`RewardHelper.ApplyRewards`, `Timer` callbacks, `void Process()` handlers) use fire-and-forget (`_ = ...Async()`) since:
- The underlying `SendMessageAsync` has its own `try/catch` with error logging
- Notifications are best-effort — server-side state changes are already applied
- Converting these callers to async would ripple through 40+ transitive callsites

Each fire-and-forget site is marked `// TODO(debt): convert caller to async to properly await` for future cleanup.

### Concurrent send safety

Multiple fire-and-forget callers can invoke `SendMessageAsync` for the same session simultaneously. This is safe on net9.0 because `ManagedWebSocket` internally serializes sends via `AsyncMutex` ([dotnet/runtime#56282](https://github.com/dotnet/runtime/pull/56282)). This is an implementation detail, not an API guarantee — noted in the commit message for future awareness.

### Not changed (intentional)

- **Connection tracking** (`Dictionary<MongoId, Dictionary<string, WebSocket>>` + `Lock`): The reconnect-without-closing-old-sockets behavior is a separate issue that requires understanding the game client's reconnection semantics.
- **`IWebSocketConnectionHandler` interface**: No changes — `SendMessage`/`SendMessageToAll` are concrete methods on `SptWebSocketConnectionHandler`, not interface methods.
- **`LocationLifecycleService` `.GetAwaiter().GetResult()` calls**: Not WebSocket-related.

### Tested

- Verified with a real game client connecting through Caddy (L7) → custom reverse proxy → SPT server
- Both local and remote clients successfully connected, loaded profiles, and interacted with stash through the proxied WebSocket notifier
- Previously this configuration would hang at "loading profile" and eventually show "Backend error: Cannot connect to destination host"

### Research context

This fix was informed by deep research across 46 primary sources including:
- [dotnet/aspnetcore#17090](https://github.com/dotnet/aspnetcore/issues/17090) — ThreadPool starvation from sync-over-async (David Fowler: *"blocking code will have really negative effects on scaling"*)
- [dotnet/aspnetcore#57072](https://github.com/dotnet/aspnetcore/issues/57072) — KeepAliveTimeout API design
- [dotnet/runtime#48729](https://github.com/dotnet/runtime/issues/48729) — Ping/Pong dead connection detection through proxies
- [dotnet/aspnetcore#17201](https://github.com/dotnet/aspnetcore/issues/17201) — KeepAliveInterval doesn't detect dead connections
- [Microsoft ASP.NET Core WebSocket docs](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/websockets) — *"Never use Task.Wait, Task.Result, or similar blocking calls"*
- [Caddy streaming.go](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/streaming.go) — Caddy passes WebSocket frames transparently (raw byte tunnel)