### PR TITLE
Add Shadow of Tagilla only figurines to pmc loot blacklist

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/pmc.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/pmc.json
@@ -164,7 +164,12 @@
     "6740987b89d5e1ddc603f4f0",
     "6707d0bdaab679420007e01a",
     "66d9f7e7099cf6adcc07a369",
-    "6866665cdf54e1190902df55"
+    "6866665cdf54e1190902df55",
+    "679b9d6390622daf9708da76",
+    "679b9d4b3374fb14f40efe6d",
+    "679b9cce4e4ed4b3b40ae5c5",
+    "679b9d43597ba2ed120c3d44",
+    "679b9d55708cfcb2060b9ae3"
   ],
   "useDifficultyOverride": false,
   "difficulty": "AsOnline",


### PR DESCRIPTION
These figurines should only spawn on Shadow of Tagilla or in specific locations on Labyrinth