### PR TITLE
Ragfair fixes (blacklists, currency, default chance for barter)

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
@@ -16,7 +16,8 @@
         "55802f3e4bdc2de7118b4584",
         "543be5cb4bdc2deb348b4568",
         "55818ac54bdc2d5b648b456e",
-        "5a74651486f7744e73386dd1"
+        "5a74651486f7744e73386dd1",
+        "65649eb40bf0ed77b8044453"
       ],
       "makeSingleStackOnly": true,
       "minRoubleCostToBecomeBarter": 20000,

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
@@ -11,6 +11,9 @@
       "chancePercent": 0,
       "itemCountMax": 3,
       "itemCountMin": 1,
+      "itemTplBlacklist": [
+        "5d235b4d86f7742e017bc88a"
+      ],
       "itemTypeBlacklist": [
         "55802f4a4bdc2ddb688b4569",
         "55802f3e4bdc2de7118b4584",

--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/ragfair.json
@@ -8,7 +8,7 @@
       "removeRemovablePlateChance": 40
     },
     "barter": {
-      "chancePercent": 20,
+      "chancePercent": 0,
       "itemCountMax": 3,
       "itemCountMin": 1,
       "itemTypeBlacklist": [

--- a/Libraries/SPTarkov.Server.Core/Generators/Ragfair/RagfairOfferGenerator.cs
+++ b/Libraries/SPTarkov.Server.Core/Generators/Ragfair/RagfairOfferGenerator.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using SPTarkov.Common.Extensions;
 using SPTarkov.Common.Models.Logging;
 using SPTarkov.DI.Annotations;
@@ -23,7 +24,6 @@ using SPTarkov.Server.Core.Services.Locales;
 using SPTarkov.Server.Core.Services.Ragfair;
 using SPTarkov.Server.Core.Utils;
 using SPTarkov.Server.Core.Utils.Cloners;
-using Microsoft.Extensions.Logging;
 
 namespace SPTarkov.Server.Core.Generators.Ragfair;
 
@@ -943,8 +943,10 @@ public class RagfairOfferGenerator(
                 .Where(item => itemHelper.GetItem(item.Tpl).Key);
 
             var itemTypeBlacklist = ragfairConfig.Dynamic.Barter.ItemTypeBlacklist;
+            var itemTplBlacklist = ragfairConfig.Dynamic.Barter.ItemTplBlacklist;
             AllowedFleaPriceItemsForBarter = filteredFleaItems
                 .Where(item => !itemHelper.IsOfBaseclasses(item.Tpl, itemTypeBlacklist))
+                .Where(item => !itemTplBlacklist.Contains(item.Tpl))
                 .ToList();
         }
 

--- a/Libraries/SPTarkov.Server.Core/Helpers/Ragfair/RagfairHelper.cs
+++ b/Libraries/SPTarkov.Server.Core/Helpers/Ragfair/RagfairHelper.cs
@@ -60,6 +60,8 @@ public class RagfairHelper(
     {
         switch (currencyFilter)
         {
+            case 4:
+                return "GP";
             case 3:
                 return "EUR";
             case 2:

--- a/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
+++ b/Libraries/SPTarkov.Server.Core/Models/Spt/Config/RagfairConfig.cs
@@ -330,6 +330,12 @@ public record BarterDetails
     /// <summary>
     ///     Item Tpls to never be turned into a barter
     /// </summary>
+    [JsonPropertyName("itemTplBlacklist")]
+    public required HashSet<MongoId> ItemTplBlacklist { get; set; }
+
+    /// <summary>
+    ///     Item Base Classes to never be turned into a barter
+    /// </summary>
     [JsonPropertyName("itemTypeBlacklist")]
     public required HashSet<MongoId> ItemTypeBlacklist { get; set; }
 }


### PR DESCRIPTION
Blacklist aramid inserts from barter requirement types
Change default barter chance to 0
- I left all barter logic in place so mods can just adjust the chance

Expanded ragfair config for ItemTplBlacklist
- Blacklists specific item IDs, the ItemTypeBlacklist is for `isOfBaseClass` calls

Add GP coins to CurrencyTag for filtering by Currency in the client