### PR TITLE
Extend ModHelper to read files relative to a mod’s own folder

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Helpers/Server/ModHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Server/ModHelper.cs
@@ -13,10 +13,21 @@ public class ModHelper(FileUtil fileUtil, JsonUtil jsonUtil)
         return Path.GetDirectoryName(modAssembly.Location);
     }
 
+    public string GetAbsolutePathToModFolder()
+    {
+        return GetAbsolutePathToModFolder(Assembly.GetCallingAssembly());
+    }
+
     public string GetRawFileData(string pathToFile, string fileName)
     {
         // Read the content of the config file as a string
         return fileUtil.ReadFile(Path.Combine(pathToFile, fileName));
+    }
+
+    public string GetRawModFileData(string pathToFile, string fileName)
+    {
+        var callingModFolder = GetAbsolutePathToModFolder(Assembly.GetCallingAssembly());
+        return GetRawFileData(Path.Combine(callingModFolder, pathToFile), fileName);
     }
 
     public T GetJsonDataFromFile<T>(string pathToFile, string fileName)
@@ -26,5 +37,11 @@ public class ModHelper(FileUtil fileUtil, JsonUtil jsonUtil)
 
         // Take the string above and deserialise it into a file with a type (defined between the diamond brackets)
         return jsonUtil.Deserialize<T>(rawContent);
+    }
+
+    public T GetJsonDataFromModFile<T>(string pathToFile, string fileName)
+    {
+        var callingModFolder = GetAbsolutePathToModFolder(Assembly.GetCallingAssembly());
+        return GetJsonDataFromFile<T>(Path.Combine(callingModFolder, pathToFile), fileName);
     }
 }


### PR DESCRIPTION
I've been thinking about `ModHelper` for a while and don't see that it provides much value other than combining `FileUtil` and `JsonUtil` into a single injection.
This addition should reduce friction and extraneous code in many uses, though it could maybe be further extended with async variants of the file read methods.

Examples of usage:
```cs
var modDir = modHelper.GetAbsolutePathToModFolder(Assembly.GetExecutingAssembly());
var modDir = modHelper.GetAbsolutePathToModFolder();

var content = modHelper.GetRawFileData(Path.Combine(modDir, "res"), "file.txt");
var content = modHelper.GetRawModFileData("res", "file.txt");

var config = modHelper.GetJsonDataFromFile<ModConfig>(modDir, "config.json");
var config = modHelper.GetJsonDataFromModFile<ModConfig>("", "config.json");
```