### PR TITLE
Fixed fence soft armor randomization to be based off of the mods provided instead of "Plate"

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/database/locales/server/en.json
@@ -90,6 +90,7 @@
   "fence-ammo_not_found_in_db": "Ammo: %s is not a valid item",
   "fence-unable_to_find_assort_by_id": "Unable to find fence assort for id: %s",
   "fence-unable_to_find_offer_by_id": "Unable to find offer with id: %s",
+  "fence-unable_to_find_soft_insert_template_for_slot": "Unable to find soft armor template in the database: %s",
   "fence-unable_to_get_ammo_penetration_value": "No penetration value found for Ammo: %s, Unable to check if its above penetration limit, assuming false",
   "fence-unable_to_find_root_item_to_add": "Unable to add items to Fence as no root items were found",
   "fixer-clothing_item_found": "Clothing item: %s found in profile that does not exist in SPT. You WILL experience errors, this can be due to using a clothing mod and removing the mod with your character still wearing it. DO NOT USE THIS PROFILE. Open SPT\\SPT_Data\\configs\\core.json, edit 'removeModItemsFromProfile' to be true. This will allow the server to edit your profile and hopefully remove the missing clothing",

--- a/Libraries/SPTarkov.Server.Core/Services/Commerce/FenceService.cs
+++ b/Libraries/SPTarkov.Server.Core/Services/Commerce/FenceService.cs
@@ -1121,49 +1121,61 @@ public class FenceService(
     }
 
     /// <summary>
-    ///     Randomise the durability values of items on armor with a passed in slot
+    ///     Randomise the durability values of installed soft-insert items on armor
     /// </summary>
-    /// <param name="softInsertSlots"> Slots of items to randomise </param>
-    /// <param name="armorItemAndMods"> Array of armor + inserts to get items from </param>
+    /// <param name="softInsertSlots">Slots of soft inserts to randomise</param>
+    /// <param name="armorItemAndMods">
+    ///     Flat collection of armor + inserts to get items from
+    /// </param>
     protected void RandomiseArmorSoftInsertDurabilities(IEnumerable<Slot> softInsertSlots, IEnumerable<Item> armorItemAndMods)
     {
         foreach (var requiredSlot in softInsertSlots)
         {
-            var modItemDbDetails = itemHelper.GetItem(requiredSlot.Properties.Filters.First().Plate.Value).Value;
+            // Find the soft insert for this slot
+            var modItemToAdjust = armorItemAndMods.FirstOrDefault(mod =>
+                string.Equals(mod.SlotId, requiredSlot.Name, StringComparison.OrdinalIgnoreCase));
 
-            var durabilityValues = GetRandomisedArmorDurabilityValues(modItemDbDetails, traderConfig.Fence.ArmorMaxDurabilityPercentMinMax);
-            var plateTpl = requiredSlot.Properties.Filters.First().Plate ?? string.Empty; // "Plate" property appears to be the 'default' item for slot
-            if (plateTpl.IsEmpty)
-            // Some bsg plate properties are empty, skip mod
+            if (modItemToAdjust == null)
             {
                 continue;
             }
 
-            // Find items mod to apply dura changes to
-            var modItemToAdjust = armorItemAndMods.FirstOrDefault(mod =>
-                string.Equals(mod.SlotId, requiredSlot.Name.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase)
-            );
+            var modItemDbDetails = itemHelper.GetItem(modItemToAdjust.Template).Value;
+            if (modItemDbDetails == null)
+            {
+                logger.Error(
+                    localisationService.GetText(
+                        "fence-unable_to_find_soft_insert_template_for_slot",
+                        modItemToAdjust.Template));
 
+                continue;
+            }
+
+            // Randomize durability
+            var durabilityValues = GetRandomisedArmorDurabilityValues(
+                modItemDbDetails,
+                traderConfig.Fence.ArmorMaxDurabilityPercentMinMax);
+
+            // Ensure item has defaults
             modItemToAdjust.AddUpd();
 
-            // Fence assorts can be null, ensure they have defaults
             modItemToAdjust.Upd.Repairable ??= new UpdRepairable
             {
                 Durability = modItemDbDetails.Properties.MaxDurability,
                 MaxDurability = modItemDbDetails.Properties.MaxDurability,
             };
 
+            // Apply the new durability
             modItemToAdjust.Upd.Repairable.Durability = durabilityValues.Durability;
             modItemToAdjust.Upd.Repairable.MaxDurability = durabilityValues.MaxDurability;
 
-            // 25% chance to add shots to visor items when its below max durability
+            // 25% chance to add shots to visor items when it's below max durability
             if (
                 randomUtil.GetChance100(25)
                 && modItemToAdjust.ParentId == BaseClasses.ARMORED_EQUIPMENT
                 && modItemToAdjust.SlotId == "mod_equipment_000"
                 && modItemToAdjust.Upd.Repairable.Durability < modItemDbDetails.Properties.MaxDurability
             )
-            // Is damaged
             {
                 modItemToAdjust.Upd.FaceShield = new UpdFaceShield { Hits = randomUtil.GetInt(1, 3) };
             }


### PR DESCRIPTION
Previously this method would throw an error if it tried to randomize a soft armor plate that had an empty "Plate" string, which would crash on server start and throw on fence assort refresh. 

It now randomizes the armor based on the collection of armor and mods provided to the method.