### PR TITLE
fix typo

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Callbacks/QuestCallbacks.cs
+++ b/Libraries/SPTarkov.Server.Core/Callbacks/QuestCallbacks.cs
@@ -81,7 +81,7 @@ public class QuestCallbacks(
     }
 
     /// <summary>
-    ///     Handle client/repeatalbeQuests/activityPeriods
+    ///     Handle client/repeatableQuests/activityPeriods
     /// </summary>
     /// <param name="url"></param>
     /// <param name="_"></param>

--- a/Libraries/SPTarkov.Server.Core/Routers/Static/QuestStaticRouter.cs
+++ b/Libraries/SPTarkov.Server.Core/Routers/Static/QuestStaticRouter.cs
@@ -17,7 +17,7 @@ public class QuestStaticRouter(JsonUtil jsonUtil, QuestCallbacks questCallbacks)
                 async (url, info, sessionID, output) => await questCallbacks.ListQuests(url, info, sessionID)
             ),
             new RouteAction<EmptyRequestData>(
-                "/client/repeatalbeQuests/activityPeriods",
+                "/client/repeatableQuests/activityPeriods",
                 async (url, info, sessionID, output) => await questCallbacks.ActivityPeriods(url, info, sessionID)
             ),
         ]


### PR DESCRIPTION
Changes `repeatalbeQuests` to `repeatableQuests`

I don't know if this call comes from something vanilla and that is why it is misspelled or if there is another location it needs to be changed.