### PR TITLE
Remove halloween masks and loot box from default scav loadouts

### DIFF
--- a/Libraries/SPTarkov.Server.Core/Generators/Bot/BotGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/Bot/BotGenerator.cs
@@ -230,6 +230,11 @@ public class BotGenerator(
             }
         }
 
+        if (!seasonalEventService.HalloweenEventEnabled())
+        {
+            seasonalEventService.RemoveHalloweenItemsFromBotInventory(botJsonTemplate.BotInventory, botGenerationDetails.Role);
+        }
+
         RemoveBlacklistedLootFromBotTemplate(botJsonTemplate.BotInventory);
 
         // Remove hideout data if bot is not a PMC or pscav - match what live sends

--- a/Libraries/SPTarkov.Server.Core/Services/Server/SeasonalEventService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Server/SeasonalEventService.cs
@@ -381,6 +381,49 @@ public class SeasonalEventService(
     }
 
     /// <summary>
+    ///     Iterate through bots inventory and loot to find and remove halloween items (as defined in SeasonalEventService)
+    /// </summary>
+    /// <param name="botInventory">Bots inventory to iterate over</param>
+    /// <param name="botRole">the role of the bot being processed</param>
+    public void RemoveHalloweenItemsFromBotInventory(BotTypeInventory botInventory, string botRole)
+    {
+        var halloweenItems = GetHalloweenEventItems();
+
+        // Remove halloween related equipment
+        foreach (var equipmentSlotKey in EquipmentSlotsToFilter)
+        {
+            if (!botInventory.Equipment.TryGetValue(equipmentSlotKey, out var equipment))
+            {
+                logger.Warning(
+                    serverLocalisationService.GetText(
+                        "seasonal-missing_equipment_slot_on_bot",
+                        new { equipmentSlot = equipmentSlotKey, botRole }
+                    )
+                );
+
+                continue;
+            }
+
+            botInventory.Equipment[equipmentSlotKey] = equipment.Where(i => !HalloweenEventItems.Contains(i.Key)).ToDictionary();
+        }
+
+        var containersToCheck = new List<Dictionary<MongoId, double>>
+        {
+            botInventory.Items.Backpack,
+            botInventory.Items.Pockets,
+            botInventory.Items.SecuredContainer,
+            botInventory.Items.TacticalVest,
+            botInventory.Items.SpecialLoot,
+        };
+
+        foreach (var container in containersToCheck)
+        {
+            // Find all Halloween items in container and remove
+            container.RemoveItems(halloweenItems);
+        }
+    }
+
+    /// <summary>
     ///     Make adjusted to server code based on the name of the event passed in
     /// </summary>
     /// <param name="globalConfig">globals.json</param>


### PR DESCRIPTION
4.1 scav data appears to have been gathered during the time it was live so halloween loot is included in scav data. This patch removes the masks and pumpkin helmet, which are already present in the seasonal event gear list, as well as the pumpkin loot container, which was not present in event loot but has been added similar to Christmas ornaments.